### PR TITLE
Add foreground service for active BT connections

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.REQUEST_COMPANION_RUN_IN_BACKGROUND" />
     <uses-permission android:name="android.permission.REQUEST_COMPANION_START_FOREGROUND_SERVICES_FROM_BACKGROUND" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".MeshcoreApp"
@@ -35,6 +38,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Foreground service for persistent BT connection notification -->
+        <service
+            android:name=".service.ConnectionForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
 
         <!-- gRPC binder service for inter-app mesh access -->
         <service

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/connection/AppConnectionController.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/connection/AppConnectionController.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import android.content.Context
 import android.util.Log
 import ee.schimke.meshcore.app.ble.DevicePresenceManager
+import ee.schimke.meshcore.app.service.ConnectionForegroundService
 import ee.schimke.meshcore.app.widget.PeriodicRefreshWorker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -122,6 +123,9 @@ class AppConnectionController(
                             }.onFailure { Log.w(TAG, "upsertDevice failed for $deviceId", it) }
                         }
                         _state.value = ConnectionUiState.Connected(ms.client)
+                        appContext?.let { ctx ->
+                            ConnectionForegroundService.start(ctx, attempt?.label ?: "MeshCore device")
+                        }
                         if (attempt != null) {
                             val deviceId = _connectedDeviceId.value ?: attempt.id
                             // Persist messages in background
@@ -146,6 +150,7 @@ class AppConnectionController(
                     is ManagerState.Failed -> {
                         _connectedDeviceId.value = null
                         persisterJob?.cancel()
+                        appContext?.let { ConnectionForegroundService.stop(it) }
                         if (_state.value !is ConnectionUiState.Failed) {
                             _state.value = ConnectionUiState.Failed(
                                 cause = ms.cause,
@@ -157,6 +162,7 @@ class AppConnectionController(
                         if (_state.value is ConnectionUiState.Connected) {
                             _connectedDeviceId.value = null
                             persisterJob?.cancel()
+                            appContext?.let { ConnectionForegroundService.stop(it) }
                             _state.value = ConnectionUiState.Idle
                         }
                     }
@@ -237,6 +243,7 @@ class AppConnectionController(
         _warnings.value = emptyList()
         _state.value = ConnectionUiState.Idle
         currentAttempt = null
+        appContext?.let { ConnectionForegroundService.stop(it) }
         scope.launch { runCatching { manager.disconnect() }.onFailure { Log.d(TAG, "disconnect during cancel failed", it) } }
     }
 

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/service/ConnectionForegroundService.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/service/ConnectionForegroundService.kt
@@ -1,0 +1,149 @@
+package ee.schimke.meshcore.app.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import android.util.Log
+import ee.schimke.meshcore.app.MainActivity
+import ee.schimke.meshcore.app.MeshcoreApp
+import ee.schimke.meshcore.app.R
+
+/**
+ * Foreground service that maintains a persistent notification while a
+ * Bluetooth connection is active. The invariant is:
+ *
+ *   **BT connected ⟺ this service is running ⟺ notification is visible.**
+ *
+ * - [AppConnectionController] starts this service on connect and stops
+ *   it on disconnect.
+ * - If the service is destroyed for any other reason (task-swipe, system
+ *   reclaim), [onDestroy] triggers a disconnect so no BT connection can
+ *   exist without the notification.
+ * - The notification includes a "Disconnect" action that stops the
+ *   service (which in turn disconnects BT via [onDestroy]).
+ * - On Android 14+ users can dismiss foreground-service notifications;
+ *   [onTaskRemoved] and [deleteIntent] handle that edge-case by also
+ *   stopping the service.
+ */
+class ConnectionForegroundService : Service() {
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel(this)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_DISCONNECT) {
+            Log.d(TAG, "Disconnect action received")
+            disconnect()
+            return START_NOT_STICKY
+        }
+
+        val deviceLabel = intent?.getStringExtra(EXTRA_DEVICE_LABEL) ?: "MeshCore device"
+        val notification = buildNotification(deviceLabel)
+        startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        disconnect()
+        super.onDestroy()
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // User swiped the app away — tear down BT to maintain the invariant.
+        disconnect()
+        super.onTaskRemoved(rootIntent)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    // ------------------------------------------------------------------
+
+    private fun disconnect() {
+        Log.d(TAG, "Service stopping — disconnecting BT")
+        val app = applicationContext as? MeshcoreApp ?: return
+        app.connectionController.cancel()
+        stopSelf()
+    }
+
+    private fun buildNotification(deviceLabel: String): Notification {
+        val openAppIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val disconnectIntent = PendingIntent.getService(
+            this, 1,
+            Intent(this, ConnectionForegroundService::class.java).apply {
+                action = ACTION_DISCONNECT
+            },
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        // deleteIntent fires if the user dismisses the notification
+        // (possible on Android 14+ for foreground services).
+        val deleteIntent = PendingIntent.getService(
+            this, 2,
+            Intent(this, ConnectionForegroundService::class.java).apply {
+                action = ACTION_DISCONNECT
+            },
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        return Notification.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bluetooth_connected)
+            .setContentTitle("Connected to $deviceLabel")
+            .setContentText("MeshCore — tap to open")
+            .setContentIntent(openAppIntent)
+            .setDeleteIntent(deleteIntent)
+            .setOngoing(true)
+            .addAction(
+                Notification.Action.Builder(
+                    null, "Disconnect", disconnectIntent,
+                ).build(),
+            )
+            .build()
+    }
+
+    companion object {
+        private const val TAG = "ConnFgService"
+        private const val CHANNEL_ID = "meshcore_connection"
+        private const val NOTIFICATION_ID = 1
+        private const val ACTION_DISCONNECT = "ee.schimke.meshcore.DISCONNECT"
+        private const val EXTRA_DEVICE_LABEL = "device_label"
+
+        fun start(context: Context, deviceLabel: String) {
+            val intent = Intent(context, ConnectionForegroundService::class.java).apply {
+                putExtra(EXTRA_DEVICE_LABEL, deviceLabel)
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, ConnectionForegroundService::class.java))
+        }
+
+        private fun ensureNotificationChannel(context: Context) {
+            val nm = context.getSystemService(NotificationManager::class.java) ?: return
+            if (nm.getNotificationChannel(CHANNEL_ID) != null) return
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Active Connection",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Shown while connected to a MeshCore device over Bluetooth"
+            }
+            nm.createNotificationChannel(channel)
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_bluetooth_connected.xml
+++ b/app/src/main/res/drawable/ic_bluetooth_connected.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!-- Material Design "bluetooth_connected" icon -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,12l-2,-2l-2,2l2,2L7,12zM17.71,7.71L12,2h-1v7.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L11,14.41V22h1l5.71,-5.71L13.41,12L17.71,7.71zM13,5.83l1.88,1.88L13,9.59V5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88zM19,10l-2,2l2,2l2,-2L19,10z" />
+</vector>


### PR DESCRIPTION
## Changes

- **ConnectionForegroundService**: New foreground service that maintains a persistent notification while Bluetooth is connected
  - Implements invariant: BT connected ⟺ service running ⟺ notification visible
  - Includes "Disconnect" action to stop service
  - Handles task removal and notification dismissal (Android 14+)
  - Triggers disconnect via AppConnectionController.cancel() on destroy

- **AppConnectionController**: Integrated service lifecycle management
  - Starts foreground service on successful connection
  - Stops service on disconnect, failure, or cancel

- **AndroidManifest.xml**: Added required permissions and service declaration
  - `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_CONNECTED_DEVICE`, `POST_NOTIFICATIONS`
  - Declared `ConnectionForegroundService` with `connectedDevice` foreground service type

- **ic_bluetooth_connected.xml**: New notification icon (Material Design)