### PR TITLE
Defer DebugBridge attach until app graph is ready

### DIFF
--- a/app/src/debug/kotlin/ee/schimke/meshcore/app/debug/DebugBridgeImpl.kt
+++ b/app/src/debug/kotlin/ee/schimke/meshcore/app/debug/DebugBridgeImpl.kt
@@ -11,7 +11,11 @@ import java.io.PrintWriter
  */
 internal class DebugBridgeImpl(private val app: MeshcoreApp) : DebugBridge {
 
-    private val events = DebugEventBuffer().also { it.attach(app) }
+    private val events = DebugEventBuffer()
+
+    override fun onAppReady() {
+        events.attach(app)
+    }
 
     override fun dumpService(service: Service, writer: PrintWriter, args: Array<String>?) {
         DebugDump.dispatch(app, writer, args, events)

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/MeshcoreApp.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/MeshcoreApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import dev.zacsweers.metro.createGraphFactory
 import ee.schimke.meshcore.app.ble.DevicePresenceManager
 import ee.schimke.meshcore.app.connection.AppConnectionController
+import ee.schimke.meshcore.app.debug.DebugBridge
 import ee.schimke.meshcore.app.ui.theme.ThemePreferences
 import ee.schimke.meshcore.app.widget.PeriodicRefreshWorker
 import ee.schimke.meshcore.app.widget.WidgetStateBridge
@@ -34,6 +35,7 @@ class MeshcoreApp : Application() {
         super.onCreate()
         instance = this
         graph = createGraphFactory<MobileGraph.Factory>().create(this)
+        DebugBridge.instance?.onAppReady()
         WidgetStateBridge.start(this, manager)
         @Suppress("OPT_IN_USAGE")
         kotlinx.coroutines.GlobalScope.launch(kotlinx.coroutines.Dispatchers.Default) {

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/debug/DebugBridge.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/debug/DebugBridge.kt
@@ -15,6 +15,13 @@ interface DebugBridge {
     /** Handle a `dumpsys activity service <svc>` invocation. */
     fun dumpService(service: Service, writer: PrintWriter, args: Array<String>?)
 
+    /**
+     * Invoked from [android.app.Application.onCreate] once the app graph is
+     * initialized. The bridge is installed earlier (via ContentProvider) so it
+     * cannot safely touch graph-backed state from its constructor.
+     */
+    fun onAppReady() {}
+
     companion object {
         @Volatile
         var instance: DebugBridge? = null


### PR DESCRIPTION
## Summary
- `DebugInit` is a ContentProvider, so it runs **before** `Application.onCreate()`. Its `DebugBridgeImpl` constructor immediately called `DebugEventBuffer.attach(app)`, which launched a `Dispatchers.Default` coroutine that touched `app.connectionController` → `manager` → `graph`. When the coroutine started before `MeshcoreApp.onCreate()` set `graph`, it crashed with `UninitializedPropertyAccessException: lateinit property graph has not been initialized`.
- Added a default no-op `DebugBridge.onAppReady()` hook. `DebugBridgeImpl` now overrides it to perform the attach, and `MeshcoreApp.onCreate()` calls it right after the graph is built. Release builds are unaffected (no provider, so `instance` stays null).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [ ] Install debug build, confirm no `UninitializedPropertyAccessException` on cold start
- [ ] `adb shell dumpsys activity service ee.schimke.meshcore/.app.service.MeshcoreConnectionService --events` still reports buffered events