### PR TITLE
Make device page the start destination, scanner secondary

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/MainActivity.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,6 +26,7 @@ import ee.schimke.meshcore.app.ui.theme.MeshcoreTheme
 import ee.schimke.meshcore.app.ui.theme.ThemePickerDialog
 import ee.schimke.meshcore.app.ui.theme.ThemeSettings
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
@@ -57,24 +59,25 @@ private fun MeshcoreAppUi() {
 
     MeshcoreTheme(settings = themeSettings) {
         Surface {
-            val backStack = rememberNavBackStack(ScannerRoute)
+            val backStack = rememberNavBackStack(DeviceRoute)
+
+            // If no favourite device on launch, show the scanner immediately
+            LaunchedEffect(Unit) {
+                val fav = app.repository.observeFavorite().first()
+                if (fav == null) {
+                    backStack.add(ScannerRoute)
+                }
+            }
+
             NavDisplay(
                 backStack = backStack,
                 onBack = { if (backStack.size > 1) backStack.removeLastOrNull() },
                 entryProvider = entryProvider {
-                    entry<ScannerRoute> {
-                        ScannerScreen(
-                            onConnect = { if (backStack.lastOrNull() !is DeviceRoute) backStack.add(DeviceRoute) },
-                            onOpenThemePicker = { pickerVisible = true },
-                            onViewCachedDevice = { deviceId -> backStack.add(CachedDeviceRoute(deviceId)) },
-                            onOpenLicenses = { backStack.add(LicensesRoute) },
-                        )
-                    }
                     entry<DeviceRoute> {
                         DeviceScreen(
                             onDisconnected = {
-                                // Pop back to scanner, removing any chat screens too
-                                while (backStack.size > 1) backStack.removeLastOrNull()
+                                // Push scanner on top so user can reconnect
+                                if (backStack.lastOrNull() !is ScannerRoute) backStack.add(ScannerRoute)
                             },
                             onOpenThemePicker = { pickerVisible = true },
                             onNavigateToContact = { contact ->
@@ -83,6 +86,17 @@ private fun MeshcoreAppUi() {
                             onNavigateToChannel = { channel ->
                                 backStack.add(ChannelRoute(channel.index))
                             },
+                        )
+                    }
+                    entry<ScannerRoute> {
+                        ScannerScreen(
+                            onConnect = {
+                                // Pop back to device screen
+                                while (backStack.lastOrNull() is ScannerRoute) backStack.removeLastOrNull()
+                            },
+                            onOpenThemePicker = { pickerVisible = true },
+                            onViewCachedDevice = { deviceId -> backStack.add(CachedDeviceRoute(deviceId)) },
+                            onOpenLicenses = { backStack.add(LicensesRoute) },
                         )
                     }
                     entry<ContactRoute> { route ->

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreen.kt
@@ -73,12 +73,19 @@ fun DeviceScreen(
     val controller = MeshcoreApp.get().connectionController
     val uiState by controller.state.collectAsState()
 
-    // Navigate back to the scanner on Idle. The controller is the
-    // one holding Failed states now, so we don't need a "hasEngaged"
-    // latch — the controller never flashes Idle during a connect
-    // attempt, it drives Connecting→Failed→Idle in order.
+    // Track whether we've seen an active connection attempt so we
+    // don't navigate to the scanner on the brief initial Idle before
+    // auto-reconnect kicks in.
+    var hasEngaged by remember { mutableStateOf(false) }
+
     LaunchedEffect(uiState) {
-        if (uiState is ConnectionUiState.Idle) onDisconnected()
+        when (uiState) {
+            is ConnectionUiState.Connecting,
+            is ConnectionUiState.Retrying,
+            is ConnectionUiState.Connected -> hasEngaged = true
+            is ConnectionUiState.Idle -> if (hasEngaged) onDisconnected()
+            else -> {}
+        }
     }
 
     when (val s = uiState) {


### PR DESCRIPTION
## Changes

- **Navigation restructuring**: Device screen is now the initial/primary destination instead of scanner
- **Smart scanner activation**: Scanner is automatically shown on app launch only if no favorite device is configured
- **Improved disconnect handling**: When device disconnects, scanner is pushed on top rather than popping back, allowing easier reconnection
- **Better state tracking**: Added `hasEngaged` flag to DeviceScreen to prevent premature navigation to scanner during initial app startup before auto-reconnect logic engages
- **Updated scanner callback**: Modified `onConnect` callback to properly pop scanner when reconnecting to device

## Files Modified

- `MainActivity.kt`: Reordered navigation entries and added launch-time favorite device check
- `DeviceScreen.kt`: Enhanced connection state tracking to avoid false disconnection signals