### PR TITLE
Add ktfmt with Google style, .editorconfig, hook, and CI check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,97 @@
+# This .editorconfig section approximates ktfmt's formatting rules. You can include it in an
+# existing .editorconfig file or use it standalone by copying it to <project root>/.editorconfig
+# and making sure your editor is set to read settings from .editorconfig files.
+#
+# It includes editor-specific config options for IntelliJ IDEA.
+#
+# If any option is wrong, PR are welcome
+
+[{*.kt,*.kts}]
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+indent_size = 2
+ij_continuation_indent_size = 2
+ij_java_names_count_to_use_import_on_demand = 9999
+ij_kotlin_align_in_columns_case_branch = false
+ij_kotlin_align_multiline_binary_operation = false
+ij_kotlin_align_multiline_extends_list = false
+ij_kotlin_align_multiline_method_parentheses = false
+ij_kotlin_align_multiline_parameters = true
+ij_kotlin_align_multiline_parameters_in_calls = false
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_assignment_wrap = normal
+ij_kotlin_blank_lines_after_class_header = 0
+ij_kotlin_blank_lines_around_block_when_branches = 0
+ij_kotlin_blank_lines_before_declaration_with_comment_or_annotation_on_separate_line = 1
+ij_kotlin_block_comment_at_first_column = true
+ij_kotlin_call_parameters_new_line_after_left_paren = true
+ij_kotlin_call_parameters_right_paren_on_new_line = false
+ij_kotlin_call_parameters_wrap = on_every_item
+ij_kotlin_catch_on_new_line = false
+ij_kotlin_class_annotation_wrap = split_into_lines
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+ij_kotlin_continuation_indent_for_chained_calls = true
+ij_kotlin_continuation_indent_for_expression_bodies = true
+ij_kotlin_continuation_indent_in_argument_lists = true
+ij_kotlin_continuation_indent_in_elvis = false
+ij_kotlin_continuation_indent_in_if_conditions = false
+ij_kotlin_continuation_indent_in_parameter_lists = false
+ij_kotlin_continuation_indent_in_supertype_lists = false
+ij_kotlin_continuation_indent_size = 2
+ij_kotlin_else_on_new_line = false
+ij_kotlin_enum_constants_wrap = off
+ij_kotlin_extends_list_wrap = normal
+ij_kotlin_field_annotation_wrap = split_into_lines
+ij_kotlin_finally_on_new_line = false
+ij_kotlin_if_rparen_on_new_line = false
+ij_kotlin_import_nested_classes = false
+ij_kotlin_imports_layout = *
+ij_kotlin_indent_size = 2
+ij_kotlin_insert_whitespaces_in_simple_one_line_method = true
+ij_kotlin_keep_blank_lines_before_right_brace = 2
+ij_kotlin_keep_blank_lines_in_code = 2
+ij_kotlin_keep_blank_lines_in_declarations = 2
+ij_kotlin_keep_first_column_comment = true
+ij_kotlin_keep_indents_on_empty_lines = false
+ij_kotlin_keep_line_breaks = true
+ij_kotlin_lbrace_on_next_line = false
+ij_kotlin_line_comment_add_space = false
+ij_kotlin_line_comment_at_first_column = true
+ij_kotlin_method_annotation_wrap = split_into_lines
+ij_kotlin_method_call_chain_wrap = normal
+ij_kotlin_method_parameters_new_line_after_left_paren = true
+ij_kotlin_method_parameters_right_paren_on_new_line = true
+ij_kotlin_method_parameters_wrap = on_every_item
+ij_kotlin_name_count_to_use_star_import = 9999
+ij_kotlin_name_count_to_use_star_import_for_members = 9999
+ij_kotlin_parameter_annotation_wrap = off
+ij_kotlin_space_after_comma = true
+ij_kotlin_space_after_extend_colon = true
+ij_kotlin_space_after_type_colon = true
+ij_kotlin_space_before_catch_parentheses = true
+ij_kotlin_space_before_comma = false
+ij_kotlin_space_before_extend_colon = true
+ij_kotlin_space_before_for_parentheses = true
+ij_kotlin_space_before_if_parentheses = true
+ij_kotlin_space_before_lambda_arrow = true
+ij_kotlin_space_before_type_colon = false
+ij_kotlin_space_before_when_parentheses = true
+ij_kotlin_space_before_while_parentheses = true
+ij_kotlin_spaces_around_additive_operators = true
+ij_kotlin_spaces_around_assignment_operators = true
+ij_kotlin_spaces_around_equality_operators = true
+ij_kotlin_spaces_around_function_type_arrow = true
+ij_kotlin_spaces_around_logical_operators = true
+ij_kotlin_spaces_around_multiplicative_operators = true
+ij_kotlin_spaces_around_range = false
+ij_kotlin_spaces_around_relational_operators = true
+ij_kotlin_spaces_around_unary_operator = false
+ij_kotlin_spaces_around_when_arrow = true
+ij_kotlin_variable_annotation_wrap = off
+ij_kotlin_while_on_new_line = false
+ij_kotlin_wrap_elvis_expressions = 1
+ij_kotlin_wrap_expression_body_functions = 1
+ij_kotlin_wrap_first_method_in_call_chain = false
+ktfmt_trailing_comma_management_strategy = complete

