### PR TITLE
Rely on device echo for channel message history

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/appfunctions/MeshcoreFunctions.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/appfunctions/MeshcoreFunctions.kt
@@ -175,19 +175,10 @@ class MeshcoreFunctions {
         val client = (connectionState as? ConnectionUiState.Connected)?.client
             ?: return SendResult(success = false, error = "Not connected to a mesh device")
 
-        val deviceId = app.connectionController.connectedDeviceId.value
-            ?: return SendResult(success = false, error = "No device ID available")
-
         return try {
             val now = Clock.System.now()
-            val ack = client.sendChannelText(channelIdx = channelIndex, text = message, timestamp = now)
-            repository.insertSentChannelMessage(
-                deviceId = deviceId,
-                channelIndex = channelIndex,
-                text = message,
-                timestamp = now,
-                ackHash = ack.ackHash,
-            )
+            client.sendChannelText(channelIdx = channelIndex, text = message, timestamp = now)
+            // Message appears in history when the device echoes it back
             SendResult(success = true, error = null)
         } catch (e: Exception) {
             SendResult(success = false, error = e.message ?: "Failed to send message")

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/service/MeshcoreBinderService.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/service/MeshcoreBinderService.kt
@@ -15,6 +15,7 @@ import io.grpc.binder.BinderServerBuilder
 import io.grpc.binder.IBinderReceiver
 import io.grpc.binder.SecurityPolicies
 import io.grpc.binder.ServerSecurityPolicy
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -37,6 +38,17 @@ class MeshcoreBinderService : LifecycleService() {
                 get() = app.manager.state
             override val client: MeshCoreClient?
                 get() = app.manager.client
+
+            override suspend fun persistSentDm(
+                contactKeyHex: String,
+                text: String,
+                timestamp: Instant,
+                ackHash: Int?,
+            ) {
+                val deviceId = app.connectionController.connectedDeviceId.value ?: return
+                app.repository.insertSentDm(deviceId, contactKeyHex, text, timestamp, ackHash)
+            }
+
         }
 
         val address = AndroidComponentAddress.forContext(this)

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ChannelChatScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ChannelChatScreen.kt
@@ -29,7 +29,6 @@ import ee.schimke.meshcore.components.ui.ChatInput
 import ee.schimke.meshcore.components.ui.ChatMessage
 import ee.schimke.meshcore.components.ui.ChatMessageList
 import ee.schimke.meshcore.components.ui.MessageStatus
-import ee.schimke.meshcore.data.entity.MessageDirection
 import ee.schimke.meshcore.data.entity.MessageStatus as DbMessageStatus
 import android.util.Log
 import kotlinx.coroutines.launch
@@ -54,21 +53,23 @@ fun ChannelChatScreen(
     val channels by client?.channels?.collectAsState() ?: remember { mutableStateOf(emptyList()) }
     val channel = channels.firstOrNull { it.index == channelIndex }
     val channelName = channel?.name?.ifBlank { null } ?: "Channel $channelIndex"
+    val selfName = client?.selfInfo?.collectAsState()?.value?.name
 
     // Read messages from Room
     val dbMessages by (deviceId?.let { repository.observeChannelMessages(it, channelIndex) }
         ?: kotlinx.coroutines.flow.flowOf(emptyList())).collectAsState(initial = emptyList())
 
-    val messages by remember(dbMessages) {
+    val messages by remember(dbMessages, selfName) {
         derivedStateOf {
             dbMessages.map { entity ->
+                val isMine = selfName != null && entity.senderName == selfName
                 ChatMessage(
                     id = "msg-${entity.rowId}",
-                    senderName = if (entity.direction == MessageDirection.RECEIVED) entity.senderName else null,
+                    senderName = if (!isMine) entity.senderName else null,
                     text = entity.text,
                     timestamp = Instant.fromEpochMilliseconds(entity.timestampEpochMs),
                     snr = entity.snr,
-                    isMine = entity.direction == MessageDirection.SENT,
+                    isMine = isMine,
                     status = when (entity.status) {
                         DbMessageStatus.SENDING -> MessageStatus.Sending
                         DbMessageStatus.SENT -> MessageStatus.Sent
@@ -133,21 +134,14 @@ fun ChannelChatScreen(
                                 timestamp = now,
                             )
                         }
-                        val ack = result.getOrNull()
                         if (result.isFailure) {
                             Log.e(TAG, "Channel send failed: ${result.exceptionOrNull()?.message}", result.exceptionOrNull())
                         } else {
+                            val ack = result.getOrNull()
                             Log.d(TAG, "Channel send ok: ackHash=${ack?.ackHash} flood=${ack?.isFlood}")
                         }
-                        repository.insertSentChannelMessage(
-                            deviceId = deviceId,
-                            channelIndex = channelIndex,
-                            text = text,
-                            timestamp = now,
-                            ackHash = ack?.ackHash,
-                            status = if (result.isSuccess) DbMessageStatus.SENT else DbMessageStatus.FAILED,
-                        )
-                        Log.d(TAG, "Channel msg persisted to Room")
+                        // Message appears in history when the device echoes it back
+                        // as a ChannelMessage event, picked up by MessagePersister.
                     }
                 },
             )

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/MessageDao.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/MessageDao.kt
@@ -57,4 +57,5 @@ interface MessageDao {
         timestampMs: Long,
         text: String,
     ): Int
+
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/repository/MeshcoreRepository.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/repository/MeshcoreRepository.kt
@@ -327,28 +327,6 @@ class MeshcoreRepository(private val db: MeshcoreDatabase) {
         )
     }
 
-    suspend fun insertSentChannelMessage(
-        deviceId: String,
-        channelIndex: Int,
-        text: String,
-        timestamp: Instant,
-        ackHash: Int?,
-        status: MessageStatus = MessageStatus.SENT,
-    ) {
-        db.messageDao().insert(
-            MessageEntity(
-                deviceId = deviceId,
-                kind = MessageKind.CHANNEL,
-                direction = MessageDirection.SENT,
-                channelIndex = channelIndex,
-                text = text,
-                timestampEpochMs = timestamp.toEpochMilliseconds(),
-                ackHash = ackHash,
-                status = status,
-            ),
-        )
-    }
-
     suspend fun markConfirmed(ackHash: Int) {
         db.messageDao().updateStatusByAckHash(ackHash, MessageStatus.CONFIRMED)
     }

--- a/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshServiceBridge.kt
+++ b/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshServiceBridge.kt
@@ -3,6 +3,7 @@ package ee.schimke.meshcore.grpc
 import ee.schimke.meshcore.core.client.MeshCoreClient
 import ee.schimke.meshcore.core.manager.ManagerState
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.time.Instant
 
 /**
  * Bridge interface that decouples the gRPC service implementation from
@@ -12,4 +13,12 @@ import kotlinx.coroutines.flow.StateFlow
 interface MeshServiceBridge {
     val managerState: StateFlow<ManagerState>
     val client: MeshCoreClient?
+
+    /** Persist a sent DM to the local message store. */
+    suspend fun persistSentDm(
+        contactKeyHex: String,
+        text: String,
+        timestamp: Instant,
+        ackHash: Int?,
+    ) {}
 }

--- a/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshcoreGrpcServiceImpl.kt
+++ b/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshcoreGrpcServiceImpl.kt
@@ -56,10 +56,17 @@ class MeshcoreGrpcServiceImpl(
                 .build()
         return try {
             val recipient = PublicKey.fromBytes(request.recipientPublicKey.toByteArray())
+            val now = Clock.System.now()
             val ack = client.sendText(
                 recipient = recipient,
                 text = request.text,
-                timestamp = Clock.System.now(),
+                timestamp = now,
+            )
+            bridge.persistSentDm(
+                contactKeyHex = recipient.toHex(),
+                text = request.text,
+                timestamp = now,
+                ackHash = ack.ackHash,
             )
             SendAckResponse.newBuilder()
                 .setSuccess(true)
@@ -81,11 +88,13 @@ class MeshcoreGrpcServiceImpl(
                 .setErrorMessage("Not connected")
                 .build()
         return try {
+            val now = Clock.System.now()
             val ack = client.sendChannelText(
                 channelIdx = request.channelIndex,
                 text = request.text,
-                timestamp = Clock.System.now(),
+                timestamp = now,
             )
+            // Message appears in history when the device echoes it back
             SendAckResponse.newBuilder()
                 .setSuccess(true)
                 .setAckHash(ack.ackHash)


### PR DESCRIPTION
## Changes

- **Remove local SENT inserts for channel messages**: Channel messages are now persisted only when the device echoes them back, eliminating race conditions and duplicate messages.
- **Add DM persistence in gRPC service**: Moved DM message persistence from client code to `MeshcoreGrpcServiceImpl`, ensuring sent DMs are recorded via the bridge interface.
- **Update message status detection**: Changed from `MessageDirection` enum to comparing sender name with `selfInfo` to determine if a message is sent or received.
- **Simplify ChannelChatScreen**: Remove manual message insertion logic; messages now appear automatically when echoed by the device.
- **Add `persistSentDm` to MeshServiceBridge**: New interface method allows gRPC service to persist DMs to the local repository.

## Benefits

- Single source of truth: messages only exist in history after device confirmation
- Reduced complexity in UI and function layers
- Consistent behavior between DMs and channel messages