### PR TITLE
Add GitHub Actions CI for Android build, tests, and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Assemble Android apps (debug)
+        run: ./gradlew :app:assembleDebug :wear:assembleDebug --stacktrace
+
+      - name: Check (tests + lint, all modules)
+        run: ./gradlew check --stacktrace
+
+      - name: Upload APKs
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apks
+          path: |
+            app/build/outputs/apk/debug/*.apk
+            wear/build/outputs/apk/debug/*.apk
+          if-no-files-found: ignore
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**
+          if-no-files-found: ignore
+
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: |
+            **/build/reports/lint-results-*.html
+            **/build/reports/lint-results-*.xml
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on pushes to `main`, all PRs, and manual dispatch.
- Bootstraps JDK 21 (Temurin); the JetBrains JVM 21 from `gradle/gradle-daemon-jvm.properties` is auto-provisioned by Gradle via the foojay resolver already configured in `settings.gradle.kts`.
- Uses `gradle/actions/setup-gradle@v4` for build caching (read-only off `main`).
- Builds `:app` and `:wear` debug APKs, then runs `check` (tests + Android Lint) across all modules.
- Uploads debug APKs, test reports, and lint reports as artifacts.

## Test plan
- [ ] Workflow runs green on this PR.
- [ ] Debug APKs for `app` and `wear` appear in the run artifacts.
- [ ] Test and lint reports are uploaded (even on failure).
- [ ] Concurrency cancels superseded runs on non-`main` refs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzVEQLJRfYExsfn9sFS7NP)_