### PR TITLE
Reduce Gradle daemon memory footprint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,8 @@
 #Kotlin
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx3072M
 
 #Gradle
-org.gradle.jvmargs=-Xmx3072M -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 


### PR DESCRIPTION
## Summary
- Remove `kotlin.daemon.jvmargs=-Xmx3072M` so the Kotlin compiler daemon uses the 512m default. 3g was well above what any meshcore module actually needs.
- Lower the Gradle daemon heap from `-Xmx3072M` to `-Xmx2g` and switch to the `g` suffix so the string matches the sibling projects byte-for-byte — this lets Gradle reuse one daemon across multiple local checkouts when they're all idle.

Part of a small cross-project pass to stop local JVMs from saturating memory when several projects are open at once.

## Test plan
- [ ] `./gradlew :meshcore-mobile:assembleDebug` still succeeds
- [ ] `./gradlew check` still succeeds
- [ ] Confirm daemon heap matches via `jcmd <pid> VM.flags | grep Heap` or the build scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)