--- a/.github/workflows/ktfmt.yml
+++ b/.github/workflows/ktfmt.yml
@@ -1,0 +1,25 @@
+name: ktfmt
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ktfmt-check:
+    name: ktfmtCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run ktfmtCheck
+        run: ./gradlew ktfmtCheck --no-configuration-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,4 +10,27 @@ plugins {
     alias(libs.plugins.metro) apply false
     alias(libs.plugins.graalvmNative) apply false
     alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.ktfmt) apply false
+}
+
+subprojects {
+    apply(plugin = rootProject.libs.plugins.ktfmt.get().pluginId)
+    extensions.configure<com.ncorti.ktfmt.gradle.KtfmtExtension> {
+        googleStyle()
+    }
+}
+
+tasks.register("installGitHooks") {
+    group = "git hooks"
+    description = "Installs the project's git hooks into .git/hooks"
+    val source = file("scripts/git-hooks/pre-commit")
+    val target = file(".git/hooks/pre-commit")
+    inputs.file(source)
+    outputs.file(target)
+    doLast {
+        target.parentFile.mkdirs()
+        source.copyTo(target, overwrite = true)
+        target.setExecutable(true)
+        println("Installed git pre-commit hook -> ${target.relativeTo(rootDir)}")
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ wear-compose-material3 = "1.6.0"
 wear-compose-remote = "1.0.0-alpha01"
 playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.0"
+ktfmt = "0.26.0"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }
@@ -147,3 +148,4 @@ room = { id = "androidx.room", version.ref = "room" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Pre-commit hook: verify staged Kotlin files are formatted with ktfmt.
+# Bypass with: git commit --no-verify
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+mapfile -t staged_kt < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(kt|kts)$' || true)
+if [ "${#staged_kt[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+echo "ktfmt: checking ${#staged_kt[@]} staged Kotlin file(s)..."
+if ! ./gradlew --quiet --no-configuration-cache ktfmtCheck; then
+  cat <<'EOF'
+
+ktfmt found formatting issues. Run:
+
+  ./gradlew ktfmtFormat
+
+then re-stage your changes and commit again. To bypass once: git commit --no-verify
+EOF
+  exit 1
+fi

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Install repo-managed git hooks into .git/hooks.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+src="$repo_root/scripts/git-hooks"
+dst="$repo_root/.git/hooks"
+
+mkdir -p "$dst"
+for hook in "$src"/*; do
+  name="$(basename "$hook")"
+  install -m 0755 "$hook" "$dst/$name"
+  echo "installed $name -> .git/hooks/$name"
+done


### PR DESCRIPTION
## Summary

- Apply ncorti `ktfmt-gradle` 0.26.0 to all subprojects from the root build, configured with `googleStyle()` (2-space indent, trailing commas).
- Add `.editorconfig` from `facebook/ktfmt` (`docs/editorconfig/.editorconfig-google`) so IntelliJ matches ktfmt's formatting.
- Add `scripts/git-hooks/pre-commit` that runs `ktfmtCheck` only when staged `.kt`/`.kts` files are present (bypass with `--no-verify`), plus `scripts/install-git-hooks.sh` and a Gradle `installGitHooks` task to copy it into `.git/hooks`.
- Add `.github/workflows/ktfmt.yml` running `./gradlew ktfmtCheck` on push to `main` and on PRs (JDK 21).

## Test plan

- [ ] `./gradlew ktfmtCheck` runs locally (sandbox here couldn't download the Gradle distribution, so this hasn't been verified end-to-end).
- [ ] If the existing tree isn't already ktfmt-clean, run `./gradlew ktfmtFormat` and commit the reformat so CI is green.
- [ ] `./gradlew installGitHooks` installs `.git/hooks/pre-commit`; staging a deliberately mis-indented `.kt` file blocks the commit, and `--no-verify` bypasses it.
- [ ] The `ktfmt` workflow runs and passes on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4qJTuiEBsYn5r6wtnXdzo)_