### PR TITLE
Apply ktfmt googleStyle reformat across all subprojects

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,86 +1,78 @@
 plugins {
-    // AGP 9 has built-in Kotlin support, so `com.android.application`
-    // alone covers both Android and Kotlin compilation — don't add
-    // `org.jetbrains.kotlin.android` on top (it's rejected as redundant).
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.metro)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.kotlinSerialization)
-    id("ee.schimke.composeai.preview") version "0.7.5"
+  // AGP 9 has built-in Kotlin support, so `com.android.application`
+  // alone covers both Android and Kotlin compilation — don't add
+  // `org.jetbrains.kotlin.android` on top (it's rejected as redundant).
+  alias(libs.plugins.androidApplication)
+  alias(libs.plugins.composeMultiplatform)
+  alias(libs.plugins.composeCompiler)
+  alias(libs.plugins.metro)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.kotlinSerialization)
+  id("ee.schimke.composeai.preview") version "0.7.5"
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-    }
-}
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
 android {
-    namespace = "ee.schimke.meshcore.app"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        applicationId = "ee.schimke.meshcore"
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1"
-    }
-    buildTypes {
-        getByName("release") { isMinifyEnabled = false }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    testOptions.unitTests {
-        isIncludeAndroidResources = true
-    }
+  namespace = "ee.schimke.meshcore.app"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    applicationId = "ee.schimke.meshcore"
+    minSdk = libs.versions.android.minSdk.get().toInt()
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    versionCode = 1
+    versionName = "0.1"
+  }
+  buildTypes { getByName("release") { isMinifyEnabled = false } }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+  }
+  testOptions.unitTests { isIncludeAndroidResources = true }
 }
 
 dependencies {
-    implementation(projects.meshcoreGrpcService)
-    implementation(libs.grpc.binder)
-    implementation(libs.androidx.lifecycle.service)
-    implementation(libs.horologist.datalayer.grpc)
-    implementation(libs.horologist.datalayer.phone)
-    implementation(libs.playservices.wearable)
-    implementation(projects.meshcoreCore)
-    implementation(projects.meshcoreTransportTcp)
-    implementation(projects.meshcoreTransportBle)
-    implementation(projects.meshcoreTransportUsb)
-    implementation(projects.meshcoreComponents)
-    implementation(projects.meshcoreMobile)
-    implementation(projects.meshcoreData)
-    implementation(libs.metro.runtime)
-    implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.androidx.activity.compose)
-    implementation(libs.compose.runtime)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
-    implementation(libs.compose.ui.text.google.fonts)
-    implementation(libs.compose.ui)
-    implementation(libs.compose.uiToolingPreview)
-    implementation(libs.androidx.lifecycle.runtimeCompose)
-    implementation(libs.androidx.lifecycle.viewmodelCompose)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
-    implementation(projects.meshcoreDevicesProto)
-    implementation(libs.androidx.datastore)
-    implementation(libs.androidx.remote.core)
-    implementation(libs.androidx.remote.creation)
-    implementation(libs.androidx.remote.creation.compose)
-    implementation(libs.androidx.remote.tooling.preview)
-    implementation(libs.androidx.work.runtime)
-    implementation(libs.wear.compose.remote.material3)
-    implementation(libs.androidx.appfunctions)
-    implementation(libs.androidx.appfunctions.service)
-    implementation(libs.aboutlibraries.compose.m3)
-    ksp(libs.androidx.appfunctions.compiler)
-    debugImplementation(libs.compose.uiTooling)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.androidx.core)
-    testImplementation(libs.androidx.testExt.junit)
+  implementation(projects.meshcoreGrpcService)
+  implementation(libs.grpc.binder)
+  implementation(libs.androidx.lifecycle.service)
+  implementation(libs.horologist.datalayer.grpc)
+  implementation(libs.horologist.datalayer.phone)
+  implementation(libs.playservices.wearable)
+  implementation(projects.meshcoreCore)
+  implementation(projects.meshcoreTransportTcp)
+  implementation(projects.meshcoreTransportBle)
+  implementation(projects.meshcoreTransportUsb)
+  implementation(projects.meshcoreComponents)
+  implementation(projects.meshcoreMobile)
+  implementation(projects.meshcoreData)
+  implementation(libs.metro.runtime)
+  implementation(libs.kotlinx.coroutines.android)
+  implementation(libs.androidx.activity.compose)
+  implementation(libs.compose.runtime)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.material.icons.extended)
+  implementation(libs.compose.ui.text.google.fonts)
+  implementation(libs.compose.ui)
+  implementation(libs.compose.uiToolingPreview)
+  implementation(libs.androidx.lifecycle.runtimeCompose)
+  implementation(libs.androidx.lifecycle.viewmodelCompose)
+  implementation(libs.androidx.navigation3.runtime)
+  implementation(libs.androidx.navigation3.ui)
+  implementation(projects.meshcoreDevicesProto)
+  implementation(libs.androidx.datastore)
+  implementation(libs.androidx.remote.core)
+  implementation(libs.androidx.remote.creation)
+  implementation(libs.androidx.remote.creation.compose)
+  implementation(libs.androidx.remote.tooling.preview)
+  implementation(libs.androidx.work.runtime)
+  implementation(libs.wear.compose.remote.material3)
+  implementation(libs.androidx.appfunctions)
+  implementation(libs.androidx.appfunctions.service)
+  implementation(libs.aboutlibraries.compose.m3)
+  ksp(libs.androidx.appfunctions.compiler)
+  debugImplementation(libs.compose.uiTooling)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.androidx.core)
+  testImplementation(libs.androidx.testExt.junit)
 }

--- a/meshcore-cli/build.gradle.kts
+++ b/meshcore-cli/build.gradle.kts
@@ -1,58 +1,50 @@
-import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import java.nio.file.Files
+import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 
 plugins {
-    alias(libs.plugins.kotlinJvm)
-    application
-    alias(libs.plugins.graalvmNative)
+  alias(libs.plugins.kotlinJvm)
+  application
+  alias(libs.plugins.graalvmNative)
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-    }
-}
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 dependencies {
-    implementation(projects.meshcoreCore)
-    implementation(projects.meshcoreData)
-    implementation(projects.meshcoreTransportTcp)
-    implementation(projects.meshcoreTransportBle)
-    implementation(projects.meshcoreTransportUsb)
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.serialization.json)
-    implementation(libs.clikt)
-    implementation(libs.mordant)
-    implementation(libs.mordant.coroutines)
+  implementation(projects.meshcoreCore)
+  implementation(projects.meshcoreData)
+  implementation(projects.meshcoreTransportTcp)
+  implementation(projects.meshcoreTransportBle)
+  implementation(projects.meshcoreTransportUsb)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.clikt)
+  implementation(libs.mordant)
+  implementation(libs.mordant.coroutines)
 }
 
-application {
-    mainClass.set("ee.schimke.meshcore.cli.MainKt")
-}
+application { mainClass.set("ee.schimke.meshcore.cli.MainKt") }
 
 graalvmNative {
-    binaries {
-        named("main") {
-            mainClass.set("ee.schimke.meshcore.cli.MainKt")
-            imageName.set("meshcore")
-            buildArgs.addAll(
-                "--no-fallback",
-                "-H:+UnlockExperimentalVMOptions",
-                "-H:+ReportExceptionStackTraces",
-            )
-            javaLauncher.set(
-                javaToolchains.launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(25))
-                    vendor.set(JvmVendorSpec.GRAAL_VM)
-                },
-            )
+  binaries {
+    named("main") {
+      mainClass.set("ee.schimke.meshcore.cli.MainKt")
+      imageName.set("meshcore")
+      buildArgs.addAll(
+        "--no-fallback",
+        "-H:+UnlockExperimentalVMOptions",
+        "-H:+ReportExceptionStackTraces",
+      )
+      javaLauncher.set(
+        javaToolchains.launcherFor {
+          languageVersion.set(JavaLanguageVersion.of(25))
+          vendor.set(JvmVendorSpec.GRAAL_VM)
         }
+      )
     }
-    metadataRepository { enabled.set(true) }
+  }
+  metadataRepository { enabled.set(true) }
 }
 
 // https://github.com/gradle/gradle/issues/28583
@@ -60,20 +52,21 @@ graalvmNative {
 // provisioning ends up with empty files where links should be. Recreate
 // them before nativeCompile runs. Fix via square/okhttp#9393.
 tasks.named<BuildNativeImageTask>("nativeCompile") {
-    val toolchainDir = options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
-        if (name == "bin") parentFile else this
+  val toolchainDir =
+    options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
+      if (name == "bin") parentFile else this
     }
-    val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
-    val emptyFiles = toolchainFiles.filter { it.length() == 0L }
-    val links = toolchainFiles.mapNotNull { file ->
-        emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
+  val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
+  val emptyFiles = toolchainFiles.filter { it.length() == 0L }
+  val links = toolchainFiles.mapNotNull { file ->
+    emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
+  }
+  links.forEach { (target, link) ->
+    logger.quiet("Fixing up '$link' to link to '$target'.")
+    if (link.delete()) {
+      Files.createSymbolicLink(link.toPath(), target.toPath())
+    } else {
+      logger.warn("Unable to delete '$link'.")
     }
-    links.forEach { (target, link) ->
-        logger.quiet("Fixing up '$link' to link to '$target'.")
-        if (link.delete()) {
-            Files.createSymbolicLink(link.toPath(), target.toPath())
-        } else {
-            logger.warn("Unable to delete '$link'.")
-        }
-    }
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/BatteryCommand.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/BatteryCommand.kt
@@ -5,15 +5,16 @@ import com.github.ajalt.mordant.rendering.TextColors.red
 import com.github.ajalt.mordant.rendering.TextColors.yellow
 
 class BatteryCommand : SessionCommand("battery", "Show battery and storage status") {
-    override fun run() = withClient { client ->
-        val b = client.getBatteryAndStorage()
-        val pct = b.estimatePercent()
-        val colored = when {
-            pct >= 60 -> green("$pct%")
-            pct >= 25 -> yellow("$pct%")
-            else -> red("$pct%")
-        }
-        terminal.println("Battery: ${b.millivolts} mV ($colored)")
-        terminal.println("Storage: ${b.storageUsedKb} / ${b.storageTotalKb} kB")
-    }
+  override fun run() = withClient { client ->
+    val b = client.getBatteryAndStorage()
+    val pct = b.estimatePercent()
+    val colored =
+      when {
+        pct >= 60 -> green("$pct%")
+        pct >= 25 -> yellow("$pct%")
+        else -> red("$pct%")
+      }
+    terminal.println("Battery: ${b.millivolts} mV ($colored)")
+    terminal.println("Storage: ${b.storageUsedKb} / ${b.storageTotalKb} kB")
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/ContactsCommand.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/ContactsCommand.kt
@@ -6,20 +6,20 @@ import com.github.ajalt.mordant.rendering.TextStyles.bold
 import com.github.ajalt.mordant.table.table
 
 class ContactsCommand : SessionCommand("contacts", "List contacts known to the device") {
-    override fun run() = withClient { client ->
-        val contacts = client.getContacts()
-        terminal.println(bold("${contacts.size} contacts"))
-        if (contacts.isEmpty()) return@withClient
-        terminal.println(
-            table {
-                header { row("name", "type", "path", "pubkey") }
-                body {
-                    contacts.forEach { c ->
-                        val path = if (c.isFlood) yellow("flood") else green("${c.pathLength} hops")
-                        row(c.name, c.type.name, path, c.publicKey.toString().take(12) + "…")
-                    }
-                }
-            },
-        )
-    }
+  override fun run() = withClient { client ->
+    val contacts = client.getContacts()
+    terminal.println(bold("${contacts.size} contacts"))
+    if (contacts.isEmpty()) return@withClient
+    terminal.println(
+      table {
+        header { row("name", "type", "path", "pubkey") }
+        body {
+          contacts.forEach { c ->
+            val path = if (c.isFlood) yellow("flood") else green("${c.pathLength} hops")
+            row(c.name, c.type.name, path, c.publicKey.toString().take(12) + "…")
+          }
+        }
+      }
+    )
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/DeviceStore.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/DeviceStore.kt
@@ -7,18 +7,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 /**
- * CLI device store backed by Room (same DB as the Android app on JVM).
- * Stored at `~/.meshcore/meshcore.db`.
+ * CLI device store backed by Room (same DB as the Android app on JVM). Stored at
+ * `~/.meshcore/meshcore.db`.
  */
 class DeviceStore {
-    val repository: MeshcoreRepository by lazy {
-        MeshcoreRepository(createMeshcoreDatabase())
-    }
+  val repository: MeshcoreRepository by lazy { MeshcoreRepository(createMeshcoreDatabase()) }
 
-    /** Returns the favorite device's TCP host and port, or null. */
-    fun getFavorite(): Pair<String, Int>? = runBlocking {
-        val fav = repository.observeFavorite().first() ?: return@runBlocking null
-        val tcp = fav.transport as? SavedTransport.Tcp ?: return@runBlocking null
-        tcp.host to tcp.port
-    }
+  /** Returns the favorite device's TCP host and port, or null. */
+  fun getFavorite(): Pair<String, Int>? = runBlocking {
+    val fav = repository.observeFavorite().first() ?: return@runBlocking null
+    val tcp = fav.transport as? SavedTransport.Tcp ?: return@runBlocking null
+    tcp.host to tcp.port
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/InfoCommand.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/InfoCommand.kt
@@ -7,34 +7,34 @@ import com.github.ajalt.mordant.rendering.TextStyles.bold
 import com.github.ajalt.mordant.table.table
 
 class InfoCommand : SessionCommand("info", "Show device self info, radio and battery") {
-    override fun run() = withClient { client ->
-        val self = client.selfInfo.value
-        val radio = client.radio.value
-        val battery = client.battery.value
-        terminal.println((bold + brightBlue)("MeshCore device"))
-        terminal.println(
-            table {
-                header { row("Field", "Value") }
-                body {
-                    row("name", self?.name ?: "(unknown)")
-                    row("pubkey", self?.publicKey?.toString() ?: "—")
-                    row("location", self?.let { "${it.latitude}, ${it.longitude}" } ?: "—")
-                    row("tx power", self?.let { "${it.txPowerDbm} / ${it.maxPowerDbm} dBm" } ?: "—")
-                    radio?.let {
-                        row("frequency", "${it.frequencyHz / 1_000_000.0} MHz")
-                        row("bandwidth", "${it.bandwidthHz / 1_000.0} kHz")
-                        row("spreading", "SF${it.spreadingFactor}")
-                        row("coding rate", "4/${it.codingRate}")
-                    }
-                    battery?.let {
-                        row("battery", cyan("${it.millivolts} mV (${it.estimatePercent()}%)"))
-                        row("storage", "${it.storageUsedKb} / ${it.storageTotalKb} kB")
-                    }
-                }
-            },
-        )
-        if (self == null) {
-            terminal.println(gray("No SELF_INFO received yet — try a longer --warmup."))
+  override fun run() = withClient { client ->
+    val self = client.selfInfo.value
+    val radio = client.radio.value
+    val battery = client.battery.value
+    terminal.println((bold + brightBlue)("MeshCore device"))
+    terminal.println(
+      table {
+        header { row("Field", "Value") }
+        body {
+          row("name", self?.name ?: "(unknown)")
+          row("pubkey", self?.publicKey?.toString() ?: "—")
+          row("location", self?.let { "${it.latitude}, ${it.longitude}" } ?: "—")
+          row("tx power", self?.let { "${it.txPowerDbm} / ${it.maxPowerDbm} dBm" } ?: "—")
+          radio?.let {
+            row("frequency", "${it.frequencyHz / 1_000_000.0} MHz")
+            row("bandwidth", "${it.bandwidthHz / 1_000.0} kHz")
+            row("spreading", "SF${it.spreadingFactor}")
+            row("coding rate", "4/${it.codingRate}")
+          }
+          battery?.let {
+            row("battery", cyan("${it.millivolts} mV (${it.estimatePercent()}%)"))
+            row("storage", "${it.storageUsedKb} / ${it.storageTotalKb} kB")
+          }
         }
+      }
+    )
+    if (self == null) {
+      terminal.println(gray("No SELF_INFO received yet — try a longer --warmup."))
     }
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/Main.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/Main.kt
@@ -6,25 +6,25 @@ import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.mordant.terminal.Terminal
 
 /**
- * Entry point for the `meshcore` CLI. Wires all subcommands together
- * under a single root command. The CLI connects to a MeshCore device
- * over TCP (the companion "serial bridge"); BLE and USB are mobile
- * concerns and live in the Android sample.
+ * Entry point for the `meshcore` CLI. Wires all subcommands together under a single root command.
+ * The CLI connects to a MeshCore device over TCP (the companion "serial bridge"); BLE and USB are
+ * mobile concerns and live in the Android sample.
  */
 class MeshcoreCli : NoOpCliktCommand(name = "meshcore") {
-    override fun help(context: com.github.ajalt.clikt.core.Context): String =
-        "Talk to a MeshCore device over TCP from the command line."
+  override fun help(context: com.github.ajalt.clikt.core.Context): String =
+    "Talk to a MeshCore device over TCP from the command line."
 }
 
 val terminal: Terminal = Terminal()
 
-fun main(args: Array<String>) = MeshcoreCli()
+fun main(args: Array<String>) =
+  MeshcoreCli()
     .subcommands(
-        InfoCommand(),
-        ContactsCommand(),
-        BatteryCommand(),
-        RadioCommand(),
-        SendCommand(),
-        ReplCommand(),
+      InfoCommand(),
+      ContactsCommand(),
+      BatteryCommand(),
+      RadioCommand(),
+      SendCommand(),
+      ReplCommand(),
     )
     .main(args)

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/RadioCommand.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/RadioCommand.kt
@@ -6,26 +6,26 @@ import com.github.ajalt.clikt.parameters.types.int
 
 class RadioCommand : SessionCommand("radio", "Read (or update) LoRa radio parameters") {
 
-    private val setFreq by option("--freq").int().help("Set frequency in Hz (optional)")
-    private val setBw by option("--bw").int().help("Set bandwidth in Hz (optional)")
-    private val setSf by option("--sf").int().help("Set spreading factor (5-12)")
-    private val setCr by option("--cr").int().help("Set coding rate (5-8)")
+  private val setFreq by option("--freq").int().help("Set frequency in Hz (optional)")
+  private val setBw by option("--bw").int().help("Set bandwidth in Hz (optional)")
+  private val setSf by option("--sf").int().help("Set spreading factor (5-12)")
+  private val setCr by option("--cr").int().help("Set coding rate (5-8)")
 
-    override fun run() = withClient { client ->
-        val current = client.getRadioSettings()
-        if (listOf(setFreq, setBw, setSf, setCr).any { it != null }) {
-            client.setRadioParams(
-                freqHz = setFreq ?: current.frequencyHz,
-                bwHz = setBw ?: current.bandwidthHz,
-                sf = setSf ?: current.spreadingFactor,
-                cr = setCr ?: current.codingRate,
-            )
-            terminal.println("Sent new radio params; re-reading…")
-        }
-        val updated = client.getRadioSettings()
-        terminal.println("Frequency  : ${updated.frequencyHz / 1_000_000.0} MHz")
-        terminal.println("Bandwidth  : ${updated.bandwidthHz / 1_000.0} kHz")
-        terminal.println("Spreading  : SF${updated.spreadingFactor}")
-        terminal.println("CodingRate : 4/${updated.codingRate}")
+  override fun run() = withClient { client ->
+    val current = client.getRadioSettings()
+    if (listOf(setFreq, setBw, setSf, setCr).any { it != null }) {
+      client.setRadioParams(
+        freqHz = setFreq ?: current.frequencyHz,
+        bwHz = setBw ?: current.bandwidthHz,
+        sf = setSf ?: current.spreadingFactor,
+        cr = setCr ?: current.codingRate,
+      )
+      terminal.println("Sent new radio params; re-reading…")
     }
+    val updated = client.getRadioSettings()
+    terminal.println("Frequency  : ${updated.frequencyHz / 1_000_000.0} MHz")
+    terminal.println("Bandwidth  : ${updated.bandwidthHz / 1_000.0} kHz")
+    terminal.println("Spreading  : SF${updated.spreadingFactor}")
+    terminal.println("CodingRate : 4/${updated.codingRate}")
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/ReplCommand.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/ReplCommand.kt
@@ -14,6 +14,7 @@ import com.github.ajalt.mordant.table.table
 import ee.schimke.meshcore.core.client.MeshCoreClient
 import ee.schimke.meshcore.core.model.PublicKey
 import ee.schimke.meshcore.core.transport.TransportState
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -27,415 +28,473 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import kotlin.time.Clock
 
 /**
- * Interactive shell over one connection. Reads commands from stdin, one per
- * line, and writes results to stdout. In `--json` mode each command emits a
- * single JSON object/array line, making it friendly to scripted pipelines.
+ * Interactive shell over one connection. Reads commands from stdin, one per line, and writes
+ * results to stdout. In `--json` mode each command emits a single JSON object/array line, making it
+ * friendly to scripted pipelines.
  */
-class ReplCommand : SessionCommand(
+class ReplCommand :
+  SessionCommand(
     name = "repl",
     help = "Interactive shell — connects once and accepts commands until quit",
-) {
-    private val jsonMode by option("--json").flag()
-        .help("Emit JSON objects to stdout (one per line) instead of formatted text")
+  ) {
+  private val jsonMode by
+    option("--json")
+      .flag()
+      .help("Emit JSON objects to stdout (one per line) instead of formatted text")
 
-    private val json = Json { prettyPrint = false }
+  private val json = Json { prettyPrint = false }
 
-    override fun run() = try {
-        withClient { client -> runRepl(client) }
+  override fun run() =
+    try {
+      withClient { client -> runRepl(client) }
     } catch (t: Throwable) {
-        val msg = t.message ?: t.toString()
-        if (jsonMode) emit(buildJsonObject { put("error", "failed to connect: $msg") })
-        else terminal.println(red("failed to connect: $msg"))
+      val msg = t.message ?: t.toString()
+      if (jsonMode) emit(buildJsonObject { put("error", "failed to connect: $msg") })
+      else terminal.println(red("failed to connect: $msg"))
     }
 
-    private suspend fun runRepl(client: MeshCoreClient) {
-        val watcherScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val watcher: Job = watcherScope.launch {
-            // Report mid-session transport transitions so the user notices drops.
-            client.connection.drop(1).collect { reportConnectionChange(it) }
+  private suspend fun runRepl(client: MeshCoreClient) {
+    val watcherScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val watcher: Job = watcherScope.launch {
+      // Report mid-session transport transitions so the user notices drops.
+      client.connection.drop(1).collect { reportConnectionChange(it) }
+    }
+    try {
+      if (!jsonMode) printBanner(client)
+      while (true) {
+        if (!jsonMode) {
+          val name = client.selfInfo.value?.name ?: "meshcore"
+          terminal.print("${brightBlue(name)}> ")
         }
-        try {
-            if (!jsonMode) printBanner(client)
-            while (true) {
-                if (!jsonMode) {
-                    val name = client.selfInfo.value?.name ?: "meshcore"
-                    terminal.print("${brightBlue(name)}> ")
+        val line = readlnOrNull()?.trim() ?: break
+        if (line.isEmpty()) continue
+        val done = dispatch(client, line)
+        if (done) break
+      }
+      if (jsonMode) emit(buildJsonObject { put("goodbye", true) })
+      else terminal.println(gray("bye."))
+    } finally {
+      watcher.cancel()
+      watcherScope.cancel()
+    }
+  }
+
+  private fun reportConnectionChange(state: TransportState) {
+    val label = describe(state)
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put("connection", label)
+          if (state is TransportState.Error) put("cause", state.cause.message)
+        }
+      )
+    } else {
+      val msg =
+        "connection: $label" +
+          if (state is TransportState.Error) " (${state.cause.message})" else ""
+      terminal.println(red(msg))
+    }
+  }
+
+  private fun describe(state: TransportState): String =
+    when (state) {
+      TransportState.Connected -> "connected"
+      TransportState.Connecting -> "connecting"
+      TransportState.Disconnected -> "disconnected"
+      is TransportState.Error -> "error"
+    }
+
+  private fun printBanner(client: MeshCoreClient) {
+    val self = client.selfInfo.value
+    val conn = describe(client.connection.value)
+    terminal.println(
+      bold("MeshCore REPL") + gray(" — ") + (self?.name ?: "(unknown)") + gray(" [$conn]")
+    )
+    terminal.println(
+      gray("Type 'help' for commands, 'status' for connection info, 'quit' to exit.")
+    )
+  }
+
+  private fun status(client: MeshCoreClient) {
+    val conn = describe(client.connection.value)
+    val self = client.selfInfo.value
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put("connection", conn)
+          put("self_info_received", self != null)
+          put("name", self?.name)
+        }
+      )
+    } else {
+      terminal.println("Connection: $conn")
+      terminal.println(
+        "SelfInfo   : " + if (self != null) "received (${self.name})" else gray("(none yet)")
+      )
+    }
+  }
+
+  /** Returns true if the REPL should exit. */
+  private suspend fun dispatch(client: MeshCoreClient, line: String): Boolean {
+    val tokens = tokenize(line)
+    if (tokens.isEmpty()) return false
+    val cmd = tokens[0].lowercase()
+    val args = tokens.drop(1)
+    return try {
+      when (cmd) {
+        "quit",
+        "exit",
+        "q" -> true
+        "help",
+        "?" -> {
+          help()
+          false
+        }
+        "status" -> {
+          status(client)
+          false
+        }
+        "info",
+        "i" -> {
+          info(client)
+          false
+        }
+        "contacts",
+        "c",
+        "ls" -> {
+          contacts(client)
+          false
+        }
+        "battery",
+        "bat" -> {
+          battery(client)
+          false
+        }
+        "radio" -> {
+          radio(client, args)
+          false
+        }
+        "send",
+        "msg" -> {
+          send(client, args)
+          false
+        }
+        "login" -> {
+          login(client, args)
+          false
+        }
+        "sync",
+        "sync_msgs" -> {
+          sync(client)
+          false
+        }
+        else -> {
+          error("unknown command: $cmd — try 'help'")
+          false
+        }
+      }
+    } catch (t: Throwable) {
+      error(t.message ?: t.toString())
+      false
+    }
+  }
+
+  // ── Commands ────────────────────────────────────────────────────────────
+
+  private fun help() {
+    val helpText =
+      """
+      |Commands
+      |  info, i                         self info, radio, battery
+      |  contacts, c, ls                 contact list
+      |  battery, bat                    battery + storage
+      |  radio                           show radio params
+      |  radio set <freqHz> <bwHz> <sf> <cr>
+      |                                  update radio params
+      |  send <name> <text…>             send DM; <name> matches contact substring
+      |  login <name> <password>         login to a repeater/room server
+      |  sync                            pull unread messages from the device
+      |  help, ?                         this help
+      |  quit, exit, q                   leave REPL
+      """
+        .trimMargin()
+    if (jsonMode) emit(buildJsonObject { put("help", helpText) }) else terminal.println(helpText)
+  }
+
+  private fun info(client: MeshCoreClient) {
+    val self = client.selfInfo.value
+    val radio = client.radio.value
+    val bat = client.battery.value
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put("name", self?.name)
+          put("pubkey", self?.publicKey?.toString())
+          put("latitude", self?.latitude)
+          put("longitude", self?.longitude)
+          put("tx_power_dbm", self?.txPowerDbm)
+          put("max_tx_power_dbm", self?.maxPowerDbm)
+          radio?.let {
+            put("radio_freq_hz", it.frequencyHz)
+            put("radio_bw_hz", it.bandwidthHz)
+            put("radio_sf", it.spreadingFactor)
+            put("radio_cr", it.codingRate)
+          }
+          bat?.let {
+            put("battery_mv", it.millivolts)
+            put("battery_pct", it.estimatePercent())
+            put("storage_used_kb", it.storageUsedKb)
+            put("storage_total_kb", it.storageTotalKb)
+          }
+        }
+      )
+      return
+    }
+    terminal.println(
+      table {
+        header { row("Field", "Value") }
+        body {
+          row("name", self?.name ?: "(unknown)")
+          row("pubkey", self?.publicKey?.toString() ?: "—")
+          row("location", self?.let { "${it.latitude}, ${it.longitude}" } ?: "—")
+          row("tx power", self?.let { "${it.txPowerDbm} / ${it.maxPowerDbm} dBm" } ?: "—")
+          radio?.let {
+            row("frequency", "${it.frequencyHz / 1_000_000.0} MHz")
+            row("bandwidth", "${it.bandwidthHz / 1_000.0} kHz")
+            row("spreading", "SF${it.spreadingFactor}")
+            row("coding rate", "4/${it.codingRate}")
+          }
+          bat?.let {
+            row("battery", cyan("${it.millivolts} mV (${it.estimatePercent()}%)"))
+            row("storage", "${it.storageUsedKb} / ${it.storageTotalKb} kB")
+          }
+        }
+      }
+    )
+  }
+
+  private suspend fun contacts(client: MeshCoreClient) {
+    val list = client.getContacts()
+    if (jsonMode) {
+      emit(
+        buildJsonArray {
+          list.forEach { c ->
+            add(
+              buildJsonObject {
+                put("name", c.name)
+                put("type", c.type.name)
+                put("pubkey", c.publicKey.toString())
+                put("is_flood", c.isFlood)
+                put("path_length", c.pathLength)
+              }
+            )
+          }
+        }
+      )
+      return
+    }
+    terminal.println(bold("${list.size} contacts"))
+    if (list.isEmpty()) return
+    terminal.println(
+      table {
+        header { row("name", "type", "path", "pubkey") }
+        body {
+          list.forEach { c ->
+            val path = if (c.isFlood) yellow("flood") else green("${c.pathLength} hops")
+            row(c.name, c.type.name, path, c.publicKey.toString().take(12) + "…")
+          }
+        }
+      }
+    )
+  }
+
+  private suspend fun battery(client: MeshCoreClient) {
+    val b = client.getBatteryAndStorage()
+    val pct = b.estimatePercent()
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put("millivolts", b.millivolts)
+          put("percent", pct)
+          put("storage_used_kb", b.storageUsedKb)
+          put("storage_total_kb", b.storageTotalKb)
+        }
+      )
+      return
+    }
+    val colored =
+      when {
+        pct >= 60 -> green("$pct%")
+        pct >= 25 -> yellow("$pct%")
+        else -> red("$pct%")
+      }
+    terminal.println("Battery: ${b.millivolts} mV ($colored)")
+    terminal.println("Storage: ${b.storageUsedKb} / ${b.storageTotalKb} kB")
+  }
+
+  private suspend fun radio(client: MeshCoreClient, args: List<String>) {
+    if (args.firstOrNull()?.lowercase() == "set") {
+      val rest = args.drop(1)
+      if (rest.size != 4) {
+        error("usage: radio set <freqHz> <bwHz> <sf> <cr>")
+        return
+      }
+      val ints = rest.map { it.toIntOrNull() }
+      if (ints.any { it == null }) {
+        error("radio set: all four values must be integers")
+        return
+      }
+      client.setRadioParams(ints[0]!!, ints[1]!!, ints[2]!!, ints[3]!!)
+    }
+    val r = client.getRadioSettings()
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put("freq_hz", r.frequencyHz)
+          put("bw_hz", r.bandwidthHz)
+          put("sf", r.spreadingFactor)
+          put("cr", r.codingRate)
+        }
+      )
+      return
+    }
+    terminal.println("Frequency  : ${r.frequencyHz / 1_000_000.0} MHz")
+    terminal.println("Bandwidth  : ${r.bandwidthHz / 1_000.0} kHz")
+    terminal.println("Spreading  : SF${r.spreadingFactor}")
+    terminal.println("CodingRate : 4/${r.codingRate}")
+  }
+
+  private suspend fun send(client: MeshCoreClient, args: List<String>) {
+    if (args.size < 2) {
+      error("usage: send <name-substring> <text…>")
+      return
+    }
+    val recipient = resolveContact(client, args[0]) ?: return
+    val text = args.drop(1).joinToString(" ")
+    val ack = client.sendText(recipient = recipient, text = text, timestamp = Clock.System.now())
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put("sent", true)
+          put("flood", ack.isFlood)
+          put("timeout_ms", ack.timeoutMs)
+        }
+      )
+    } else {
+      terminal.println(green("sent.") + " flood=${ack.isFlood} timeout=${ack.timeoutMs}ms")
+    }
+  }
+
+  private suspend fun login(client: MeshCoreClient, args: List<String>) {
+    if (args.size < 2) {
+      error("usage: login <name-substring> <password>")
+      return
+    }
+    val recipient = resolveContact(client, args[0]) ?: return
+    val password = args.drop(1).joinToString(" ")
+    client.login(recipient, password)
+    if (jsonMode) emit(buildJsonObject { put("login", true) })
+    else terminal.println(green("login ok"))
+  }
+
+  private suspend fun sync(client: MeshCoreClient) {
+    client.syncMessages()
+    val direct = client.directMessages.value
+    val channel = client.channelMessages.value
+    if (jsonMode) {
+      emit(
+        buildJsonObject {
+          put(
+            "direct",
+            buildJsonArray {
+              direct.forEach { (prefix, msgs) ->
+                msgs.forEach { m ->
+                  add(
+                    buildJsonObject {
+                      put("from_prefix", prefix)
+                      put("text", m.text)
+                      put("timestamp", m.timestamp.toString())
+                    }
+                  )
                 }
-                val line = readlnOrNull()?.trim() ?: break
-                if (line.isEmpty()) continue
-                val done = dispatch(client, line)
-                if (done) break
-            }
-            if (jsonMode) emit(buildJsonObject { put("goodbye", true) })
-            else terminal.println(gray("bye."))
-        } finally {
-            watcher.cancel()
-            watcherScope.cancel()
-        }
-    }
-
-    private fun reportConnectionChange(state: TransportState) {
-        val label = describe(state)
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put("connection", label)
-                    if (state is TransportState.Error) put("cause", state.cause.message)
-                },
-            )
-        } else {
-            val msg = "connection: $label" + if (state is TransportState.Error) " (${state.cause.message})" else ""
-            terminal.println(red(msg))
-        }
-    }
-
-    private fun describe(state: TransportState): String = when (state) {
-        TransportState.Connected -> "connected"
-        TransportState.Connecting -> "connecting"
-        TransportState.Disconnected -> "disconnected"
-        is TransportState.Error -> "error"
-    }
-
-    private fun printBanner(client: MeshCoreClient) {
-        val self = client.selfInfo.value
-        val conn = describe(client.connection.value)
-        terminal.println(
-            bold("MeshCore REPL") + gray(" — ") + (self?.name ?: "(unknown)") + gray(" [$conn]"),
-        )
-        terminal.println(gray("Type 'help' for commands, 'status' for connection info, 'quit' to exit."))
-    }
-
-    private fun status(client: MeshCoreClient) {
-        val conn = describe(client.connection.value)
-        val self = client.selfInfo.value
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put("connection", conn)
-                    put("self_info_received", self != null)
-                    put("name", self?.name)
-                },
-            )
-        } else {
-            terminal.println("Connection: $conn")
-            terminal.println("SelfInfo   : " + if (self != null) "received (${self.name})" else gray("(none yet)"))
-        }
-    }
-
-    /** Returns true if the REPL should exit. */
-    private suspend fun dispatch(client: MeshCoreClient, line: String): Boolean {
-        val tokens = tokenize(line)
-        if (tokens.isEmpty()) return false
-        val cmd = tokens[0].lowercase()
-        val args = tokens.drop(1)
-        return try {
-            when (cmd) {
-                "quit", "exit", "q" -> true
-                "help", "?" -> { help(); false }
-                "status" -> { status(client); false }
-                "info", "i" -> { info(client); false }
-                "contacts", "c", "ls" -> { contacts(client); false }
-                "battery", "bat" -> { battery(client); false }
-                "radio" -> { radio(client, args); false }
-                "send", "msg" -> { send(client, args); false }
-                "login" -> { login(client, args); false }
-                "sync", "sync_msgs" -> { sync(client); false }
-                else -> { error("unknown command: $cmd — try 'help'"); false }
-            }
-        } catch (t: Throwable) {
-            error(t.message ?: t.toString())
-            false
-        }
-    }
-
-    // ── Commands ────────────────────────────────────────────────────────────
-
-    private fun help() {
-        val helpText = """
-            |Commands
-            |  info, i                         self info, radio, battery
-            |  contacts, c, ls                 contact list
-            |  battery, bat                    battery + storage
-            |  radio                           show radio params
-            |  radio set <freqHz> <bwHz> <sf> <cr>
-            |                                  update radio params
-            |  send <name> <text…>             send DM; <name> matches contact substring
-            |  login <name> <password>         login to a repeater/room server
-            |  sync                            pull unread messages from the device
-            |  help, ?                         this help
-            |  quit, exit, q                   leave REPL
-        """.trimMargin()
-        if (jsonMode) emit(buildJsonObject { put("help", helpText) })
-        else terminal.println(helpText)
-    }
-
-    private fun info(client: MeshCoreClient) {
-        val self = client.selfInfo.value
-        val radio = client.radio.value
-        val bat = client.battery.value
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put("name", self?.name)
-                    put("pubkey", self?.publicKey?.toString())
-                    put("latitude", self?.latitude)
-                    put("longitude", self?.longitude)
-                    put("tx_power_dbm", self?.txPowerDbm)
-                    put("max_tx_power_dbm", self?.maxPowerDbm)
-                    radio?.let {
-                        put("radio_freq_hz", it.frequencyHz)
-                        put("radio_bw_hz", it.bandwidthHz)
-                        put("radio_sf", it.spreadingFactor)
-                        put("radio_cr", it.codingRate)
-                    }
-                    bat?.let {
-                        put("battery_mv", it.millivolts)
-                        put("battery_pct", it.estimatePercent())
-                        put("storage_used_kb", it.storageUsedKb)
-                        put("storage_total_kb", it.storageTotalKb)
-                    }
-                },
-            )
-            return
-        }
-        terminal.println(
-            table {
-                header { row("Field", "Value") }
-                body {
-                    row("name", self?.name ?: "(unknown)")
-                    row("pubkey", self?.publicKey?.toString() ?: "—")
-                    row("location", self?.let { "${it.latitude}, ${it.longitude}" } ?: "—")
-                    row("tx power", self?.let { "${it.txPowerDbm} / ${it.maxPowerDbm} dBm" } ?: "—")
-                    radio?.let {
-                        row("frequency", "${it.frequencyHz / 1_000_000.0} MHz")
-                        row("bandwidth", "${it.bandwidthHz / 1_000.0} kHz")
-                        row("spreading", "SF${it.spreadingFactor}")
-                        row("coding rate", "4/${it.codingRate}")
-                    }
-                    bat?.let {
-                        row("battery", cyan("${it.millivolts} mV (${it.estimatePercent()}%)"))
-                        row("storage", "${it.storageUsedKb} / ${it.storageTotalKb} kB")
-                    }
-                }
+              }
             },
-        )
-    }
-
-    private suspend fun contacts(client: MeshCoreClient) {
-        val list = client.getContacts()
-        if (jsonMode) {
-            emit(
-                buildJsonArray {
-                    list.forEach { c ->
-                        add(
-                            buildJsonObject {
-                                put("name", c.name)
-                                put("type", c.type.name)
-                                put("pubkey", c.publicKey.toString())
-                                put("is_flood", c.isFlood)
-                                put("path_length", c.pathLength)
-                            },
-                        )
+          )
+          put(
+            "channel",
+            buildJsonArray {
+              channel.forEach { (idx, msgs) ->
+                msgs.forEach { m ->
+                  add(
+                    buildJsonObject {
+                      put("channel", idx)
+                      put("text", m.text)
+                      put("timestamp", m.timestamp.toString())
                     }
-                },
-            )
-            return
-        }
-        terminal.println(bold("${list.size} contacts"))
-        if (list.isEmpty()) return
-        terminal.println(
-            table {
-                header { row("name", "type", "path", "pubkey") }
-                body {
-                    list.forEach { c ->
-                        val path = if (c.isFlood) yellow("flood") else green("${c.pathLength} hops")
-                        row(c.name, c.type.name, path, c.publicKey.toString().take(12) + "…")
-                    }
+                  )
                 }
+              }
             },
-        )
-    }
-
-    private suspend fun battery(client: MeshCoreClient) {
-        val b = client.getBatteryAndStorage()
-        val pct = b.estimatePercent()
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put("millivolts", b.millivolts)
-                    put("percent", pct)
-                    put("storage_used_kb", b.storageUsedKb)
-                    put("storage_total_kb", b.storageTotalKb)
-                },
-            )
-            return
+          )
         }
-        val colored = when {
-            pct >= 60 -> green("$pct%")
-            pct >= 25 -> yellow("$pct%")
-            else -> red("$pct%")
-        }
-        terminal.println("Battery: ${b.millivolts} mV ($colored)")
-        terminal.println("Storage: ${b.storageUsedKb} / ${b.storageTotalKb} kB")
+      )
+      return
     }
-
-    private suspend fun radio(client: MeshCoreClient, args: List<String>) {
-        if (args.firstOrNull()?.lowercase() == "set") {
-            val rest = args.drop(1)
-            if (rest.size != 4) {
-                error("usage: radio set <freqHz> <bwHz> <sf> <cr>"); return
-            }
-            val ints = rest.map { it.toIntOrNull() }
-            if (ints.any { it == null }) {
-                error("radio set: all four values must be integers"); return
-            }
-            client.setRadioParams(ints[0]!!, ints[1]!!, ints[2]!!, ints[3]!!)
-        }
-        val r = client.getRadioSettings()
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put("freq_hz", r.frequencyHz)
-                    put("bw_hz", r.bandwidthHz)
-                    put("sf", r.spreadingFactor)
-                    put("cr", r.codingRate)
-                },
-            )
-            return
-        }
-        terminal.println("Frequency  : ${r.frequencyHz / 1_000_000.0} MHz")
-        terminal.println("Bandwidth  : ${r.bandwidthHz / 1_000.0} kHz")
-        terminal.println("Spreading  : SF${r.spreadingFactor}")
-        terminal.println("CodingRate : 4/${r.codingRate}")
+    val dmTotal = direct.values.sumOf { it.size }
+    val chTotal = channel.values.sumOf { it.size }
+    terminal.println(bold("Direct ($dmTotal)"))
+    direct.forEach { (prefix, msgs) ->
+      msgs.forEach { m -> terminal.println("  ${gray(prefix.take(12))}  ${m.text}") }
     }
+    terminal.println(bold("Channels ($chTotal)"))
+    channel.forEach { (idx, msgs) ->
+      msgs.forEach { m -> terminal.println("  ${gray("#$idx")}  ${m.text}") }
+    }
+  }
 
-    private suspend fun send(client: MeshCoreClient, args: List<String>) {
-        if (args.size < 2) { error("usage: send <name-substring> <text…>"); return }
-        val recipient = resolveContact(client, args[0]) ?: return
-        val text = args.drop(1).joinToString(" ")
-        val ack = client.sendText(
-            recipient = recipient,
-            text = text,
-            timestamp = Clock.System.now(),
-        )
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put("sent", true)
-                    put("flood", ack.isFlood)
-                    put("timeout_ms", ack.timeoutMs)
-                },
-            )
-        } else {
-            terminal.println(green("sent.") + " flood=${ack.isFlood} timeout=${ack.timeoutMs}ms")
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  private suspend fun resolveContact(client: MeshCoreClient, needle: String): PublicKey? {
+    val n = needle.lowercase()
+    val match = client.getContacts().firstOrNull { it.name.lowercase().contains(n) }
+    if (match == null) {
+      error("no contact matches '$needle'")
+      return null
+    }
+    return match.publicKey
+  }
+
+  private fun error(message: String) {
+    if (jsonMode) emit(buildJsonObject { put("error", message) })
+    else terminal.println(red(message))
+  }
+
+  private fun emit(obj: JsonObject) = println(json.encodeToString(JsonObject.serializer(), obj))
+
+  private fun emit(arr: JsonArray) = println(json.encodeToString(JsonArray.serializer(), arr))
+
+  /** Minimal shell-style tokenizer: whitespace splits, single or double quotes group. */
+  private fun tokenize(line: String): List<String> {
+    val out = mutableListOf<String>()
+    val cur = StringBuilder()
+    var quote: Char? = null
+    for (ch in line) {
+      when {
+        quote != null && ch == quote -> quote = null
+        quote != null -> cur.append(ch)
+        ch == '"' || ch == '\'' -> quote = ch
+        ch.isWhitespace() -> {
+          if (cur.isNotEmpty()) {
+            out += cur.toString()
+            cur.clear()
+          }
         }
+        else -> cur.append(ch)
+      }
     }
-
-    private suspend fun login(client: MeshCoreClient, args: List<String>) {
-        if (args.size < 2) { error("usage: login <name-substring> <password>"); return }
-        val recipient = resolveContact(client, args[0]) ?: return
-        val password = args.drop(1).joinToString(" ")
-        client.login(recipient, password)
-        if (jsonMode) emit(buildJsonObject { put("login", true) })
-        else terminal.println(green("login ok"))
-    }
-
-    private suspend fun sync(client: MeshCoreClient) {
-        client.syncMessages()
-        val direct = client.directMessages.value
-        val channel = client.channelMessages.value
-        if (jsonMode) {
-            emit(
-                buildJsonObject {
-                    put(
-                        "direct",
-                        buildJsonArray {
-                            direct.forEach { (prefix, msgs) ->
-                                msgs.forEach { m ->
-                                    add(
-                                        buildJsonObject {
-                                            put("from_prefix", prefix)
-                                            put("text", m.text)
-                                            put("timestamp", m.timestamp.toString())
-                                        },
-                                    )
-                                }
-                            }
-                        },
-                    )
-                    put(
-                        "channel",
-                        buildJsonArray {
-                            channel.forEach { (idx, msgs) ->
-                                msgs.forEach { m ->
-                                    add(
-                                        buildJsonObject {
-                                            put("channel", idx)
-                                            put("text", m.text)
-                                            put("timestamp", m.timestamp.toString())
-                                        },
-                                    )
-                                }
-                            }
-                        },
-                    )
-                },
-            )
-            return
-        }
-        val dmTotal = direct.values.sumOf { it.size }
-        val chTotal = channel.values.sumOf { it.size }
-        terminal.println(bold("Direct ($dmTotal)"))
-        direct.forEach { (prefix, msgs) ->
-            msgs.forEach { m ->
-                terminal.println("  ${gray(prefix.take(12))}  ${m.text}")
-            }
-        }
-        terminal.println(bold("Channels ($chTotal)"))
-        channel.forEach { (idx, msgs) ->
-            msgs.forEach { m ->
-                terminal.println("  ${gray("#$idx")}  ${m.text}")
-            }
-        }
-    }
-
-    // ── Helpers ─────────────────────────────────────────────────────────────
-
-    private suspend fun resolveContact(client: MeshCoreClient, needle: String): PublicKey? {
-        val n = needle.lowercase()
-        val match = client.getContacts().firstOrNull { it.name.lowercase().contains(n) }
-        if (match == null) { error("no contact matches '$needle'"); return null }
-        return match.publicKey
-    }
-
-    private fun error(message: String) {
-        if (jsonMode) emit(buildJsonObject { put("error", message) })
-        else terminal.println(red(message))
-    }
-
-    private fun emit(obj: JsonObject) = println(json.encodeToString(JsonObject.serializer(), obj))
-    private fun emit(arr: JsonArray) = println(json.encodeToString(JsonArray.serializer(), arr))
-
-    /** Minimal shell-style tokenizer: whitespace splits, single or double quotes group. */
-    private fun tokenize(line: String): List<String> {
-        val out = mutableListOf<String>()
-        val cur = StringBuilder()
-        var quote: Char? = null
-        for (ch in line) {
-            when {
-                quote != null && ch == quote -> quote = null
-                quote != null -> cur.append(ch)
-                ch == '"' || ch == '\'' -> quote = ch
-                ch.isWhitespace() -> {
-                    if (cur.isNotEmpty()) { out += cur.toString(); cur.clear() }
-                }
-                else -> cur.append(ch)
-            }
-        }
-        if (cur.isNotEmpty()) out += cur.toString()
-        return out
-    }
+    if (cur.isNotEmpty()) out += cur.toString()
+    return out
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/SendCommand.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/SendCommand.kt
@@ -11,29 +11,25 @@ import kotlin.time.Clock
 
 class SendCommand : SessionCommand("send", "Send a direct text message to a contact") {
 
-    private val targetHex by option("--to")
-        .help("Recipient hex pubkey (full or 6-byte prefix). If omitted, pick by --name.")
-    private val targetName by option("--name")
-        .help("Recipient contact name (substring match, case-insensitive)")
-    private val text by argument().help("Message body")
+  private val targetHex by
+    option("--to").help("Recipient hex pubkey (full or 6-byte prefix). If omitted, pick by --name.")
+  private val targetName by
+    option("--name").help("Recipient contact name (substring match, case-insensitive)")
+  private val text by argument().help("Message body")
 
-    override fun run() = withClient { client ->
-        val contacts = client.getContacts()
-        val recipient: PublicKey = when {
-            targetHex != null -> PublicKey.fromHex(targetHex!!)
-            targetName != null -> {
-                val needle = targetName!!.lowercase()
-                contacts.firstOrNull { it.name.lowercase().contains(needle) }
-                    ?.publicKey
-                    ?: throw CliktError("no contact matches '$needle'")
-            }
-            else -> throw CliktError("specify --to <hex> or --name <substring>")
+  override fun run() = withClient { client ->
+    val contacts = client.getContacts()
+    val recipient: PublicKey =
+      when {
+        targetHex != null -> PublicKey.fromHex(targetHex!!)
+        targetName != null -> {
+          val needle = targetName!!.lowercase()
+          contacts.firstOrNull { it.name.lowercase().contains(needle) }?.publicKey
+            ?: throw CliktError("no contact matches '$needle'")
         }
-        val ack = client.sendText(
-            recipient = recipient,
-            text = text,
-            timestamp = Clock.System.now(),
-        )
-        terminal.println(green("Sent.") + " flood=${ack.isFlood} timeout=${ack.timeoutMs}ms")
-    }
+        else -> throw CliktError("specify --to <hex> or --name <substring>")
+      }
+    val ack = client.sendText(recipient = recipient, text = text, timestamp = Clock.System.now())
+    terminal.println(green("Sent.") + " flood=${ack.isFlood} timeout=${ack.timeoutMs}ms")
+  }
 }

--- a/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/Session.kt
+++ b/meshcore-cli/src/main/kotlin/ee/schimke/meshcore/cli/Session.kt
@@ -24,129 +24,127 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 
-abstract class SessionCommand(
-    name: String,
-    help: String,
-) : CliktCommand(name = name) {
+abstract class SessionCommand(name: String, help: String) : CliktCommand(name = name) {
 
-    private val helpText = help
-    override fun help(context: com.github.ajalt.clikt.core.Context): String = helpText
+  private val helpText = help
 
-    protected val host by option("--host", "-h")
-        .help("TCP host of the MeshCore companion")
+  override fun help(context: com.github.ajalt.clikt.core.Context): String = helpText
 
-    protected val port by option("--port", "-p").int()
-        .help("TCP port of the MeshCore companion")
+  protected val host by option("--host", "-h").help("TCP host of the MeshCore companion")
 
-    protected val ble by option("--ble")
-        .help("BLE device identifier (MAC address) or name prefix to scan for")
+  protected val port by option("--port", "-p").int().help("TCP port of the MeshCore companion")
 
-    protected val usb by option("--usb")
-        .help("USB serial port name (e.g. /dev/ttyUSB0, COM3). Use --usb list to enumerate.")
+  protected val ble by
+    option("--ble").help("BLE device identifier (MAC address) or name prefix to scan for")
 
-    protected val warmupMs by option("--warmup")
-        .int()
-        .help("How long to wait after CMD_APP_START for device responses (ms). Default: 400")
+  protected val usb by
+    option("--usb")
+      .help("USB serial port name (e.g. /dev/ttyUSB0, COM3). Use --usb list to enumerate.")
 
-    private val store = DeviceStore()
+  protected val warmupMs by
+    option("--warmup")
+      .int()
+      .help("How long to wait after CMD_APP_START for device responses (ms). Default: 400")
 
-    private fun createTransport(): Transport = when {
-        ble != null -> createBleTransport(ble!!)
-        usb != null -> createUsbTransport(usb!!)
-        host != null || port != null -> TcpTransport(host ?: "127.0.0.1", port ?: 5000)
-        else -> {
-            val saved = store.getFavorite()
-            if (saved != null) {
-                terminal.println(gray("Using saved device ${saved.first}:${saved.second}"))
-                TcpTransport(saved.first, saved.second)
-            } else {
-                TcpTransport("127.0.0.1", 5000)
-            }
+  private val store = DeviceStore()
+
+  private fun createTransport(): Transport =
+    when {
+      ble != null -> createBleTransport(ble!!)
+      usb != null -> createUsbTransport(usb!!)
+      host != null || port != null -> TcpTransport(host ?: "127.0.0.1", port ?: 5000)
+      else -> {
+        val saved = store.getFavorite()
+        if (saved != null) {
+          terminal.println(gray("Using saved device ${saved.first}:${saved.second}"))
+          TcpTransport(saved.first, saved.second)
+        } else {
+          TcpTransport("127.0.0.1", 5000)
         }
+      }
     }
 
-    private fun createBleTransport(identifier: String): Transport {
-        if (identifier.contains(":") || identifier.contains("-")) {
-            terminal.println(gray("Connecting to BLE device $identifier..."))
-            return BleTransport.fromIdentifier(identifier.toIdentifier())
-        }
-        terminal.println(gray("Scanning for BLE device matching '$identifier' (10s timeout)..."))
-        return runBlocking {
-            val scanner = BleScanner()
-            val adv = withTimeoutOrNull(10_000) {
-                scanner.advertisements.first { a ->
-                    a.name?.contains(identifier, ignoreCase = true) == true
-                }
-            } ?: error("No BLE device matching '$identifier' found within 10s.")
-            terminal.println(gray("Found ${adv.name} (${adv.identifier})"))
-            BleTransport(adv)
-        }
+  private fun createBleTransport(identifier: String): Transport {
+    if (identifier.contains(":") || identifier.contains("-")) {
+      terminal.println(gray("Connecting to BLE device $identifier..."))
+      return BleTransport.fromIdentifier(identifier.toIdentifier())
     }
+    terminal.println(gray("Scanning for BLE device matching '$identifier' (10s timeout)..."))
+    return runBlocking {
+      val scanner = BleScanner()
+      val adv =
+        withTimeoutOrNull(10_000) {
+          scanner.advertisements.first { a ->
+            a.name?.contains(identifier, ignoreCase = true) == true
+          }
+        } ?: error("No BLE device matching '$identifier' found within 10s.")
+      terminal.println(gray("Found ${adv.name} (${adv.identifier})"))
+      BleTransport(adv)
+    }
+  }
 
-    private fun createUsbTransport(portName: String): Transport {
-        if (portName == "list") {
-            val ports = JvmSerialPort.listPorts()
-            if (ports.isEmpty()) {
-                terminal.println("No USB serial ports found.")
-            } else {
-                terminal.println("Available USB serial ports:")
-                ports.forEach { p ->
-                    terminal.println("  ${p.portName} — ${p.descriptivePortName}")
-                }
-            }
-            throw ProgramResult(0)
-        }
-        val ports = JvmSerialPort.listPorts()
-        val match = ports.firstOrNull {
-            it.portName == portName || it.portName.endsWith(portName)
-        } ?: error("USB port '$portName' not found. Available: ${ports.map { it.portName }}")
-        terminal.println(gray("Using USB port ${match.portName} (${match.descriptivePortName})"))
-        return UsbSerialTransport(match)
+  private fun createUsbTransport(portName: String): Transport {
+    if (portName == "list") {
+      val ports = JvmSerialPort.listPorts()
+      if (ports.isEmpty()) {
+        terminal.println("No USB serial ports found.")
+      } else {
+        terminal.println("Available USB serial ports:")
+        ports.forEach { p -> terminal.println("  ${p.portName} — ${p.descriptivePortName}") }
+      }
+      throw ProgramResult(0)
     }
+    val ports = JvmSerialPort.listPorts()
+    val match =
+      ports.firstOrNull { it.portName == portName || it.portName.endsWith(portName) }
+        ?: error("USB port '$portName' not found. Available: ${ports.map { it.portName }}")
+    terminal.println(gray("Using USB port ${match.portName} (${match.descriptivePortName})"))
+    return UsbSerialTransport(match)
+  }
 
-    protected fun <T> withClient(block: suspend (MeshCoreClient) -> T): T = runBlocking {
-        val transport = createTransport()
-        val warmup = warmupMs
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        transport.connect()
-        val client = MeshCoreClient(transport, scope)
-        try {
-            client.start() // waits for SelfInfo response
-            if (warmup != null && warmup > 0) delay(warmup.toLong())
-            val result = block(client)
-            // Persist device to Room on success (TCP only for now)
-            if (transport is TcpTransport) {
-                persistDevice(host ?: "127.0.0.1", port ?: 5000, client)
-            }
-            result
-        } finally {
-            client.stop()
-            transport.close()
-            scope.cancel()
-        }
+  protected fun <T> withClient(block: suspend (MeshCoreClient) -> T): T = runBlocking {
+    val transport = createTransport()
+    val warmup = warmupMs
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    transport.connect()
+    val client = MeshCoreClient(transport, scope)
+    try {
+      client.start() // waits for SelfInfo response
+      if (warmup != null && warmup > 0) delay(warmup.toLong())
+      val result = block(client)
+      // Persist device to Room on success (TCP only for now)
+      if (transport is TcpTransport) {
+        persistDevice(host ?: "127.0.0.1", port ?: 5000, client)
+      }
+      result
+    } finally {
+      client.stop()
+      transport.close()
+      scope.cancel()
     }
+  }
 
-    private suspend fun persistDevice(host: String, port: Int, client: MeshCoreClient) {
-        runCatching {
-            val repo = store.repository
-            val self = client.selfInfo.value
-            val label = self?.name ?: "tcp:$host:$port"
-            val id = "tcp:$host:$port"
-            repo.upsertDevice(id, label, SavedTransport.Tcp(host, port))
-            // Persist state
-            val now = System.currentTimeMillis()
-            self?.let { repo.updateSelfInfo(id, it, now) }
-            client.battery.value?.let { repo.updateBattery(id, it, now) }
-            client.radio.value?.let { repo.updateRadio(id, it, now) }
-            client.device.value?.let { repo.updateDeviceInfo(id, it, now) }
-            if (client.contacts.value.isNotEmpty()) {
-                repo.replaceContacts(id, client.contacts.value, now)
-            }
-            if (client.channels.value.isNotEmpty()) {
-                repo.replaceChannels(id, client.channels.value, now)
-            }
-            // Set as favorite
-            repo.toggleFavorite(id)
-        }
+  private suspend fun persistDevice(host: String, port: Int, client: MeshCoreClient) {
+    runCatching {
+      val repo = store.repository
+      val self = client.selfInfo.value
+      val label = self?.name ?: "tcp:$host:$port"
+      val id = "tcp:$host:$port"
+      repo.upsertDevice(id, label, SavedTransport.Tcp(host, port))
+      // Persist state
+      val now = System.currentTimeMillis()
+      self?.let { repo.updateSelfInfo(id, it, now) }
+      client.battery.value?.let { repo.updateBattery(id, it, now) }
+      client.radio.value?.let { repo.updateRadio(id, it, now) }
+      client.device.value?.let { repo.updateDeviceInfo(id, it, now) }
+      if (client.contacts.value.isNotEmpty()) {
+        repo.replaceContacts(id, client.contacts.value, now)
+      }
+      if (client.channels.value.isNotEmpty()) {
+        repo.replaceChannels(id, client.channels.value, now)
+      }
+      // Set as favorite
+      repo.toggleFavorite(id)
     }
+  }
 }

--- a/meshcore-components/build.gradle.kts
+++ b/meshcore-components/build.gradle.kts
@@ -1,40 +1,40 @@
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKotlinMultiplatformLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
+  alias(libs.plugins.kotlinMultiplatform)
+  alias(libs.plugins.androidKotlinMultiplatformLibrary)
+  alias(libs.plugins.composeMultiplatform)
+  alias(libs.plugins.composeCompiler)
 }
 
 kotlin {
-    jvmToolchain(21)
+  jvmToolchain(21)
 
-    android {
-        namespace = "ee.schimke.meshcore.components"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
+  android {
+    namespace = "ee.schimke.meshcore.components"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
 
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.meshcoreCore)
-            implementation(libs.kotlinx.coroutines.core)
-        }
-        val androidMain by getting {
-            dependencies {
-                implementation(libs.kotlinx.coroutines.android)
-                api(projects.meshcoreTransportBle)
-                api(projects.meshcoreTransportUsb)
-                implementation(libs.mcarr.usb.android)
-                // Reusable Compose UI primitives for mobile apps.
-                api(libs.compose.runtime)
-                api(libs.compose.foundation)
-                api(libs.compose.material3)
-                api(libs.compose.material.icons.extended)
-                api(libs.compose.ui)
-                api(libs.compose.uiToolingPreview)
-                api(libs.androidx.activity.compose)
-                api(libs.androidx.core.ktx)
-            }
-        }
+  sourceSets {
+    commonMain.dependencies {
+      api(projects.meshcoreCore)
+      implementation(libs.kotlinx.coroutines.core)
     }
+    val androidMain by getting {
+      dependencies {
+        implementation(libs.kotlinx.coroutines.android)
+        api(projects.meshcoreTransportBle)
+        api(projects.meshcoreTransportUsb)
+        implementation(libs.mcarr.usb.android)
+        // Reusable Compose UI primitives for mobile apps.
+        api(libs.compose.runtime)
+        api(libs.compose.foundation)
+        api(libs.compose.material3)
+        api(libs.compose.material.icons.extended)
+        api(libs.compose.ui)
+        api(libs.compose.uiToolingPreview)
+        api(libs.androidx.activity.compose)
+        api(libs.androidx.core.ktx)
+      }
+    }
+  }
 }

--- a/meshcore-core/build.gradle.kts
+++ b/meshcore-core/build.gradle.kts
@@ -1,30 +1,30 @@
 plugins {
-    // Unified AGP-9 plugin replacing com.android.library + kotlinMultiplatform.
-    // Android target is configured via `kotlin { android { ... } }` below.
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKotlinMultiplatformLibrary)
+  // Unified AGP-9 plugin replacing com.android.library + kotlinMultiplatform.
+  // Android target is configured via `kotlin { android { ... } }` below.
+  alias(libs.plugins.kotlinMultiplatform)
+  alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
 kotlin {
-    jvmToolchain(21)
+  jvmToolchain(21)
 
-    android {
-        namespace = "ee.schimke.meshcore.core"
-        //noinspection GradleDependency
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    jvm()
+  android {
+    namespace = "ee.schimke.meshcore.core"
+    //noinspection GradleDependency
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  jvm()
 
-    sourceSets {
-        commonMain.dependencies {
-            implementation(libs.kotlinx.coroutines.core)
-            api(libs.kotlinx.io.core)
-            api(libs.kotlinx.io.bytestring)
-        }
-        commonTest.dependencies {
-            implementation(libs.kotlin.test)
-            implementation(libs.kotlinx.coroutines.test)
-        }
+  sourceSets {
+    commonMain.dependencies {
+      implementation(libs.kotlinx.coroutines.core)
+      api(libs.kotlinx.io.core)
+      api(libs.kotlinx.io.bytestring)
     }
+    commonTest.dependencies {
+      implementation(libs.kotlin.test)
+      implementation(libs.kotlinx.coroutines.test)
+    }
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/client/MeshCoreClient.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/client/MeshCoreClient.kt
@@ -5,10 +5,10 @@ import ee.schimke.meshcore.core.model.ChannelInfo
 import ee.schimke.meshcore.core.model.Contact
 import ee.schimke.meshcore.core.model.DeviceInfo
 import ee.schimke.meshcore.core.model.MeshEvent
-import ee.schimke.meshcore.core.model.ReceivedChannelMessage
-import ee.schimke.meshcore.core.model.ReceivedDirectMessage
 import ee.schimke.meshcore.core.model.PublicKey
 import ee.schimke.meshcore.core.model.RadioSettings
+import ee.schimke.meshcore.core.model.ReceivedChannelMessage
+import ee.schimke.meshcore.core.model.ReceivedDirectMessage
 import ee.schimke.meshcore.core.model.SelfInfo
 import ee.schimke.meshcore.core.model.SendAck
 import ee.schimke.meshcore.core.protocol.Frames
@@ -16,6 +16,7 @@ import ee.schimke.meshcore.core.protocol.MeshCoreConstants
 import ee.schimke.meshcore.core.protocol.Parsers
 import ee.schimke.meshcore.core.transport.Transport
 import ee.schimke.meshcore.core.transport.TransportState
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -34,377 +35,391 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.bytestring.ByteString
-import kotlin.time.Instant
 
 /**
- * High-level coroutine API over a [Transport]. Construct one per active
- * device connection; call [start] after the transport is connected.
+ * High-level coroutine API over a [Transport]. Construct one per active device connection; call
+ * [start] after the transport is connected.
  */
-class MeshCoreClient(
-    private val transport: Transport,
-    private val scope: CoroutineScope,
-) {
-    private fun log(msg: String) = println("[MeshCoreClient] $msg")
-    private val _events = MutableSharedFlow<MeshEvent>(
-        replay = 0, extraBufferCapacity = 64,
-    )
-    val events: SharedFlow<MeshEvent> = _events.asSharedFlow()
+class MeshCoreClient(private val transport: Transport, private val scope: CoroutineScope) {
+  private fun log(msg: String) = println("[MeshCoreClient] $msg")
 
-    private val _selfInfo = MutableStateFlow<SelfInfo?>(null)
-    val selfInfo: StateFlow<SelfInfo?> = _selfInfo.asStateFlow()
+  private val _events = MutableSharedFlow<MeshEvent>(replay = 0, extraBufferCapacity = 64)
+  val events: SharedFlow<MeshEvent> = _events.asSharedFlow()
 
-    private val _contacts = MutableStateFlow<List<Contact>>(emptyList())
-    val contacts: StateFlow<List<Contact>> = _contacts.asStateFlow()
+  private val _selfInfo = MutableStateFlow<SelfInfo?>(null)
+  val selfInfo: StateFlow<SelfInfo?> = _selfInfo.asStateFlow()
 
-    private val _battery = MutableStateFlow<BatteryInfo?>(null)
-    val battery: StateFlow<BatteryInfo?> = _battery.asStateFlow()
+  private val _contacts = MutableStateFlow<List<Contact>>(emptyList())
+  val contacts: StateFlow<List<Contact>> = _contacts.asStateFlow()
 
-    private val _radio = MutableStateFlow<RadioSettings?>(null)
-    val radio: StateFlow<RadioSettings?> = _radio.asStateFlow()
+  private val _battery = MutableStateFlow<BatteryInfo?>(null)
+  val battery: StateFlow<BatteryInfo?> = _battery.asStateFlow()
 
-    private val _device = MutableStateFlow<DeviceInfo?>(null)
-    val device: StateFlow<DeviceInfo?> = _device.asStateFlow()
+  private val _radio = MutableStateFlow<RadioSettings?>(null)
+  val radio: StateFlow<RadioSettings?> = _radio.asStateFlow()
 
-    private val _channels = MutableStateFlow<List<ChannelInfo>>(emptyList())
-    val channels: StateFlow<List<ChannelInfo>> = _channels.asStateFlow()
+  private val _device = MutableStateFlow<DeviceInfo?>(null)
+  val device: StateFlow<DeviceInfo?> = _device.asStateFlow()
 
-    /** Accumulated DMs keyed by the contact's full public key hex. */
-    private val _directMessages = MutableStateFlow<Map<String, List<ReceivedDirectMessage>>>(emptyMap())
-    val directMessages: StateFlow<Map<String, List<ReceivedDirectMessage>>> = _directMessages.asStateFlow()
+  private val _channels = MutableStateFlow<List<ChannelInfo>>(emptyList())
+  val channels: StateFlow<List<ChannelInfo>> = _channels.asStateFlow()
 
-    /** Accumulated channel messages keyed by channel index. */
-    private val _channelMessages = MutableStateFlow<Map<Int, List<ReceivedChannelMessage>>>(emptyMap())
-    val channelMessages: StateFlow<Map<Int, List<ReceivedChannelMessage>>> = _channelMessages.asStateFlow()
+  /** Accumulated DMs keyed by the contact's full public key hex. */
+  private val _directMessages =
+    MutableStateFlow<Map<String, List<ReceivedDirectMessage>>>(emptyMap())
+  val directMessages: StateFlow<Map<String, List<ReceivedDirectMessage>>> =
+    _directMessages.asStateFlow()
 
-    val connection: StateFlow<TransportState> get() = transport.state
+  /** Accumulated channel messages keyed by channel index. */
+  private val _channelMessages =
+    MutableStateFlow<Map<Int, List<ReceivedChannelMessage>>>(emptyMap())
+  val channelMessages: StateFlow<Map<Int, List<ReceivedChannelMessage>>> =
+    _channelMessages.asStateFlow()
 
-    /**
-     * Pre-populate StateFlows with cached data from a previous session
-     * so the UI has something to show immediately while fresh data loads.
-     * Only sets values that are still null/empty — live data from the
-     * device takes priority.
-     */
-    fun seedFromCache(
-        selfInfo: SelfInfo? = null,
-        contacts: List<Contact>? = null,
-        battery: BatteryInfo? = null,
-        radio: RadioSettings? = null,
-        deviceInfo: DeviceInfo? = null,
-        channels: List<ChannelInfo>? = null,
-    ) {
-        if (_selfInfo.value == null && selfInfo != null) _selfInfo.value = selfInfo
-        if (_contacts.value.isEmpty() && contacts != null) _contacts.value = contacts
-        if (_battery.value == null && battery != null) _battery.value = battery
-        if (_radio.value == null && radio != null) _radio.value = radio
-        if (_device.value == null && deviceInfo != null) _device.value = deviceInfo
-        if (_channels.value.isEmpty() && channels != null) _channels.value = channels
-    }
+  val connection: StateFlow<TransportState>
+    get() = transport.state
 
-    private val sendMutex = Mutex()
-    private var pumpJob: Job? = null
-    private val contactsAccumulator = mutableListOf<Contact>()
+  /**
+   * Pre-populate StateFlows with cached data from a previous session so the UI has something to
+   * show immediately while fresh data loads. Only sets values that are still null/empty — live data
+   * from the device takes priority.
+   */
+  fun seedFromCache(
+    selfInfo: SelfInfo? = null,
+    contacts: List<Contact>? = null,
+    battery: BatteryInfo? = null,
+    radio: RadioSettings? = null,
+    deviceInfo: DeviceInfo? = null,
+    channels: List<ChannelInfo>? = null,
+  ) {
+    if (_selfInfo.value == null && selfInfo != null) _selfInfo.value = selfInfo
+    if (_contacts.value.isEmpty() && contacts != null) _contacts.value = contacts
+    if (_battery.value == null && battery != null) _battery.value = battery
+    if (_radio.value == null && radio != null) _radio.value = radio
+    if (_device.value == null && deviceInfo != null) _device.value = deviceInfo
+    if (_channels.value.isEmpty() && channels != null) _channels.value = channels
+  }
 
-    /** Timestamp of the last successful contacts fetch, for delta queries. */
-    @Volatile var lastContactsFetchedAt: Instant? = null
-        private set
+  private val sendMutex = Mutex()
+  private var pumpJob: Job? = null
+  private val contactsAccumulator = mutableListOf<Contact>()
 
-    /**
-     * Start the protocol session. Sends AppStart + device queries and
-     * waits for the SelfInfo response (up to [timeoutMs]) so the caller
-     * knows the handshake completed. Battery, radio, and device-info
-     * responses may still arrive after this returns — they populate
-     * their StateFlows asynchronously.
-     */
-    suspend fun start(
-        appName: String = "meshcore-kmp",
-        appVersion: Int = MeshCoreConstants.APP_PROTOCOL_VERSION,
-        timeoutMs: Long = 5_000,
-    ) {
-        if (pumpJob == null) {
-            pumpJob = scope.launch(start = CoroutineStart.UNDISPATCHED) {
-                transport.incoming.collect { frame ->
-                    handleEvent(Parsers.parse(frame))
-                }
-            }
-        }
-        log("start: sending AppStart + queries")
-        // Subscribe for SelfInfo before sending, then send all queries
-        coroutineScope {
-            val selfInfoDeferred = async(start = CoroutineStart.UNDISPATCHED) {
-                withTimeout(timeoutMs) {
-                    events.filter { it is MeshEvent.SelfInfoEvent }.first()
-                }
-            }
-            transport.send(Frames.appStart(appName, appVersion))
-            log("start: AppStart sent")
-            runCatching { transport.send(Frames.deviceQuery()) }
-            runCatching { transport.send(Frames.getBatteryAndStorage()) }
-            runCatching { transport.send(Frames.getRadioSettings()) }
-            log("start: all queries sent, waiting for SelfInfo (${timeoutMs}ms timeout)")
-            try {
-                selfInfoDeferred.await()
-                log("start: SelfInfo received — name='${_selfInfo.value?.name}'")
-            } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
-                log("start: SelfInfo timeout — device may not be running MeshCore")
-                throw IllegalStateException(
-                    "No response from device. It may not be running MeshCore firmware, " +
-                        "or the connection is not working.",
-                    e,
-                )
-            }
+  /** Timestamp of the last successful contacts fetch, for delta queries. */
+  @Volatile
+  var lastContactsFetchedAt: Instant? = null
+    private set
+
+  /**
+   * Start the protocol session. Sends AppStart + device queries and waits for the SelfInfo response
+   * (up to [timeoutMs]) so the caller knows the handshake completed. Battery, radio, and
+   * device-info responses may still arrive after this returns — they populate their StateFlows
+   * asynchronously.
+   */
+  suspend fun start(
+    appName: String = "meshcore-kmp",
+    appVersion: Int = MeshCoreConstants.APP_PROTOCOL_VERSION,
+    timeoutMs: Long = 5_000,
+  ) {
+    if (pumpJob == null) {
+      pumpJob =
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+          transport.incoming.collect { frame -> handleEvent(Parsers.parse(frame)) }
         }
     }
-
-    /**
-     * Authenticate to [recipient] (a repeater or room contact) using
-     * [password]. Awaits a `LoginSuccess` / `LoginFail` push from the
-     * device; throws on failure or after [timeoutMs]. This is a
-     * runtime operation on an established connection — it has nothing
-     * to do with the device handshake.
-     *
-     * Wire format verified against the MeshCore Flutter client's
-     * `buildSendLoginFrame` in `connector/meshcore_protocol.dart`.
-     */
-    suspend fun login(
-        recipient: PublicKey,
-        password: String,
-        timeoutMs: Long = 15_000,
-    ) {
-        val recipientPrefixHex = recipient.toHex().take(MeshCoreConstants.PUB_KEY_PREFIX_SIZE * 2)
-        val ev = requestOne(Frames.sendLogin(recipient, password), timeoutMs) { event ->
-            val evKey = when (event) {
-                is MeshEvent.LoginSuccess -> event.publicKey
-                is MeshEvent.LoginFail -> event.publicKey
-                else -> return@requestOne false
-            }
-            evKey.toHex().startsWith(recipientPrefixHex)
+    log("start: sending AppStart + queries")
+    // Subscribe for SelfInfo before sending, then send all queries
+    coroutineScope {
+      val selfInfoDeferred =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          withTimeout(timeoutMs) { events.filter { it is MeshEvent.SelfInfoEvent }.first() }
         }
-        if (ev is MeshEvent.LoginFail) error("device rejected login for ${recipient.toHex().take(12)}")
+      transport.send(Frames.appStart(appName, appVersion))
+      log("start: AppStart sent")
+      runCatching { transport.send(Frames.deviceQuery()) }
+      runCatching { transport.send(Frames.getBatteryAndStorage()) }
+      runCatching { transport.send(Frames.getRadioSettings()) }
+      log("start: all queries sent, waiting for SelfInfo (${timeoutMs}ms timeout)")
+      try {
+        selfInfoDeferred.await()
+        log("start: SelfInfo received — name='${_selfInfo.value?.name}'")
+      } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+        log("start: SelfInfo timeout — device may not be running MeshCore")
+        throw IllegalStateException(
+          "No response from device. It may not be running MeshCore firmware, " +
+            "or the connection is not working.",
+          e,
+        )
+      }
+    }
+  }
+
+  /**
+   * Authenticate to [recipient] (a repeater or room contact) using [password]. Awaits a
+   * `LoginSuccess` / `LoginFail` push from the device; throws on failure or after [timeoutMs]. This
+   * is a runtime operation on an established connection — it has nothing to do with the device
+   * handshake.
+   *
+   * Wire format verified against the MeshCore Flutter client's `buildSendLoginFrame` in
+   * `connector/meshcore_protocol.dart`.
+   */
+  suspend fun login(recipient: PublicKey, password: String, timeoutMs: Long = 15_000) {
+    val recipientPrefixHex = recipient.toHex().take(MeshCoreConstants.PUB_KEY_PREFIX_SIZE * 2)
+    val ev =
+      requestOne(Frames.sendLogin(recipient, password), timeoutMs) { event ->
+        val evKey =
+          when (event) {
+            is MeshEvent.LoginSuccess -> event.publicKey
+            is MeshEvent.LoginFail -> event.publicKey
+            else -> return@requestOne false
+          }
+        evKey.toHex().startsWith(recipientPrefixHex)
+      }
+    if (ev is MeshEvent.LoginFail) error("device rejected login for ${recipient.toHex().take(12)}")
+  }
+
+  fun stop() {
+    pumpJob?.cancel()
+    pumpJob = null
+  }
+
+  private suspend fun handleEvent(event: MeshEvent) {
+    when (event) {
+      is MeshEvent.SelfInfoEvent -> {
+        log("event: SelfInfo name='${event.info.name}'")
+        _selfInfo.value = event.info
+        _radio.value = event.info.radio
+      }
+      is MeshEvent.Radio -> {
+        log("event: Radio ${event.settings.frequencyHz}Hz")
+        _radio.value = event.settings
+      }
+      is MeshEvent.Battery -> {
+        log(
+          "event: Battery ${event.info.millivolts}mV storage=${event.info.storageUsedKb}/${event.info.storageTotalKb}kB"
+        )
+        _battery.value = event.info
+      }
+      is MeshEvent.Device -> {
+        log(
+          "event: DeviceInfo proto=${event.info.protocolVersion} contacts=${event.info.maxContacts} channels=${event.info.maxChannels}"
+        )
+        _device.value = event.info
+      }
+      MeshEvent.ContactsStart -> contactsAccumulator.clear()
+      is MeshEvent.ContactEvent -> contactsAccumulator += event.contact
+      MeshEvent.EndOfContacts -> {
+        log("event: EndOfContacts count=${contactsAccumulator.size}")
+        _contacts.value = contactsAccumulator.toList()
+        contactsAccumulator.clear()
+      }
+      is MeshEvent.ChannelInfoEvent -> {
+        // Don't accumulate individual channel responses here —
+        // getChannels() sets _channels atomically after filtering
+        // empty entries. Accumulating here causes transient ghost
+        // channels (e.g. "Channel 4", "Channel 5") in the UI.
+      }
+      is MeshEvent.DirectMessage -> {
+        val msg = event.message
+        val prefix = msg.senderPrefix.toHex()
+        val contactKey =
+          _contacts.value
+            .firstOrNull { it.publicKey.toHex().startsWith(prefix) }
+            ?.publicKey
+            ?.toHex() ?: prefix
+        log("event: DirectMessage from=${prefix.take(12)} text='${msg.text.take(30)}'")
+        val current = _directMessages.value
+        _directMessages.value = current + (contactKey to (current[contactKey].orEmpty() + msg))
+      }
+      is MeshEvent.ChannelMessage -> {
+        val msg = event.message
+        log("event: ChannelMessage ch=${msg.channelIndex} body='${msg.body.take(30)}'")
+        val idx = msg.channelIndex
+        val current = _channelMessages.value
+        _channelMessages.value = current + (idx to (current[idx].orEmpty() + msg))
+      }
+      MeshEvent.MessagesWaiting -> log("event: MessagesWaiting")
+      MeshEvent.NoMoreMessages -> log("event: NoMoreMessages")
+      is MeshEvent.Raw ->
+        log("event: Raw code=0x${event.code.toString(16)} size=${event.body.size}")
+      else -> Unit
+    }
+    _events.emit(event)
+  }
+
+  /**
+   * Fetch contacts from the device. If [delta] is true and a previous fetch timestamp exists, only
+   * requests contacts modified since then.
+   */
+  suspend fun getContacts(delta: Boolean = false, timeoutMs: Long = 5_000): List<Contact> =
+    sendMutex.withLock {
+      val since = if (delta) lastContactsFetchedAt else null
+      log("getContacts: requesting (delta=$delta, since=$since)")
+      coroutineScope {
+        val deferred =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(timeoutMs) { events.filter { it is MeshEvent.EndOfContacts }.first() }
+          }
+        transport.send(Frames.getContacts(since))
+        deferred.await()
+      }
+      lastContactsFetchedAt = kotlin.time.Clock.System.now()
+      log("getContacts: done, ${_contacts.value.size} contacts")
+      _contacts.value
     }
 
-    fun stop() {
-        pumpJob?.cancel()
-        pumpJob = null
+  /**
+   * Enumerate all configured channels by requesting each index from 0 until
+   * [DeviceInfo.maxChannels]. Empty channels are filtered out.
+   */
+  suspend fun getChannels(perChannelTimeoutMs: Long = 1_000): List<ChannelInfo> {
+    val maxCh = _device.value?.maxChannels ?: 8
+    log("getChannels: requesting 0..$maxCh")
+    val result = mutableListOf<ChannelInfo>()
+    for (i in 0 until maxCh) {
+      val ev =
+        runCatching {
+            requestOne(Frames.getChannel(i), perChannelTimeoutMs) {
+              it is MeshEvent.ChannelInfoEvent
+            }
+          }
+          .getOrNull() as? MeshEvent.ChannelInfoEvent ?: continue
+      val ch = ev.info
+      val isEmpty = ch.name.isBlank() && ch.psk.toByteArray().all { it == 0.toByte() }
+      if (!isEmpty) result += ch
     }
+    _channels.value = result
+    log("getChannels: done, ${result.size} non-empty channels")
+    return result
+  }
 
-    private suspend fun handleEvent(event: MeshEvent) {
-        when (event) {
-            is MeshEvent.SelfInfoEvent -> {
-                log("event: SelfInfo name='${event.info.name}'")
-                _selfInfo.value = event.info
-                _radio.value = event.info.radio
+  /**
+   * Create or update a channel on the device. After a successful call the local channel list is
+   * refreshed.
+   */
+  suspend fun setChannel(
+    index: Int,
+    name: String,
+    psk: kotlinx.io.bytestring.ByteString,
+    timeoutMs: Long = 2_000,
+  ) {
+    val frame = Frames.setChannel(index, name, psk)
+    val ev = requestOne(frame, timeoutMs) { it is MeshEvent.Ok || it is MeshEvent.Err }
+    if (ev is MeshEvent.Err) error("setChannel failed: error code ${ev.code}")
+    log("setChannel($index, '$name') ok")
+    getChannels() // refresh local cache
+  }
+
+  /**
+   * Drain the device's pending message queue by repeatedly sending `SyncNextMessage` until the
+   * device replies with `NoMoreMessages`. Each iteration yields a `DirectMessage` or
+   * `ChannelMessage` event through the [events] SharedFlow as usual.
+   */
+  suspend fun syncMessages(perMessageTimeoutMs: Long = 5_000) {
+    log("syncMessages: draining pending queue")
+    var count = 0
+    while (true) {
+      val ev =
+        runCatching {
+            requestOne(Frames.syncNextMessage(), perMessageTimeoutMs) {
+              it is MeshEvent.DirectMessage ||
+                it is MeshEvent.ChannelMessage ||
+                it is MeshEvent.NoMoreMessages
             }
-            is MeshEvent.Radio -> {
-                log("event: Radio ${event.settings.frequencyHz}Hz")
-                _radio.value = event.settings
-            }
-            is MeshEvent.Battery -> {
-                log("event: Battery ${event.info.millivolts}mV storage=${event.info.storageUsedKb}/${event.info.storageTotalKb}kB")
-                _battery.value = event.info
-            }
-            is MeshEvent.Device -> {
-                log("event: DeviceInfo proto=${event.info.protocolVersion} contacts=${event.info.maxContacts} channels=${event.info.maxChannels}")
-                _device.value = event.info
-            }
-            MeshEvent.ContactsStart -> contactsAccumulator.clear()
-            is MeshEvent.ContactEvent -> contactsAccumulator += event.contact
-            MeshEvent.EndOfContacts -> {
-                log("event: EndOfContacts count=${contactsAccumulator.size}")
-                _contacts.value = contactsAccumulator.toList()
-                contactsAccumulator.clear()
-            }
-            is MeshEvent.ChannelInfoEvent -> {
-                // Don't accumulate individual channel responses here —
-                // getChannels() sets _channels atomically after filtering
-                // empty entries. Accumulating here causes transient ghost
-                // channels (e.g. "Channel 4", "Channel 5") in the UI.
-            }
-            is MeshEvent.DirectMessage -> {
-                val msg = event.message
-                val prefix = msg.senderPrefix.toHex()
-                val contactKey = _contacts.value
-                    .firstOrNull { it.publicKey.toHex().startsWith(prefix) }
-                    ?.publicKey?.toHex() ?: prefix
-                log("event: DirectMessage from=${prefix.take(12)} text='${msg.text.take(30)}'")
-                val current = _directMessages.value
-                _directMessages.value = current + (contactKey to (current[contactKey].orEmpty() + msg))
-            }
-            is MeshEvent.ChannelMessage -> {
-                val msg = event.message
-                log("event: ChannelMessage ch=${msg.channelIndex} body='${msg.body.take(30)}'")
-                val idx = msg.channelIndex
-                val current = _channelMessages.value
-                _channelMessages.value = current + (idx to (current[idx].orEmpty() + msg))
-            }
-            MeshEvent.MessagesWaiting -> log("event: MessagesWaiting")
-            MeshEvent.NoMoreMessages -> log("event: NoMoreMessages")
-            is MeshEvent.Raw -> log("event: Raw code=0x${event.code.toString(16)} size=${event.body.size}")
-            else -> Unit
+          }
+          .getOrNull() ?: break
+      if (ev is MeshEvent.NoMoreMessages) break
+      count++
+    }
+    log("syncMessages: done, $count messages received")
+  }
+
+  suspend fun getBatteryAndStorage(timeoutMs: Long = 3_000): BatteryInfo =
+    (requestOne(Frames.getBatteryAndStorage(), timeoutMs) { it is MeshEvent.Battery }
+        as MeshEvent.Battery)
+      .info
+
+  suspend fun getRadioSettings(timeoutMs: Long = 3_000): RadioSettings =
+    (requestOne(Frames.getRadioSettings(), timeoutMs) { it is MeshEvent.Radio } as MeshEvent.Radio)
+      .settings
+
+  suspend fun getDeviceTime(timeoutMs: Long = 3_000): Instant =
+    (requestOne(Frames.getDeviceTime(), timeoutMs) { it is MeshEvent.CurrentTime }
+        as MeshEvent.CurrentTime)
+      .time
+
+  suspend fun setDeviceTime(time: Instant) = sendMutex.withLock {
+    transport.send(Frames.setDeviceTime(time))
+  }
+
+  suspend fun setAdvertName(name: String) = sendMutex.withLock {
+    transport.send(Frames.setAdvertName(name))
+  }
+
+  suspend fun setAdvertLatLon(lat: Double, lon: Double) = sendMutex.withLock {
+    transport.send(Frames.setAdvertLatLon(lat, lon))
+  }
+
+  suspend fun setRadioParams(freqHz: Int, bwHz: Int, sf: Int, cr: Int) = sendMutex.withLock {
+    transport.send(Frames.setRadioParams(freqHz, bwHz, sf, cr))
+  }
+
+  suspend fun setRadioTxPower(dbm: Int) = sendMutex.withLock {
+    transport.send(Frames.setRadioTxPower(dbm))
+  }
+
+  suspend fun sendSelfAdvert(floodMode: Boolean = false) = sendMutex.withLock {
+    transport.send(Frames.sendSelfAdvert(floodMode))
+  }
+
+  suspend fun reboot() = sendMutex.withLock { transport.send(Frames.reboot()) }
+
+  suspend fun syncNextMessage() = sendMutex.withLock { transport.send(Frames.syncNextMessage()) }
+
+  suspend fun sendText(
+    recipient: PublicKey,
+    text: String,
+    timestamp: Instant,
+    attempt: Int = 0,
+    timeoutMs: Long = 5_000,
+  ): SendAck {
+    val frame = Frames.sendTextMessage(recipient, text, timestamp, attempt)
+    val ev = requestOne(frame, timeoutMs) { it is MeshEvent.Sent || it is MeshEvent.Err }
+    if (ev is MeshEvent.Err) error("device returned error code ${ev.code}")
+    return (ev as MeshEvent.Sent).ack
+  }
+
+  suspend fun sendChannelText(
+    channelIdx: Int,
+    text: String,
+    timestamp: Instant,
+    timeoutMs: Long = 5_000,
+  ): SendAck {
+    val frame = Frames.sendChannelTextMessage(channelIdx, text, timestamp)
+    val ev = requestOne(frame, timeoutMs) { it is MeshEvent.Sent || it is MeshEvent.Err }
+    if (ev is MeshEvent.Err) error("device returned error code ${ev.code}")
+    return (ev as MeshEvent.Sent).ack
+  }
+
+  /**
+   * Send a frame and await the first matching reply.
+   *
+   * The collector is attached **before** `transport.send` so a very fast reply (BLE round-trips can
+   * be <10 ms) can't slip past an unattached `SharedFlow` — prior versions of this method had a
+   * race where the pump emitted the reply and dropped it because `events` is replay=0 and the
+   * collector wasn't subscribed yet.
+   */
+  private suspend fun requestOne(
+    frame: ByteString,
+    timeoutMs: Long,
+    predicate: (MeshEvent) -> Boolean,
+  ): MeshEvent = sendMutex.withLock {
+    coroutineScope {
+      val deferred =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          withTimeout(timeoutMs) { events.filter(predicate).first() }
         }
-        _events.emit(event)
+      transport.send(frame)
+      deferred.await()
     }
-
-    /**
-     * Fetch contacts from the device. If [delta] is true and a previous
-     * fetch timestamp exists, only requests contacts modified since then.
-     */
-    suspend fun getContacts(
-        delta: Boolean = false,
-        timeoutMs: Long = 5_000,
-    ): List<Contact> = sendMutex.withLock {
-        val since = if (delta) lastContactsFetchedAt else null
-        log("getContacts: requesting (delta=$delta, since=$since)")
-        coroutineScope {
-            val deferred = async(start = CoroutineStart.UNDISPATCHED) {
-                withTimeout(timeoutMs) { events.filter { it is MeshEvent.EndOfContacts }.first() }
-            }
-            transport.send(Frames.getContacts(since))
-            deferred.await()
-        }
-        lastContactsFetchedAt = kotlin.time.Clock.System.now()
-        log("getContacts: done, ${_contacts.value.size} contacts")
-        _contacts.value
-    }
-
-    /**
-     * Enumerate all configured channels by requesting each index
-     * from 0 until [DeviceInfo.maxChannels]. Empty channels are filtered out.
-     */
-    suspend fun getChannels(perChannelTimeoutMs: Long = 1_000): List<ChannelInfo> {
-        val maxCh = _device.value?.maxChannels ?: 8
-        log("getChannels: requesting 0..$maxCh")
-        val result = mutableListOf<ChannelInfo>()
-        for (i in 0 until maxCh) {
-            val ev = runCatching {
-                requestOne(Frames.getChannel(i), perChannelTimeoutMs) {
-                    it is MeshEvent.ChannelInfoEvent
-                }
-            }.getOrNull() as? MeshEvent.ChannelInfoEvent ?: continue
-            val ch = ev.info
-            val isEmpty = ch.name.isBlank() && ch.psk.toByteArray().all { it == 0.toByte() }
-            if (!isEmpty) result += ch
-        }
-        _channels.value = result
-        log("getChannels: done, ${result.size} non-empty channels")
-        return result
-    }
-
-    /**
-     * Create or update a channel on the device. After a successful call
-     * the local channel list is refreshed.
-     */
-    suspend fun setChannel(
-        index: Int,
-        name: String,
-        psk: kotlinx.io.bytestring.ByteString,
-        timeoutMs: Long = 2_000,
-    ) {
-        val frame = Frames.setChannel(index, name, psk)
-        val ev = requestOne(frame, timeoutMs) { it is MeshEvent.Ok || it is MeshEvent.Err }
-        if (ev is MeshEvent.Err) error("setChannel failed: error code ${ev.code}")
-        log("setChannel($index, '$name') ok")
-        getChannels()  // refresh local cache
-    }
-
-    /**
-     * Drain the device's pending message queue by repeatedly sending
-     * `SyncNextMessage` until the device replies with `NoMoreMessages`.
-     * Each iteration yields a `DirectMessage` or `ChannelMessage` event
-     * through the [events] SharedFlow as usual.
-     */
-    suspend fun syncMessages(perMessageTimeoutMs: Long = 5_000) {
-        log("syncMessages: draining pending queue")
-        var count = 0
-        while (true) {
-            val ev = runCatching {
-                requestOne(Frames.syncNextMessage(), perMessageTimeoutMs) {
-                    it is MeshEvent.DirectMessage ||
-                        it is MeshEvent.ChannelMessage ||
-                        it is MeshEvent.NoMoreMessages
-                }
-            }.getOrNull() ?: break
-            if (ev is MeshEvent.NoMoreMessages) break
-            count++
-        }
-        log("syncMessages: done, $count messages received")
-    }
-
-    suspend fun getBatteryAndStorage(timeoutMs: Long = 3_000): BatteryInfo =
-        (requestOne(Frames.getBatteryAndStorage(), timeoutMs) { it is MeshEvent.Battery } as MeshEvent.Battery).info
-
-    suspend fun getRadioSettings(timeoutMs: Long = 3_000): RadioSettings =
-        (requestOne(Frames.getRadioSettings(), timeoutMs) { it is MeshEvent.Radio } as MeshEvent.Radio).settings
-
-    suspend fun getDeviceTime(timeoutMs: Long = 3_000): Instant =
-        (requestOne(Frames.getDeviceTime(), timeoutMs) { it is MeshEvent.CurrentTime } as MeshEvent.CurrentTime).time
-
-    suspend fun setDeviceTime(time: Instant) =
-        sendMutex.withLock { transport.send(Frames.setDeviceTime(time)) }
-
-    suspend fun setAdvertName(name: String) =
-        sendMutex.withLock { transport.send(Frames.setAdvertName(name)) }
-
-    suspend fun setAdvertLatLon(lat: Double, lon: Double) =
-        sendMutex.withLock { transport.send(Frames.setAdvertLatLon(lat, lon)) }
-
-    suspend fun setRadioParams(freqHz: Int, bwHz: Int, sf: Int, cr: Int) =
-        sendMutex.withLock { transport.send(Frames.setRadioParams(freqHz, bwHz, sf, cr)) }
-
-    suspend fun setRadioTxPower(dbm: Int) =
-        sendMutex.withLock { transport.send(Frames.setRadioTxPower(dbm)) }
-
-    suspend fun sendSelfAdvert(floodMode: Boolean = false) =
-        sendMutex.withLock { transport.send(Frames.sendSelfAdvert(floodMode)) }
-
-    suspend fun reboot() = sendMutex.withLock { transport.send(Frames.reboot()) }
-
-    suspend fun syncNextMessage() = sendMutex.withLock { transport.send(Frames.syncNextMessage()) }
-
-    suspend fun sendText(
-        recipient: PublicKey,
-        text: String,
-        timestamp: Instant,
-        attempt: Int = 0,
-        timeoutMs: Long = 5_000,
-    ): SendAck {
-        val frame = Frames.sendTextMessage(recipient, text, timestamp, attempt)
-        val ev = requestOne(frame, timeoutMs) { it is MeshEvent.Sent || it is MeshEvent.Err }
-        if (ev is MeshEvent.Err) error("device returned error code ${ev.code}")
-        return (ev as MeshEvent.Sent).ack
-    }
-
-    suspend fun sendChannelText(
-        channelIdx: Int,
-        text: String,
-        timestamp: Instant,
-        timeoutMs: Long = 5_000,
-    ): SendAck {
-        val frame = Frames.sendChannelTextMessage(channelIdx, text, timestamp)
-        val ev = requestOne(frame, timeoutMs) { it is MeshEvent.Sent || it is MeshEvent.Err }
-        if (ev is MeshEvent.Err) error("device returned error code ${ev.code}")
-        return (ev as MeshEvent.Sent).ack
-    }
-
-    /**
-     * Send a frame and await the first matching reply.
-     *
-     * The collector is attached **before** `transport.send` so a very
-     * fast reply (BLE round-trips can be <10 ms) can't slip past an
-     * unattached `SharedFlow` — prior versions of this method had a
-     * race where the pump emitted the reply and dropped it because
-     * `events` is replay=0 and the collector wasn't subscribed yet.
-     */
-    private suspend fun requestOne(
-        frame: ByteString,
-        timeoutMs: Long,
-        predicate: (MeshEvent) -> Boolean,
-    ): MeshEvent = sendMutex.withLock {
-        coroutineScope {
-            val deferred = async(start = CoroutineStart.UNDISPATCHED) {
-                withTimeout(timeoutMs) { events.filter(predicate).first() }
-            }
-            transport.send(frame)
-            deferred.await()
-        }
-    }
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/manager/MeshCoreManager.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/manager/MeshCoreManager.kt
@@ -3,6 +3,7 @@ package ee.schimke.meshcore.core.manager
 import ee.schimke.meshcore.core.client.MeshCoreClient
 import ee.schimke.meshcore.core.transport.Transport
 import ee.schimke.meshcore.core.transport.TransportState
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,131 +15,135 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.coroutineContext
 
 /**
- * Thin, transport-agnostic orchestrator: given any [Transport] instance
- * (BLE, USB serial, TCP – or a test double), opens it, spins up a
- * [MeshCoreClient], exposes connection state as a [StateFlow], and tears
- * everything down on disconnect.
+ * Thin, transport-agnostic orchestrator: given any [Transport] instance (BLE, USB serial, TCP – or
+ * a test double), opens it, spins up a [MeshCoreClient], exposes connection state as a [StateFlow],
+ * and tears everything down on disconnect.
  *
- * Lives in commonMain because it knows nothing about Android or the JVM.
- * Platform-specific concerns (runtime permissions, discovering USB ports,
- * etc.) belong in platform modules such as `meshcore-mobile`.
+ * Lives in commonMain because it knows nothing about Android or the JVM. Platform-specific concerns
+ * (runtime permissions, discovering USB ports, etc.) belong in platform modules such as
+ * `meshcore-mobile`.
  */
 class MeshCoreManager(
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+  private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) {
-    private val _state = MutableStateFlow<ManagerState>(ManagerState.Idle)
-    val state: StateFlow<ManagerState> = _state.asStateFlow()
+  private val _state = MutableStateFlow<ManagerState>(ManagerState.Idle)
+  val state: StateFlow<ManagerState> = _state.asStateFlow()
 
-    @Volatile private var currentTransport: Transport? = null
-    @Volatile private var currentClient: MeshCoreClient? = null
-    private var transportStateJob: Job? = null
+  @Volatile private var currentTransport: Transport? = null
+  @Volatile private var currentClient: MeshCoreClient? = null
+  private var transportStateJob: Job? = null
 
-    /**
-     * Serialises [connect]/[disconnect] calls so callers that fire a new
-     * connect while a previous one is still in-flight can't drive the
-     * state machine into a weird intermediate state. The incoming call
-     * tears down the previous attempt and takes over.
-     */
-    private val lifecycleMutex = Mutex()
+  /**
+   * Serialises [connect]/[disconnect] calls so callers that fire a new connect while a previous one
+   * is still in-flight can't drive the state machine into a weird intermediate state. The incoming
+   * call tears down the previous attempt and takes over.
+   */
+  private val lifecycleMutex = Mutex()
 
-    /** Job representing the currently in-flight [connect] invocation, if any. */
-    @Volatile private var inflightConnectJob: Job? = null
+  /** Job representing the currently in-flight [connect] invocation, if any. */
+  @Volatile private var inflightConnectJob: Job? = null
 
-    val client: MeshCoreClient? get() = currentClient
+  val client: MeshCoreClient?
+    get() = currentClient
 
-    /**
-     * Connect using [transport]. Any existing session (including an
-     * in-flight connect attempt) is cancelled first. On success [state]
-     * transitions to [ManagerState.Connected].
-     */
-    suspend fun connect(transport: Transport) {
-        // Cancel any in-flight connect first so the new call doesn't queue
-        // up behind a 20-second BLE timeout.
-        inflightConnectJob?.cancel(CancellationException("superseded by new connect()"))
-        val callerJob = coroutineContext[Job]
-        inflightConnectJob = callerJob
-        try {
-            lifecycleMutex.withLock {
-                disconnectLocked()
-                _state.value = ManagerState.Connecting
-                currentTransport = transport
-                transportStateJob = scope.launch {
-                    transport.state.collect { ts ->
-                        when (ts) {
-                            is TransportState.Error ->
-                                _state.value = ManagerState.Failed(ts.cause)
-                            TransportState.Disconnected -> {
-                                if (_state.value is ManagerState.Connected) {
-                                    _state.value = ManagerState.Idle
-                                }
-                            }
-                            else -> Unit
-                        }
-                    }
+  /**
+   * Connect using [transport]. Any existing session (including an in-flight connect attempt) is
+   * cancelled first. On success [state] transitions to [ManagerState.Connected].
+   */
+  suspend fun connect(transport: Transport) {
+    // Cancel any in-flight connect first so the new call doesn't queue
+    // up behind a 20-second BLE timeout.
+    inflightConnectJob?.cancel(CancellationException("superseded by new connect()"))
+    val callerJob = coroutineContext[Job]
+    inflightConnectJob = callerJob
+    try {
+      lifecycleMutex.withLock {
+        disconnectLocked()
+        _state.value = ManagerState.Connecting
+        currentTransport = transport
+        transportStateJob = scope.launch {
+          transport.state.collect { ts ->
+            when (ts) {
+              is TransportState.Error -> _state.value = ManagerState.Failed(ts.cause)
+              TransportState.Disconnected -> {
+                if (_state.value is ManagerState.Connected) {
+                  _state.value = ManagerState.Idle
                 }
-                try {
-                    transport.connect()
-                } catch (t: Throwable) {
-                    _state.value = ManagerState.Failed(t)
-                    throw t
-                }
-                val client = MeshCoreClient(transport, scope)
-                try {
-                    client.start()
-                } catch (t: Throwable) {
-                    try { client.stop() } catch (_: Throwable) {}
-                    _state.value = ManagerState.Failed(t)
-                    throw t
-                }
-                currentClient = client
-                _state.value = ManagerState.Connected(client)
+              }
+              else -> Unit
             }
-        } finally {
-            if (inflightConnectJob === callerJob) inflightConnectJob = null
+          }
         }
+        try {
+          transport.connect()
+        } catch (t: Throwable) {
+          _state.value = ManagerState.Failed(t)
+          throw t
+        }
+        val client = MeshCoreClient(transport, scope)
+        try {
+          client.start()
+        } catch (t: Throwable) {
+          try {
+            client.stop()
+          } catch (_: Throwable) {}
+          _state.value = ManagerState.Failed(t)
+          throw t
+        }
+        currentClient = client
+        _state.value = ManagerState.Connected(client)
+      }
+    } finally {
+      if (inflightConnectJob === callerJob) inflightConnectJob = null
     }
+  }
 
-    suspend fun disconnect() {
-        inflightConnectJob?.cancel(CancellationException("disconnect requested"))
-        // Force-close the transport outside the mutex. Some BLE stacks
-        // (notably Kable on older Android) don't cooperatively cancel
-        // a connect() that's mid-GATT-handshake — closing the
-        // underlying transport unsticks them. `close()` is expected to
-        // be idempotent so `disconnectLocked` below will no-op the
-        // second call.
-        try { currentTransport?.close() } catch (_: Throwable) {}
-        lifecycleMutex.withLock { disconnectLocked() }
-    }
+  suspend fun disconnect() {
+    inflightConnectJob?.cancel(CancellationException("disconnect requested"))
+    // Force-close the transport outside the mutex. Some BLE stacks
+    // (notably Kable on older Android) don't cooperatively cancel
+    // a connect() that's mid-GATT-handshake — closing the
+    // underlying transport unsticks them. `close()` is expected to
+    // be idempotent so `disconnectLocked` below will no-op the
+    // second call.
+    try {
+      currentTransport?.close()
+    } catch (_: Throwable) {}
+    lifecycleMutex.withLock { disconnectLocked() }
+  }
 
-    /**
-     * Fire-and-forget wrapper around [disconnect] that launches on the
-     * manager's own scope. Use this from UI click handlers so the
-     * teardown survives the composition being unmounted during
-     * navigation — otherwise the click scope is cancelled mid-disconnect
-     * and the transport is left stuck.
-     */
-    fun requestDisconnect() {
-        scope.launch { runCatching { disconnect() } }
-    }
+  /**
+   * Fire-and-forget wrapper around [disconnect] that launches on the manager's own scope. Use this
+   * from UI click handlers so the teardown survives the composition being unmounted during
+   * navigation — otherwise the click scope is cancelled mid-disconnect and the transport is left
+   * stuck.
+   */
+  fun requestDisconnect() {
+    scope.launch { runCatching { disconnect() } }
+  }
 
-    private suspend fun disconnectLocked() {
-        transportStateJob?.cancel()
-        transportStateJob = null
-        currentClient?.stop()
-        currentClient = null
-        val t = currentTransport
-        currentTransport = null
-        try { t?.close() } catch (_: Throwable) {}
-        if (_state.value !is ManagerState.Failed) _state.value = ManagerState.Idle
-    }
+  private suspend fun disconnectLocked() {
+    transportStateJob?.cancel()
+    transportStateJob = null
+    currentClient?.stop()
+    currentClient = null
+    val t = currentTransport
+    currentTransport = null
+    try {
+      t?.close()
+    } catch (_: Throwable) {}
+    if (_state.value !is ManagerState.Failed) _state.value = ManagerState.Idle
+  }
 }
 
 sealed class ManagerState {
-    object Idle : ManagerState()
-    object Connecting : ManagerState()
-    data class Connected(val client: MeshCoreClient) : ManagerState()
-    data class Failed(val cause: Throwable) : ManagerState()
+  object Idle : ManagerState()
+
+  object Connecting : ManagerState()
+
+  data class Connected(val client: MeshCoreClient) : ManagerState()
+
+  data class Failed(val cause: Throwable) : ManagerState()
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/model/MeshEvent.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/model/MeshEvent.kt
@@ -1,37 +1,56 @@
 package ee.schimke.meshcore.core.model
 
 /**
- * Anything that can arrive from the device after it has been parsed.
- * Unparsed frames are carried through as [Raw] so that callers can
- * inspect/extend behavior without the library needing to know every
- * opcode.
+ * Anything that can arrive from the device after it has been parsed. Unparsed frames are carried
+ * through as [Raw] so that callers can inspect/extend behavior without the library needing to know
+ * every opcode.
  */
 sealed class MeshEvent {
-    data class SelfInfoEvent(val info: SelfInfo) : MeshEvent()
-    object ContactsStart : MeshEvent()
-    data class ContactEvent(val contact: Contact) : MeshEvent()
-    object EndOfContacts : MeshEvent()
-    data class Battery(val info: BatteryInfo) : MeshEvent()
-    data class Device(val info: DeviceInfo) : MeshEvent()
-    data class Radio(val settings: RadioSettings) : MeshEvent()
-    data class ChannelInfoEvent(val info: ChannelInfo) : MeshEvent()
-    data class CurrentTime(val time: kotlin.time.Instant) : MeshEvent()
-    object NoMoreMessages : MeshEvent()
-    object Ok : MeshEvent()
-    data class Err(val code: Int) : MeshEvent()
-    data class Sent(val ack: SendAck) : MeshEvent()
-    data class DirectMessage(val message: ReceivedDirectMessage) : MeshEvent()
-    data class ChannelMessage(val message: ReceivedChannelMessage) : MeshEvent()
+  data class SelfInfoEvent(val info: SelfInfo) : MeshEvent()
 
-    // Pushes
-    data class Advert(val info: AdvertPushInfo) : MeshEvent()
-    data class NewAdvert(val info: AdvertPushInfo) : MeshEvent()
-    data class PathUpdated(val publicKey: PublicKey) : MeshEvent()
-    data class SendConfirmedEvent(val confirmed: SendConfirmed) : MeshEvent()
-    object MessagesWaiting : MeshEvent()
-    data class LoginSuccess(val publicKey: PublicKey) : MeshEvent()
-    data class LoginFail(val publicKey: PublicKey) : MeshEvent()
+  object ContactsStart : MeshEvent()
 
-    /** Catch-all for frames we haven't modelled yet. */
-    data class Raw(val code: Byte, val body: kotlinx.io.bytestring.ByteString) : MeshEvent()
+  data class ContactEvent(val contact: Contact) : MeshEvent()
+
+  object EndOfContacts : MeshEvent()
+
+  data class Battery(val info: BatteryInfo) : MeshEvent()
+
+  data class Device(val info: DeviceInfo) : MeshEvent()
+
+  data class Radio(val settings: RadioSettings) : MeshEvent()
+
+  data class ChannelInfoEvent(val info: ChannelInfo) : MeshEvent()
+
+  data class CurrentTime(val time: kotlin.time.Instant) : MeshEvent()
+
+  object NoMoreMessages : MeshEvent()
+
+  object Ok : MeshEvent()
+
+  data class Err(val code: Int) : MeshEvent()
+
+  data class Sent(val ack: SendAck) : MeshEvent()
+
+  data class DirectMessage(val message: ReceivedDirectMessage) : MeshEvent()
+
+  data class ChannelMessage(val message: ReceivedChannelMessage) : MeshEvent()
+
+  // Pushes
+  data class Advert(val info: AdvertPushInfo) : MeshEvent()
+
+  data class NewAdvert(val info: AdvertPushInfo) : MeshEvent()
+
+  data class PathUpdated(val publicKey: PublicKey) : MeshEvent()
+
+  data class SendConfirmedEvent(val confirmed: SendConfirmed) : MeshEvent()
+
+  object MessagesWaiting : MeshEvent()
+
+  data class LoginSuccess(val publicKey: PublicKey) : MeshEvent()
+
+  data class LoginFail(val publicKey: PublicKey) : MeshEvent()
+
+  /** Catch-all for frames we haven't modelled yet. */
+  data class Raw(val code: Byte, val body: kotlinx.io.bytestring.ByteString) : MeshEvent()
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/model/Models.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/model/Models.kt
@@ -1,112 +1,100 @@
 package ee.schimke.meshcore.core.model
 
 import ee.schimke.meshcore.core.protocol.TextType
-import kotlinx.io.bytestring.ByteString
 import kotlin.time.Instant
+import kotlinx.io.bytestring.ByteString
 
 /** Device identity + radio config returned by `CMD_APP_START`. */
 data class SelfInfo(
-    val advertType: Int,
-    val txPowerDbm: Int,
-    val maxPowerDbm: Int,
-    val publicKey: PublicKey,
-    val latitude: Double,
-    val longitude: Double,
-    val multiAcks: Int,
-    val advertLocationPolicy: Int,
-    val telemetryFlags: Int,
-    val manualAddContacts: Int,
-    val radio: RadioSettings,
-    val name: String,
+  val advertType: Int,
+  val txPowerDbm: Int,
+  val maxPowerDbm: Int,
+  val publicKey: PublicKey,
+  val latitude: Double,
+  val longitude: Double,
+  val multiAcks: Int,
+  val advertLocationPolicy: Int,
+  val telemetryFlags: Int,
+  val manualAddContacts: Int,
+  val radio: RadioSettings,
+  val name: String,
 )
 
 data class RadioSettings(
-    val frequencyHz: Int,
-    val bandwidthHz: Int,
-    val spreadingFactor: Int,
-    val codingRate: Int,
+  val frequencyHz: Int,
+  val bandwidthHz: Int,
+  val spreadingFactor: Int,
+  val codingRate: Int,
 )
 
 enum class ContactType(val raw: Int) {
-    CHAT(1), REPEATER(2), ROOM(3), SENSOR(4), UNKNOWN(-1);
-    companion object {
-        fun fromRaw(r: Int) = entries.firstOrNull { it.raw == r } ?: UNKNOWN
-    }
+  CHAT(1),
+  REPEATER(2),
+  ROOM(3),
+  SENSOR(4),
+  UNKNOWN(-1);
+
+  companion object {
+    fun fromRaw(r: Int) = entries.firstOrNull { it.raw == r } ?: UNKNOWN
+  }
 }
 
 data class Contact(
-    val publicKey: PublicKey,
-    val type: ContactType,
-    val flags: Int,
-    val pathLength: Int, // -1 means flood mode (path_len was 0xFF)
-    val path: ByteString,
-    val name: String,
-    val advertTimestamp: Instant,
-    val latitude: Double,
-    val longitude: Double,
-    val lastModified: Instant,
+  val publicKey: PublicKey,
+  val type: ContactType,
+  val flags: Int,
+  val pathLength: Int, // -1 means flood mode (path_len was 0xFF)
+  val path: ByteString,
+  val name: String,
+  val advertTimestamp: Instant,
+  val latitude: Double,
+  val longitude: Double,
+  val lastModified: Instant,
 ) {
-    val isFlood: Boolean get() = pathLength < 0
+  val isFlood: Boolean
+    get() = pathLength < 0
 }
 
-data class BatteryInfo(
-    val millivolts: Int,
-    val storageUsedKb: Long,
-    val storageTotalKb: Long,
-) {
-    /** Simple estimate assuming LiPo/NMC chemistry (3.0–4.2 V). */
-    fun estimatePercent(minMv: Int = 3000, maxMv: Int = 4200): Int {
-        if (millivolts <= minMv) return 0
-        if (millivolts >= maxMv) return 100
-        return ((millivolts - minMv) * 100) / (maxMv - minMv)
-    }
+data class BatteryInfo(val millivolts: Int, val storageUsedKb: Long, val storageTotalKb: Long) {
+  /** Simple estimate assuming LiPo/NMC chemistry (3.0–4.2 V). */
+  fun estimatePercent(minMv: Int = 3000, maxMv: Int = 4200): Int {
+    if (millivolts <= minMv) return 0
+    if (millivolts >= maxMv) return 100
+    return ((millivolts - minMv) * 100) / (maxMv - minMv)
+  }
 }
 
-data class DeviceInfo(
-    val protocolVersion: Int,
-    val maxContacts: Int,
-    val maxChannels: Int,
-)
+data class DeviceInfo(val protocolVersion: Int, val maxContacts: Int, val maxChannels: Int)
 
-data class ChannelInfo(
-    val index: Int,
-    val name: String,
-    val psk: ByteString,
-)
+data class ChannelInfo(val index: Int, val name: String, val psk: ByteString)
 
 data class ReceivedDirectMessage(
-    val snr: Int,
-    val senderPrefix: PublicKey,
-    val pathLength: Int,
-    val timestamp: Instant,
-    val textType: TextType,
-    val text: String,
+  val snr: Int,
+  val senderPrefix: PublicKey,
+  val pathLength: Int,
+  val timestamp: Instant,
+  val textType: TextType,
+  val text: String,
 )
 
 data class ReceivedChannelMessage(
-    val snr: Int,
-    val channelIndex: Int,
-    val pathLength: Int,
-    val timestamp: Instant,
-    val textType: TextType,
-    /** Raw "sender: text" combined form as delivered by the device. */
-    val body: String,
+  val snr: Int,
+  val channelIndex: Int,
+  val pathLength: Int,
+  val timestamp: Instant,
+  val textType: TextType,
+  /** Raw "sender: text" combined form as delivered by the device. */
+  val body: String,
 ) {
-    val sender: String? get() = body.substringBefore(": ", "").ifEmpty { null }
-    val text: String get() = if (body.contains(": ")) body.substringAfter(": ") else body
+  val sender: String?
+    get() = body.substringBefore(": ", "").ifEmpty { null }
+
+  val text: String
+    get() = if (body.contains(": ")) body.substringAfter(": ") else body
 }
 
-data class SendAck(
-    val isFlood: Boolean,
-    val ackHash: Int,
-    val timeoutMs: Long,
-)
+data class SendAck(val isFlood: Boolean, val ackHash: Int, val timeoutMs: Long)
 
-data class SendConfirmed(
-    val ackHash: Int,
-    val tripTimeMs: Long,
-)
+data class SendConfirmed(val ackHash: Int, val tripTimeMs: Long)
 
-data class AdvertPushInfo(
-    val publicKey: PublicKey,
-)
+data class AdvertPushInfo(val publicKey: PublicKey)

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/model/PublicKey.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/model/PublicKey.kt
@@ -8,75 +8,76 @@ import ee.schimke.meshcore.core.protocol.MeshCoreConstants.PUB_KEY_SIZE
 import kotlinx.io.bytestring.ByteString
 
 /**
- * MeshCore identity as a strongly-typed wrapper around a 32-byte Ed25519
- * public key. Uses an inline value class so there's no runtime overhead
- * over the underlying [ByteString].
+ * MeshCore identity as a strongly-typed wrapper around a 32-byte Ed25519 public key. Uses an inline
+ * value class so there's no runtime overhead over the underlying [ByteString].
  *
- * Construct via [fromBytes], [fromHex] or [ofPrefix]. MeshCore packets
- * routinely identify contacts by just the first 6 bytes ([prefix]).
+ * Construct via [fromBytes], [fromHex] or [ofPrefix]. MeshCore packets routinely identify contacts
+ * by just the first 6 bytes ([prefix]).
  */
 @JvmInline
 value class PublicKey private constructor(val bytes: ByteString) {
 
-    init {
-        require(bytes.size == PUB_KEY_SIZE || bytes.size == PUB_KEY_PREFIX_SIZE) {
-            "PublicKey must be $PUB_KEY_SIZE bytes (full) or $PUB_KEY_PREFIX_SIZE bytes (prefix)"
-        }
+  init {
+    require(bytes.size == PUB_KEY_SIZE || bytes.size == PUB_KEY_PREFIX_SIZE) {
+      "PublicKey must be $PUB_KEY_SIZE bytes (full) or $PUB_KEY_PREFIX_SIZE bytes (prefix)"
+    }
+  }
+
+  /** First 6 bytes – MeshCore uses this to identify routing targets. */
+  val prefix: ByteString
+    get() =
+      if (bytes.size >= PUB_KEY_PREFIX_SIZE) {
+        bytes.substring(0, PUB_KEY_PREFIX_SIZE)
+      } else {
+        bytes
+      }
+
+  val isPrefixOnly: Boolean
+    get() = bytes.size == PUB_KEY_PREFIX_SIZE
+
+  fun toHex(): String {
+    val arr = bytes.toByteArray()
+    val sb = StringBuilder(arr.size * 2)
+    for (b in arr) {
+      val v = b.toInt() and 0xFF
+      sb.append(HEX[v ushr 4])
+      sb.append(HEX[v and 0x0F])
+    }
+    return sb.toString()
+  }
+
+  override fun toString(): String = toHex()
+
+  companion object {
+    private val HEX = "0123456789abcdef".toCharArray()
+
+    fun fromBytes(bytes: ByteString): PublicKey = PublicKey(bytes)
+
+    fun fromBytes(bytes: ByteArray): PublicKey = PublicKey(ByteString(*bytes))
+
+    fun ofPrefix(prefix: ByteString): PublicKey {
+      require(prefix.size == PUB_KEY_PREFIX_SIZE) { "prefix must be $PUB_KEY_PREFIX_SIZE bytes" }
+      return PublicKey(prefix)
     }
 
-    /** First 6 bytes – MeshCore uses this to identify routing targets. */
-    val prefix: ByteString
-        get() = if (bytes.size >= PUB_KEY_PREFIX_SIZE) {
-            bytes.substring(0, PUB_KEY_PREFIX_SIZE)
-        } else {
-            bytes
-        }
-
-    val isPrefixOnly: Boolean get() = bytes.size == PUB_KEY_PREFIX_SIZE
-
-    fun toHex(): String {
-        val arr = bytes.toByteArray()
-        val sb = StringBuilder(arr.size * 2)
-        for (b in arr) {
-            val v = b.toInt() and 0xFF
-            sb.append(HEX[v ushr 4]); sb.append(HEX[v and 0x0F])
-        }
-        return sb.toString()
+    fun fromHex(hex: String): PublicKey {
+      val clean = hex.trim().removePrefix("0x")
+      require(clean.length % 2 == 0) { "hex string must have even length" }
+      val out = ByteArray(clean.length / 2)
+      for (i in out.indices) {
+        val hi = hexDigit(clean[i * 2])
+        val lo = hexDigit(clean[i * 2 + 1])
+        out[i] = ((hi shl 4) or lo).toByte()
+      }
+      return fromBytes(out)
     }
 
-    override fun toString(): String = toHex()
-
-    companion object {
-        private val HEX = "0123456789abcdef".toCharArray()
-
-        fun fromBytes(bytes: ByteString): PublicKey = PublicKey(bytes)
-
-        fun fromBytes(bytes: ByteArray): PublicKey = PublicKey(ByteString(*bytes))
-
-        fun ofPrefix(prefix: ByteString): PublicKey {
-            require(prefix.size == PUB_KEY_PREFIX_SIZE) {
-                "prefix must be $PUB_KEY_PREFIX_SIZE bytes"
-            }
-            return PublicKey(prefix)
-        }
-
-        fun fromHex(hex: String): PublicKey {
-            val clean = hex.trim().removePrefix("0x")
-            require(clean.length % 2 == 0) { "hex string must have even length" }
-            val out = ByteArray(clean.length / 2)
-            for (i in out.indices) {
-                val hi = hexDigit(clean[i * 2])
-                val lo = hexDigit(clean[i * 2 + 1])
-                out[i] = ((hi shl 4) or lo).toByte()
-            }
-            return fromBytes(out)
-        }
-
-        private fun hexDigit(c: Char): Int = when (c) {
-            in '0'..'9' -> c - '0'
-            in 'a'..'f' -> c - 'a' + 10
-            in 'A'..'F' -> c - 'A' + 10
-            else -> throw IllegalArgumentException("invalid hex char: $c")
-        }
-    }
+    private fun hexDigit(c: Char): Int =
+      when (c) {
+        in '0'..'9' -> c - '0'
+        in 'a'..'f' -> c - 'a' + 10
+        in 'A'..'F' -> c - 'A' + 10
+        else -> throw IllegalArgumentException("invalid hex char: $c")
+      }
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/BufferExt.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/BufferExt.kt
@@ -8,48 +8,47 @@ import kotlinx.io.readByteString
 import kotlinx.io.readShortLe
 
 /**
- * Shared [kotlinx.io][kotlinx.io.Buffer] helpers used by frame builders
- * and parsers. MeshCore encodes multi-byte integers as little-endian,
- * and strings as null-terminated UTF-8 (padded to fixed widths in some
- * frame layouts).
+ * Shared [kotlinx.io][kotlinx.io.Buffer] helpers used by frame builders and parsers. MeshCore
+ * encodes multi-byte integers as little-endian, and strings as null-terminated UTF-8 (padded to
+ * fixed widths in some frame layouts).
  */
 internal object BufferExt {
 
-    /** Build a [ByteString] by writing into a fresh [Buffer]. */
-    inline fun buildByteString(block: Buffer.() -> Unit): ByteString {
-        val buf = Buffer()
-        buf.block()
-        return buf.readByteString()
-    }
+  /** Build a [ByteString] by writing into a fresh [Buffer]. */
+  inline fun buildByteString(block: Buffer.() -> Unit): ByteString {
+    val buf = Buffer()
+    buf.block()
+    return buf.readByteString()
+  }
 
-    /** Read a little-endian unsigned 16-bit integer as an Int. */
-    fun Source.readU16Le(): Int = readShortLe().toInt() and 0xFFFF
+  /** Read a little-endian unsigned 16-bit integer as an Int. */
+  fun Source.readU16Le(): Int = readShortLe().toInt() and 0xFFFF
 
-    /**
-     * Read a null-terminated UTF-8 string of at most [maxLen] bytes, consuming
-     * exactly [maxLen] bytes from the source (padding is skipped).
-     */
-    fun Source.readCStringFixed(maxLen: Int): String {
-        val bytes = readByteString(maxLen)
-        val raw = bytes.toByteArray()
-        var end = 0
-        while (end < raw.size && raw[end].toInt() != 0) end++
-        return raw.decodeToString(endIndex = end)
-    }
+  /**
+   * Read a null-terminated UTF-8 string of at most [maxLen] bytes, consuming exactly [maxLen] bytes
+   * from the source (padding is skipped).
+   */
+  fun Source.readCStringFixed(maxLen: Int): String {
+    val bytes = readByteString(maxLen)
+    val raw = bytes.toByteArray()
+    var end = 0
+    while (end < raw.size && raw[end].toInt() != 0) end++
+    return raw.decodeToString(endIndex = end)
+  }
 
-    /** Read a null-terminated UTF-8 string that runs to the end of the source. */
-    fun Source.readCStringRemaining(): String {
-        val bs = readByteString()
-        if (bs.isEmpty()) return ""
-        val raw = bs.toByteArray()
-        var end = 0
-        while (end < raw.size && raw[end].toInt() != 0) end++
-        return raw.decodeToString(endIndex = end)
-    }
+  /** Read a null-terminated UTF-8 string that runs to the end of the source. */
+  fun Source.readCStringRemaining(): String {
+    val bs = readByteString()
+    if (bs.isEmpty()) return ""
+    val raw = bs.toByteArray()
+    var end = 0
+    while (end < raw.size && raw[end].toInt() != 0) end++
+    return raw.decodeToString(endIndex = end)
+  }
 
-    /** Write a UTF-8 string followed by a trailing null terminator. */
-    fun Buffer.writeCString(value: String) {
-        write(value.encodeToByteArray())
-        writeByte(0)
-    }
+  /** Write a UTF-8 string followed by a trailing null terminator. */
+  fun Buffer.writeCString(value: String) {
+    write(value.encodeToByteArray())
+    writeByte(0)
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Codes.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Codes.kt
@@ -2,86 +2,89 @@ package ee.schimke.meshcore.core.protocol
 
 /** Command codes sent App → Device. */
 enum class CommandCode(val raw: Byte) {
-    AppStart(0x01),
-    SendTextMessage(0x02),
-    SendChannelTextMessage(0x03),
-    GetContacts(0x04),
-    GetDeviceTime(0x05),
-    SetDeviceTime(0x06),
-    SendSelfAdvert(0x07),
-    SetAdvertName(0x08),
-    AddUpdateContact(0x09),
-    SyncNextMessage(0x0A),
-    SetRadioParams(0x0B),
-    SetRadioTxPower(0x0C),
-    ResetPath(0x0D),
-    SetAdvertLatLon(0x0E),
-    RemoveContact(0x0F),
-    ShareContact(0x10),
-    ExportContact(0x11),
-    ImportContact(0x12),
-    Reboot(0x13),
-    GetBatteryAndStorage(0x14),
-    DeviceQuery(0x16),
-    SendLogin(0x1A),
-    Logout(0x1D),
-    GetContactByKey(0x1E),
-    GetChannel(0x1F),
-    SetChannel(0x20),
-    FactoryReset(0x33),
-    GetRadioSettings(0x39);
+  AppStart(0x01),
+  SendTextMessage(0x02),
+  SendChannelTextMessage(0x03),
+  GetContacts(0x04),
+  GetDeviceTime(0x05),
+  SetDeviceTime(0x06),
+  SendSelfAdvert(0x07),
+  SetAdvertName(0x08),
+  AddUpdateContact(0x09),
+  SyncNextMessage(0x0A),
+  SetRadioParams(0x0B),
+  SetRadioTxPower(0x0C),
+  ResetPath(0x0D),
+  SetAdvertLatLon(0x0E),
+  RemoveContact(0x0F),
+  ShareContact(0x10),
+  ExportContact(0x11),
+  ImportContact(0x12),
+  Reboot(0x13),
+  GetBatteryAndStorage(0x14),
+  DeviceQuery(0x16),
+  SendLogin(0x1A),
+  Logout(0x1D),
+  GetContactByKey(0x1E),
+  GetChannel(0x1F),
+  SetChannel(0x20),
+  FactoryReset(0x33),
+  GetRadioSettings(0x39);
 
-    companion object {
-        private val byRaw = entries.associateBy { it.raw }
-        fun fromRaw(raw: Byte): CommandCode? = byRaw[raw]
-    }
+  companion object {
+    private val byRaw = entries.associateBy { it.raw }
+
+    fun fromRaw(raw: Byte): CommandCode? = byRaw[raw]
+  }
 }
 
 /** Response codes sent Device → App (synchronous replies). */
 enum class ResponseCode(val raw: Byte) {
-    Ok(0x00),
-    Err(0x01),
-    ContactsStart(0x02),
-    Contact(0x03),
-    EndOfContacts(0x04),
-    SelfInfo(0x05),
-    Sent(0x06),
-    ContactMessageV1(0x07),
-    ChannelMessageV1(0x08),
-    CurrentTime(0x09),
-    NoMoreMessages(0x0A),
-    ExportContact(0x0B),
-    BatteryAndStorage(0x0C),
-    DeviceInfo(0x0D),
-    PrivateKey(0x0E),
-    Disabled(0x0F),
-    ContactMessageV3(0x10),
-    ChannelMessageV3(0x11),
-    ChannelInfo(0x12),
-    RadioSettings(0x19);
+  Ok(0x00),
+  Err(0x01),
+  ContactsStart(0x02),
+  Contact(0x03),
+  EndOfContacts(0x04),
+  SelfInfo(0x05),
+  Sent(0x06),
+  ContactMessageV1(0x07),
+  ChannelMessageV1(0x08),
+  CurrentTime(0x09),
+  NoMoreMessages(0x0A),
+  ExportContact(0x0B),
+  BatteryAndStorage(0x0C),
+  DeviceInfo(0x0D),
+  PrivateKey(0x0E),
+  Disabled(0x0F),
+  ContactMessageV3(0x10),
+  ChannelMessageV3(0x11),
+  ChannelInfo(0x12),
+  RadioSettings(0x19);
 
-    companion object {
-        private val byRaw = entries.associateBy { it.raw }
-        fun fromRaw(raw: Byte): ResponseCode? = byRaw[raw]
-    }
+  companion object {
+    private val byRaw = entries.associateBy { it.raw }
+
+    fun fromRaw(raw: Byte): ResponseCode? = byRaw[raw]
+  }
 }
 
 /** Push codes sent Device → App asynchronously (top bit set). */
 enum class PushCode(val raw: Byte) {
-    Advert(0x80.toByte()),
-    PathUpdated(0x81.toByte()),
-    SendConfirmed(0x82.toByte()),
-    MessagesWaiting(0x83.toByte()),
-    RawData(0x84.toByte()),
-    LoginSuccess(0x85.toByte()),
-    LoginFail(0x86.toByte()),
-    StatusResponse(0x87.toByte()),
-    LogRxData(0x88.toByte()),
-    TraceData(0x89.toByte()),
-    NewAdvert(0x8A.toByte());
+  Advert(0x80.toByte()),
+  PathUpdated(0x81.toByte()),
+  SendConfirmed(0x82.toByte()),
+  MessagesWaiting(0x83.toByte()),
+  RawData(0x84.toByte()),
+  LoginSuccess(0x85.toByte()),
+  LoginFail(0x86.toByte()),
+  StatusResponse(0x87.toByte()),
+  LogRxData(0x88.toByte()),
+  TraceData(0x89.toByte()),
+  NewAdvert(0x8A.toByte());
 
-    companion object {
-        private val byRaw = entries.associateBy { it.raw }
-        fun fromRaw(raw: Byte): PushCode? = byRaw[raw]
-    }
+  companion object {
+    private val byRaw = entries.associateBy { it.raw }
+
+    fun fromRaw(raw: Byte): PushCode? = byRaw[raw]
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Constants.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Constants.kt
@@ -1,23 +1,23 @@
 package ee.schimke.meshcore.core.protocol
 
 object MeshCoreConstants {
-    const val PUB_KEY_SIZE = 32
-    const val PUB_KEY_PREFIX_SIZE = 6
-    const val MAX_PATH_SIZE = 64
-    const val MAX_NAME_SIZE = 32
-    const val MAX_FRAME_SIZE = 172
-    const val MAX_TEXT_PAYLOAD_BYTES = 160
-    const val APP_PROTOCOL_VERSION = 3
+  const val PUB_KEY_SIZE = 32
+  const val PUB_KEY_PREFIX_SIZE = 6
+  const val MAX_PATH_SIZE = 64
+  const val MAX_NAME_SIZE = 32
+  const val MAX_FRAME_SIZE = 172
+  const val MAX_TEXT_PAYLOAD_BYTES = 160
+  const val APP_PROTOCOL_VERSION = 3
 
-    // Stream framing markers (USB CDC-ACM + TCP)
-    const val STREAM_TX_START: Byte = 0x3C
-    const val STREAM_RX_START: Byte = 0x3E
-    const val STREAM_HEADER_LEN = 3
+  // Stream framing markers (USB CDC-ACM + TCP)
+  const val STREAM_TX_START: Byte = 0x3C
+  const val STREAM_RX_START: Byte = 0x3E
+  const val STREAM_HEADER_LEN = 3
 
-    // Nordic UART Service (BLE companion)
-    const val BLE_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
-    const val BLE_RX_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
-    const val BLE_TX_CHAR_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+  // Nordic UART Service (BLE companion)
+  const val BLE_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+  const val BLE_RX_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+  const val BLE_TX_CHAR_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 
-    val BLE_NAME_PREFIXES = listOf("MeshCore-", "Whisper-", "WisCore-", "HT-")
+  val BLE_NAME_PREFIXES = listOf("MeshCore-", "Whisper-", "WisCore-", "HT-")
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Frames.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Frames.kt
@@ -5,166 +5,165 @@ import ee.schimke.meshcore.core.protocol.BufferExt.buildByteString
 import ee.schimke.meshcore.core.protocol.BufferExt.writeCString
 import ee.schimke.meshcore.core.protocol.MeshCoreConstants.MAX_NAME_SIZE
 import ee.schimke.meshcore.core.protocol.MeshCoreConstants.MAX_TEXT_PAYLOAD_BYTES
+import kotlin.math.roundToInt
+import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.writeIntLe
-import kotlin.math.roundToInt
-import kotlin.time.Instant
 
 /**
- * Pure frame builders. They return the raw MeshCore frame payload
- * `[code][body]` ready to hand to a [ee.schimke.meshcore.core.transport.Transport].
- * Stream transports will wrap this further via [StreamFrameCodec.encodeTx].
+ * Pure frame builders. They return the raw MeshCore frame payload `[code][body]` ready to hand to a
+ * [ee.schimke.meshcore.core.transport.Transport]. Stream transports will wrap this further via
+ * [StreamFrameCodec.encodeTx].
  */
 object Frames {
 
-    fun appStart(
-        appName: String,
-        appVersion: Int = MeshCoreConstants.APP_PROTOCOL_VERSION,
-    ): ByteString = buildByteString {
-        writeByte(CommandCode.AppStart.raw)
-        writeByte(appVersion.toByte())
-        repeat(6) { writeByte(0) } // reserved
-        writeCString(appName)
+  fun appStart(
+    appName: String,
+    appVersion: Int = MeshCoreConstants.APP_PROTOCOL_VERSION,
+  ): ByteString = buildByteString {
+    writeByte(CommandCode.AppStart.raw)
+    writeByte(appVersion.toByte())
+    repeat(6) { writeByte(0) } // reserved
+    writeCString(appName)
+  }
+
+  /**
+   * `[0x1A][recipient pub_key × 32][password]\0` — authenticate to a specific contact (repeater or
+   * room) so subsequent admin commands addressed to that contact are honored. This is **not** a
+   * device-level bootstrap step — connecting to a companion radio over BLE/USB/TCP requires no
+   * login. Only call this when the user wants to unlock a password-protected contact.
+   *
+   * Verified against the MeshCore Flutter client's `buildSendLoginFrame` in
+   * `connector/meshcore_protocol.dart`.
+   */
+  fun sendLogin(recipient: PublicKey, password: String): ByteString = buildByteString {
+    writeByte(CommandCode.SendLogin.raw)
+    write(recipient.bytes.toByteArray())
+    writeCString(password)
+  }
+
+  fun deviceQuery(): ByteString = single(CommandCode.DeviceQuery)
+
+  fun getBatteryAndStorage(): ByteString = single(CommandCode.GetBatteryAndStorage)
+
+  fun getRadioSettings(): ByteString = single(CommandCode.GetRadioSettings)
+
+  fun getDeviceTime(): ByteString = single(CommandCode.GetDeviceTime)
+
+  fun setDeviceTime(time: Instant): ByteString = buildByteString {
+    writeByte(CommandCode.SetDeviceTime.raw)
+    writeIntLe(time.epochSeconds.toInt())
+  }
+
+  fun getContacts(since: Instant? = null): ByteString = buildByteString {
+    writeByte(CommandCode.GetContacts.raw)
+    if (since != null) writeIntLe(since.epochSeconds.toInt())
+  }
+
+  fun sendSelfAdvert(floodMode: Boolean = false): ByteString = buildByteString {
+    writeByte(CommandCode.SendSelfAdvert.raw)
+    writeByte(if (floodMode) 1 else 0)
+  }
+
+  fun setAdvertName(name: String): ByteString {
+    val nameBytes = name.encodeToByteArray()
+    val trimmed =
+      if (nameBytes.size > MAX_NAME_SIZE - 1) {
+        nameBytes.copyOf(MAX_NAME_SIZE - 1)
+      } else {
+        nameBytes
+      }
+    return buildByteString {
+      writeByte(CommandCode.SetAdvertName.raw)
+      write(trimmed)
     }
+  }
 
-    /**
-     * `[0x1A][recipient pub_key × 32][password]\0` — authenticate to a
-     * specific contact (repeater or room) so subsequent admin commands
-     * addressed to that contact are honored. This is **not** a
-     * device-level bootstrap step — connecting to a companion radio
-     * over BLE/USB/TCP requires no login. Only call this when the
-     * user wants to unlock a password-protected contact.
-     *
-     * Verified against the MeshCore Flutter client's
-     * `buildSendLoginFrame` in `connector/meshcore_protocol.dart`.
-     */
-    fun sendLogin(recipient: PublicKey, password: String): ByteString = buildByteString {
-        writeByte(CommandCode.SendLogin.raw)
-        write(recipient.bytes.toByteArray())
-        writeCString(password)
+  fun setAdvertLatLon(lat: Double, lon: Double): ByteString = buildByteString {
+    writeByte(CommandCode.SetAdvertLatLon.raw)
+    writeIntLe((lat * 1_000_000.0).roundToInt())
+    writeIntLe((lon * 1_000_000.0).roundToInt())
+  }
+
+  fun setRadioParams(freqHz: Int, bwHz: Int, sf: Int, cr: Int): ByteString = buildByteString {
+    writeByte(CommandCode.SetRadioParams.raw)
+    writeIntLe(freqHz)
+    writeIntLe(bwHz)
+    writeByte(sf.toByte())
+    writeByte(cr.toByte())
+  }
+
+  fun setRadioTxPower(dbm: Int): ByteString = buildByteString {
+    writeByte(CommandCode.SetRadioTxPower.raw)
+    writeByte(dbm.toByte())
+  }
+
+  /** `[0x1F][channel_idx]` — request info for a single channel. */
+  fun getChannel(index: Int): ByteString = buildByteString {
+    writeByte(CommandCode.GetChannel.raw)
+    writeByte(index.toByte())
+  }
+
+  /** `[0x20][channel_idx][name×32][psk×16]` — create or update a channel. */
+  fun setChannel(index: Int, name: String, psk: ByteString): ByteString = buildByteString {
+    writeByte(CommandCode.SetChannel.raw)
+    writeByte(index.toByte())
+    // Fixed 32-byte name field, null-padded
+    val nameBytes = name.encodeToByteArray()
+    val nameField = ByteArray(32)
+    nameBytes.copyInto(nameField, endIndex = minOf(nameBytes.size, 31))
+    write(nameField)
+    // 16-byte PSK
+    val pskBytes = psk.toByteArray()
+    val pskField = ByteArray(16)
+    pskBytes.copyInto(pskField, endIndex = minOf(pskBytes.size, 16))
+    write(pskField)
+  }
+
+  fun reboot(): ByteString = single(CommandCode.Reboot)
+
+  fun syncNextMessage(): ByteString = single(CommandCode.SyncNextMessage)
+
+  /** `[0x02][txt_type][attempt][timestamp x4][pub_key_prefix x6][text]\0` */
+  fun sendTextMessage(
+    recipient: PublicKey,
+    text: String,
+    timestamp: Instant,
+    attempt: Int = 0,
+    textType: TextType = TextType.Plain,
+  ): ByteString {
+    val textBytes = text.encodeToByteArray()
+    require(textBytes.size <= MAX_TEXT_PAYLOAD_BYTES) {
+      "text exceeds $MAX_TEXT_PAYLOAD_BYTES bytes"
     }
-
-    fun deviceQuery(): ByteString = single(CommandCode.DeviceQuery)
-
-    fun getBatteryAndStorage(): ByteString = single(CommandCode.GetBatteryAndStorage)
-
-    fun getRadioSettings(): ByteString = single(CommandCode.GetRadioSettings)
-
-    fun getDeviceTime(): ByteString = single(CommandCode.GetDeviceTime)
-
-    fun setDeviceTime(time: Instant): ByteString = buildByteString {
-        writeByte(CommandCode.SetDeviceTime.raw)
-        writeIntLe(time.epochSeconds.toInt())
+    return buildByteString {
+      writeByte(CommandCode.SendTextMessage.raw)
+      writeByte(textType.raw)
+      writeByte(attempt.toByte())
+      writeIntLe(timestamp.epochSeconds.toInt())
+      write(recipient.prefix.toByteArray())
+      writeCString(text)
     }
+  }
 
-    fun getContacts(since: Instant? = null): ByteString = buildByteString {
-        writeByte(CommandCode.GetContacts.raw)
-        if (since != null) writeIntLe(since.epochSeconds.toInt())
-    }
+  /** `[0x03][txt_type][channel_idx][timestamp x4][text]\0` */
+  fun sendChannelTextMessage(
+    channelIdx: Int,
+    text: String,
+    timestamp: Instant,
+    textType: TextType = TextType.Plain,
+  ): ByteString = buildByteString {
+    writeByte(CommandCode.SendChannelTextMessage.raw)
+    writeByte(textType.raw)
+    writeByte(channelIdx.toByte())
+    writeIntLe(timestamp.epochSeconds.toInt())
+    writeCString(text)
+  }
 
-    fun sendSelfAdvert(floodMode: Boolean = false): ByteString = buildByteString {
-        writeByte(CommandCode.SendSelfAdvert.raw)
-        writeByte(if (floodMode) 1 else 0)
-    }
-
-    fun setAdvertName(name: String): ByteString {
-        val nameBytes = name.encodeToByteArray()
-        val trimmed = if (nameBytes.size > MAX_NAME_SIZE - 1) {
-            nameBytes.copyOf(MAX_NAME_SIZE - 1)
-        } else {
-            nameBytes
-        }
-        return buildByteString {
-            writeByte(CommandCode.SetAdvertName.raw)
-            write(trimmed)
-        }
-    }
-
-    fun setAdvertLatLon(lat: Double, lon: Double): ByteString = buildByteString {
-        writeByte(CommandCode.SetAdvertLatLon.raw)
-        writeIntLe((lat * 1_000_000.0).roundToInt())
-        writeIntLe((lon * 1_000_000.0).roundToInt())
-    }
-
-    fun setRadioParams(freqHz: Int, bwHz: Int, sf: Int, cr: Int): ByteString = buildByteString {
-        writeByte(CommandCode.SetRadioParams.raw)
-        writeIntLe(freqHz)
-        writeIntLe(bwHz)
-        writeByte(sf.toByte())
-        writeByte(cr.toByte())
-    }
-
-    fun setRadioTxPower(dbm: Int): ByteString = buildByteString {
-        writeByte(CommandCode.SetRadioTxPower.raw)
-        writeByte(dbm.toByte())
-    }
-
-    /** `[0x1F][channel_idx]` — request info for a single channel. */
-    fun getChannel(index: Int): ByteString = buildByteString {
-        writeByte(CommandCode.GetChannel.raw)
-        writeByte(index.toByte())
-    }
-
-    /** `[0x20][channel_idx][name×32][psk×16]` — create or update a channel. */
-    fun setChannel(index: Int, name: String, psk: ByteString): ByteString = buildByteString {
-        writeByte(CommandCode.SetChannel.raw)
-        writeByte(index.toByte())
-        // Fixed 32-byte name field, null-padded
-        val nameBytes = name.encodeToByteArray()
-        val nameField = ByteArray(32)
-        nameBytes.copyInto(nameField, endIndex = minOf(nameBytes.size, 31))
-        write(nameField)
-        // 16-byte PSK
-        val pskBytes = psk.toByteArray()
-        val pskField = ByteArray(16)
-        pskBytes.copyInto(pskField, endIndex = minOf(pskBytes.size, 16))
-        write(pskField)
-    }
-
-    fun reboot(): ByteString = single(CommandCode.Reboot)
-
-    fun syncNextMessage(): ByteString = single(CommandCode.SyncNextMessage)
-
-    /** `[0x02][txt_type][attempt][timestamp x4][pub_key_prefix x6][text]\0` */
-    fun sendTextMessage(
-        recipient: PublicKey,
-        text: String,
-        timestamp: Instant,
-        attempt: Int = 0,
-        textType: TextType = TextType.Plain,
-    ): ByteString {
-        val textBytes = text.encodeToByteArray()
-        require(textBytes.size <= MAX_TEXT_PAYLOAD_BYTES) {
-            "text exceeds $MAX_TEXT_PAYLOAD_BYTES bytes"
-        }
-        return buildByteString {
-            writeByte(CommandCode.SendTextMessage.raw)
-            writeByte(textType.raw)
-            writeByte(attempt.toByte())
-            writeIntLe(timestamp.epochSeconds.toInt())
-            write(recipient.prefix.toByteArray())
-            writeCString(text)
-        }
-    }
-
-    /** `[0x03][txt_type][channel_idx][timestamp x4][text]\0` */
-    fun sendChannelTextMessage(
-        channelIdx: Int,
-        text: String,
-        timestamp: Instant,
-        textType: TextType = TextType.Plain,
-    ): ByteString = buildByteString {
-        writeByte(CommandCode.SendChannelTextMessage.raw)
-        writeByte(textType.raw)
-        writeByte(channelIdx.toByte())
-        writeIntLe(timestamp.epochSeconds.toInt())
-        writeCString(text)
-    }
-
-    private fun single(code: CommandCode): ByteString {
-        val b = ByteStringBuilder(1)
-        b.append(code.raw)
-        return b.toByteString()
-    }
+  private fun single(code: CommandCode): ByteString {
+    val b = ByteStringBuilder(1)
+    b.append(code.raw)
+    return b.toByteString()
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Parsers.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Parsers.kt
@@ -18,6 +18,7 @@ import ee.schimke.meshcore.core.protocol.BufferExt.readCStringFixed
 import ee.schimke.meshcore.core.protocol.BufferExt.readCStringRemaining
 import ee.schimke.meshcore.core.protocol.MeshCoreConstants.PUB_KEY_PREFIX_SIZE
 import ee.schimke.meshcore.core.protocol.MeshCoreConstants.PUB_KEY_SIZE
+import kotlin.time.Instant
 import kotlinx.io.Buffer
 import kotlinx.io.Source
 import kotlinx.io.bytestring.ByteString
@@ -25,198 +26,193 @@ import kotlinx.io.bytestring.isEmpty
 import kotlinx.io.readByteString
 import kotlinx.io.readIntLe
 import kotlinx.io.readShortLe
-import kotlin.time.Instant
 
-/** Parse a raw frame payload `[code][body...]` into a [MeshEvent]. */
+/** Parse a raw frame payload (one `code` byte followed by body bytes) into a [MeshEvent]. */
 object Parsers {
 
-    fun parse(frame: ByteString): MeshEvent {
-        if (frame.isEmpty()) return MeshEvent.Raw(0, frame)
-        val code = frame[0]
-        val buf = Buffer().apply { write(frame.toByteArray()) }
-        buf.readByte() // discard code byte
-        return try {
-            ResponseCode.fromRaw(code)?.let { parseResponse(it, buf, frame) }
-                ?: PushCode.fromRaw(code)?.let { parsePush(it, buf) }
-                ?: MeshEvent.Raw(code, frame.substring(1))
-        } catch (_: Throwable) {
-            MeshEvent.Raw(code, frame.substring(1))
-        }
+  fun parse(frame: ByteString): MeshEvent {
+    if (frame.isEmpty()) return MeshEvent.Raw(0, frame)
+    val code = frame[0]
+    val buf = Buffer().apply { write(frame.toByteArray()) }
+    buf.readByte() // discard code byte
+    return try {
+      ResponseCode.fromRaw(code)?.let { parseResponse(it, buf, frame) }
+        ?: PushCode.fromRaw(code)?.let { parsePush(it, buf) }
+        ?: MeshEvent.Raw(code, frame.substring(1))
+    } catch (_: Throwable) {
+      MeshEvent.Raw(code, frame.substring(1))
+    }
+  }
+
+  private fun parseResponse(code: ResponseCode, buf: Buffer, frame: ByteString): MeshEvent =
+    when (code) {
+      ResponseCode.Ok -> MeshEvent.Ok
+      ResponseCode.Err -> MeshEvent.Err(if (frame.size > 1) frame[1].toInt() and 0xFF else 0)
+      ResponseCode.ContactsStart -> MeshEvent.ContactsStart
+      ResponseCode.EndOfContacts -> MeshEvent.EndOfContacts
+      ResponseCode.NoMoreMessages -> MeshEvent.NoMoreMessages
+      ResponseCode.SelfInfo -> parseSelfInfo(buf)
+      ResponseCode.Contact -> parseContact(buf)
+      ResponseCode.BatteryAndStorage -> parseBatteryAndStorage(buf)
+      ResponseCode.DeviceInfo -> parseDeviceInfo(buf)
+      ResponseCode.RadioSettings -> parseRadioSettings(buf)
+      ResponseCode.CurrentTime -> MeshEvent.CurrentTime(readEpochSeconds(buf))
+      ResponseCode.Sent -> parseSent(buf)
+      ResponseCode.ContactMessageV3 -> parseContactMsgV3(buf)
+      ResponseCode.ChannelMessageV3 -> parseChannelMsgV3(buf)
+      ResponseCode.ChannelInfo -> parseChannelInfo(buf)
+      else -> MeshEvent.Raw(code.raw, frame.substring(1))
     }
 
-    private fun parseResponse(code: ResponseCode, buf: Buffer, frame: ByteString): MeshEvent =
-        when (code) {
-            ResponseCode.Ok -> MeshEvent.Ok
-            ResponseCode.Err -> MeshEvent.Err(if (frame.size > 1) frame[1].toInt() and 0xFF else 0)
-            ResponseCode.ContactsStart -> MeshEvent.ContactsStart
-            ResponseCode.EndOfContacts -> MeshEvent.EndOfContacts
-            ResponseCode.NoMoreMessages -> MeshEvent.NoMoreMessages
-            ResponseCode.SelfInfo -> parseSelfInfo(buf)
-            ResponseCode.Contact -> parseContact(buf)
-            ResponseCode.BatteryAndStorage -> parseBatteryAndStorage(buf)
-            ResponseCode.DeviceInfo -> parseDeviceInfo(buf)
-            ResponseCode.RadioSettings -> parseRadioSettings(buf)
-            ResponseCode.CurrentTime -> MeshEvent.CurrentTime(readEpochSeconds(buf))
-            ResponseCode.Sent -> parseSent(buf)
-            ResponseCode.ContactMessageV3 -> parseContactMsgV3(buf)
-            ResponseCode.ChannelMessageV3 -> parseChannelMsgV3(buf)
-            ResponseCode.ChannelInfo -> parseChannelInfo(buf)
-            else -> MeshEvent.Raw(code.raw, frame.substring(1))
-        }
-
-    private fun parsePush(code: PushCode, buf: Buffer): MeshEvent =
-        when (code) {
-            PushCode.Advert -> MeshEvent.Advert(AdvertPushInfo(readPubKey(buf)))
-            PushCode.NewAdvert -> MeshEvent.NewAdvert(AdvertPushInfo(readPubKey(buf)))
-            PushCode.PathUpdated -> MeshEvent.PathUpdated(readPubKey(buf))
-            PushCode.SendConfirmed -> parseSendConfirmed(buf)
-            PushCode.MessagesWaiting -> MeshEvent.MessagesWaiting
-            PushCode.LoginSuccess -> {
-                // Permissions byte precedes the prefix (bit 0 = is_admin).
-                buf.readByte()
-                MeshEvent.LoginSuccess(readPubKeyPrefix(buf))
-            }
-            PushCode.LoginFail -> {
-                // Reserved byte precedes the prefix.
-                buf.readByte()
-                MeshEvent.LoginFail(readPubKeyPrefix(buf))
-            }
-            else -> MeshEvent.Raw(code.raw, ByteString())
-        }
-
-    private fun readEpochSeconds(src: Source): Instant =
-        Instant.fromEpochSeconds(src.readIntLe().toLong() and 0xFFFFFFFFL)
-
-    private fun readPubKey(src: Source): PublicKey =
-        PublicKey.fromBytes(src.readByteString(PUB_KEY_SIZE))
-
-    private fun readPubKeyPrefix(src: Source): PublicKey =
-        PublicKey.ofPrefix(src.readByteString(PUB_KEY_PREFIX_SIZE))
-
-    private fun parseSelfInfo(src: Source): MeshEvent.SelfInfoEvent {
-        val advType = src.readByte().toInt() and 0xFF
-        val txPwr = src.readByte().toInt()
-        val maxPwr = src.readByte().toInt()
-        val pub = PublicKey.fromBytes(src.readByteString(PUB_KEY_SIZE))
-        val lat = src.readIntLe() / 1_000_000.0
-        val lon = src.readIntLe() / 1_000_000.0
-        val multiAcks = src.readByte().toInt() and 0xFF
-        val advPolicy = src.readByte().toInt() and 0xFF
-        val telemetry = src.readByte().toInt() and 0xFF
-        val manualAdd = src.readByte().toInt() and 0xFF
-        val freq = src.readIntLe()
-        val bw = src.readIntLe()
-        val sf = src.readByte().toInt() and 0xFF
-        val cr = src.readByte().toInt() and 0xFF
-        val name = src.readCStringRemaining()
-        return MeshEvent.SelfInfoEvent(
-            SelfInfo(
-                advertType = advType,
-                txPowerDbm = txPwr,
-                maxPowerDbm = maxPwr,
-                publicKey = pub,
-                latitude = lat,
-                longitude = lon,
-                multiAcks = multiAcks,
-                advertLocationPolicy = advPolicy,
-                telemetryFlags = telemetry,
-                manualAddContacts = manualAdd,
-                radio = RadioSettings(freq, bw, sf, cr),
-                name = name,
-            ),
-        )
+  private fun parsePush(code: PushCode, buf: Buffer): MeshEvent =
+    when (code) {
+      PushCode.Advert -> MeshEvent.Advert(AdvertPushInfo(readPubKey(buf)))
+      PushCode.NewAdvert -> MeshEvent.NewAdvert(AdvertPushInfo(readPubKey(buf)))
+      PushCode.PathUpdated -> MeshEvent.PathUpdated(readPubKey(buf))
+      PushCode.SendConfirmed -> parseSendConfirmed(buf)
+      PushCode.MessagesWaiting -> MeshEvent.MessagesWaiting
+      PushCode.LoginSuccess -> {
+        // Permissions byte precedes the prefix (bit 0 = is_admin).
+        buf.readByte()
+        MeshEvent.LoginSuccess(readPubKeyPrefix(buf))
+      }
+      PushCode.LoginFail -> {
+        // Reserved byte precedes the prefix.
+        buf.readByte()
+        MeshEvent.LoginFail(readPubKeyPrefix(buf))
+      }
+      else -> MeshEvent.Raw(code.raw, ByteString())
     }
 
-    private fun parseContact(src: Source): MeshEvent.ContactEvent {
-        val pub = PublicKey.fromBytes(src.readByteString(PUB_KEY_SIZE))
-        val type = src.readByte().toInt() and 0xFF
-        val flags = src.readByte().toInt() and 0xFF
-        val rawPathLen = src.readByte().toInt() and 0xFF
-        val pathLen = if (rawPathLen == 0xFF) -1 else rawPathLen
-        val rawPath = src.readByteString(64)
-        val path = if (pathLen in 1..64) rawPath.substring(0, pathLen) else ByteString()
-        val name = src.readCStringFixed(32)
-        val ts = readEpochSeconds(src)
-        val lat = src.readIntLe() / 1_000_000.0
-        val lon = src.readIntLe() / 1_000_000.0
-        val lastMod = readEpochSeconds(src)
-        return MeshEvent.ContactEvent(
-            Contact(pub, ContactType.fromRaw(type), flags, pathLen, path, name, ts, lat, lon, lastMod),
-        )
-    }
+  private fun readEpochSeconds(src: Source): Instant =
+    Instant.fromEpochSeconds(src.readIntLe().toLong() and 0xFFFFFFFFL)
 
-    private fun parseBatteryAndStorage(src: Source): MeshEvent.Battery {
-        val mv = src.readShortLe().toInt() and 0xFFFF
-        val used = src.readIntLe().toLong() and 0xFFFFFFFFL
-        val total = src.readIntLe().toLong() and 0xFFFFFFFFL
-        return MeshEvent.Battery(BatteryInfo(mv, used, total))
-    }
+  private fun readPubKey(src: Source): PublicKey =
+    PublicKey.fromBytes(src.readByteString(PUB_KEY_SIZE))
 
-    private fun parseDeviceInfo(src: Source): MeshEvent.Device {
-        val pv = src.readByte().toInt() and 0xFF
-        val contacts = (src.readByte().toInt() and 0xFF) * 2
-        val channels = src.readByte().toInt() and 0xFF
-        return MeshEvent.Device(DeviceInfo(pv, contacts, channels))
-    }
+  private fun readPubKeyPrefix(src: Source): PublicKey =
+    PublicKey.ofPrefix(src.readByteString(PUB_KEY_PREFIX_SIZE))
 
-    private fun parseRadioSettings(src: Source): MeshEvent.Radio {
-        val freq = src.readIntLe()
-        val bw = src.readIntLe()
-        val sf = src.readByte().toInt() and 0xFF
-        val cr = src.readByte().toInt() and 0xFF
-        return MeshEvent.Radio(RadioSettings(freq, bw, sf, cr))
-    }
+  private fun parseSelfInfo(src: Source): MeshEvent.SelfInfoEvent {
+    val advType = src.readByte().toInt() and 0xFF
+    val txPwr = src.readByte().toInt()
+    val maxPwr = src.readByte().toInt()
+    val pub = PublicKey.fromBytes(src.readByteString(PUB_KEY_SIZE))
+    val lat = src.readIntLe() / 1_000_000.0
+    val lon = src.readIntLe() / 1_000_000.0
+    val multiAcks = src.readByte().toInt() and 0xFF
+    val advPolicy = src.readByte().toInt() and 0xFF
+    val telemetry = src.readByte().toInt() and 0xFF
+    val manualAdd = src.readByte().toInt() and 0xFF
+    val freq = src.readIntLe()
+    val bw = src.readIntLe()
+    val sf = src.readByte().toInt() and 0xFF
+    val cr = src.readByte().toInt() and 0xFF
+    val name = src.readCStringRemaining()
+    return MeshEvent.SelfInfoEvent(
+      SelfInfo(
+        advertType = advType,
+        txPowerDbm = txPwr,
+        maxPowerDbm = maxPwr,
+        publicKey = pub,
+        latitude = lat,
+        longitude = lon,
+        multiAcks = multiAcks,
+        advertLocationPolicy = advPolicy,
+        telemetryFlags = telemetry,
+        manualAddContacts = manualAdd,
+        radio = RadioSettings(freq, bw, sf, cr),
+        name = name,
+      )
+    )
+  }
 
-    private fun parseSent(src: Source): MeshEvent.Sent {
-        val isFlood = src.readByte().toInt() != 0
-        val ackHash = src.readIntLe()
-        val timeout = src.readIntLe().toLong() and 0xFFFFFFFFL
-        return MeshEvent.Sent(SendAck(isFlood, ackHash, timeout))
-    }
+  private fun parseContact(src: Source): MeshEvent.ContactEvent {
+    val pub = PublicKey.fromBytes(src.readByteString(PUB_KEY_SIZE))
+    val type = src.readByte().toInt() and 0xFF
+    val flags = src.readByte().toInt() and 0xFF
+    val rawPathLen = src.readByte().toInt() and 0xFF
+    val pathLen = if (rawPathLen == 0xFF) -1 else rawPathLen
+    val rawPath = src.readByteString(64)
+    val path = if (pathLen in 1..64) rawPath.substring(0, pathLen) else ByteString()
+    val name = src.readCStringFixed(32)
+    val ts = readEpochSeconds(src)
+    val lat = src.readIntLe() / 1_000_000.0
+    val lon = src.readIntLe() / 1_000_000.0
+    val lastMod = readEpochSeconds(src)
+    return MeshEvent.ContactEvent(
+      Contact(pub, ContactType.fromRaw(type), flags, pathLen, path, name, ts, lat, lon, lastMod)
+    )
+  }
 
-    private fun parseSendConfirmed(src: Source): MeshEvent.SendConfirmedEvent {
-        val ackHash = src.readIntLe()
-        val trip = src.readIntLe().toLong() and 0xFFFFFFFFL
-        return MeshEvent.SendConfirmedEvent(SendConfirmed(ackHash, trip))
-    }
+  private fun parseBatteryAndStorage(src: Source): MeshEvent.Battery {
+    val mv = src.readShortLe().toInt() and 0xFFFF
+    val used = src.readIntLe().toLong() and 0xFFFFFFFFL
+    val total = src.readIntLe().toLong() and 0xFFFFFFFFL
+    return MeshEvent.Battery(BatteryInfo(mv, used, total))
+  }
 
-    /** `[idx][name×32][psk×16]` */
-    private fun parseChannelInfo(src: Source): MeshEvent.ChannelInfoEvent {
-        val idx = src.readByte().toInt() and 0xFF
-        val name = src.readCStringFixed(32)
-        val psk = src.readByteString(16)
-        return MeshEvent.ChannelInfoEvent(ChannelInfo(idx, name, psk))
-    }
+  private fun parseDeviceInfo(src: Source): MeshEvent.Device {
+    val pv = src.readByte().toInt() and 0xFF
+    val contacts = (src.readByte().toInt() and 0xFF) * 2
+    val channels = src.readByte().toInt() and 0xFF
+    return MeshEvent.Device(DeviceInfo(pv, contacts, channels))
+  }
 
-    private fun parseContactMsgV3(src: Source): MeshEvent.DirectMessage {
-        val snr = src.readByte().toInt()
-        src.readShort()
-        val prefix = PublicKey.ofPrefix(src.readByteString(PUB_KEY_PREFIX_SIZE))
-        val rawPathLen = src.readByte().toInt() and 0xFF
-        val pathLen = if (rawPathLen == 0xFF) -1 else rawPathLen
-        val rawTxt = src.readByte().toInt()
-        val txtType = TextType.fromRaw(rawTxt)
-            ?: error("unknown text type 0x${rawTxt.toString(16)}")
-        val ts = readEpochSeconds(src)
-        val text = src.readCStringRemaining()
-        return MeshEvent.DirectMessage(
-            ReceivedDirectMessage(snr, prefix, pathLen, ts, txtType, text),
-        )
-    }
+  private fun parseRadioSettings(src: Source): MeshEvent.Radio {
+    val freq = src.readIntLe()
+    val bw = src.readIntLe()
+    val sf = src.readByte().toInt() and 0xFF
+    val cr = src.readByte().toInt() and 0xFF
+    return MeshEvent.Radio(RadioSettings(freq, bw, sf, cr))
+  }
 
-    private fun parseChannelMsgV3(src: Source): MeshEvent.ChannelMessage {
-        val snr = src.readByte().toInt()
-        src.readShort()
-        val channelIdx = src.readByte().toInt() and 0xFF
-        val rawPathLen = src.readByte().toInt() and 0xFF
-        val pathLen = if (rawPathLen == 0xFF) -1 else rawPathLen
-        val rawTxt = src.readByte().toInt()
-        val txtType = TextType.fromRaw(rawTxt)
-            ?: error("unknown text type 0x${rawTxt.toString(16)}")
-        val ts = readEpochSeconds(src)
-        val body = src.readCStringRemaining()
-        return MeshEvent.ChannelMessage(
-            ReceivedChannelMessage(snr, channelIdx, pathLen, ts, txtType, body),
-        )
-    }
+  private fun parseSent(src: Source): MeshEvent.Sent {
+    val isFlood = src.readByte().toInt() != 0
+    val ackHash = src.readIntLe()
+    val timeout = src.readIntLe().toLong() and 0xFFFFFFFFL
+    return MeshEvent.Sent(SendAck(isFlood, ackHash, timeout))
+  }
+
+  private fun parseSendConfirmed(src: Source): MeshEvent.SendConfirmedEvent {
+    val ackHash = src.readIntLe()
+    val trip = src.readIntLe().toLong() and 0xFFFFFFFFL
+    return MeshEvent.SendConfirmedEvent(SendConfirmed(ackHash, trip))
+  }
+
+  /** `[idx][name×32][psk×16]` */
+  private fun parseChannelInfo(src: Source): MeshEvent.ChannelInfoEvent {
+    val idx = src.readByte().toInt() and 0xFF
+    val name = src.readCStringFixed(32)
+    val psk = src.readByteString(16)
+    return MeshEvent.ChannelInfoEvent(ChannelInfo(idx, name, psk))
+  }
+
+  private fun parseContactMsgV3(src: Source): MeshEvent.DirectMessage {
+    val snr = src.readByte().toInt()
+    src.readShort()
+    val prefix = PublicKey.ofPrefix(src.readByteString(PUB_KEY_PREFIX_SIZE))
+    val rawPathLen = src.readByte().toInt() and 0xFF
+    val pathLen = if (rawPathLen == 0xFF) -1 else rawPathLen
+    val rawTxt = src.readByte().toInt()
+    val txtType = TextType.fromRaw(rawTxt) ?: error("unknown text type 0x${rawTxt.toString(16)}")
+    val ts = readEpochSeconds(src)
+    val text = src.readCStringRemaining()
+    return MeshEvent.DirectMessage(ReceivedDirectMessage(snr, prefix, pathLen, ts, txtType, text))
+  }
+
+  private fun parseChannelMsgV3(src: Source): MeshEvent.ChannelMessage {
+    val snr = src.readByte().toInt()
+    src.readShort()
+    val channelIdx = src.readByte().toInt() and 0xFF
+    val rawPathLen = src.readByte().toInt() and 0xFF
+    val pathLen = if (rawPathLen == 0xFF) -1 else rawPathLen
+    val rawTxt = src.readByte().toInt()
+    val txtType = TextType.fromRaw(rawTxt) ?: error("unknown text type 0x${rawTxt.toString(16)}")
+    val ts = readEpochSeconds(src)
+    val body = src.readCStringRemaining()
+    return MeshEvent.ChannelMessage(
+      ReceivedChannelMessage(snr, channelIdx, pathLen, ts, txtType, body)
+    )
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/StreamFrameCodec.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/StreamFrameCodec.kt
@@ -12,88 +12,86 @@ import kotlinx.io.readByteString
 import kotlinx.io.writeShortLe
 
 /**
- * Length-prefixed framing used by the USB CDC-ACM and TCP companion
- * transports. The BLE transport does NOT use this – each BLE write /
- * notification already delivers one complete frame payload.
+ * Length-prefixed framing used by the USB CDC-ACM and TCP companion transports. The BLE transport
+ * does NOT use this – each BLE write / notification already delivers one complete frame payload.
  *
- * Frame layout on the wire (either direction):
- *   [start:u8][len_lo:u8][len_hi:u8][payload…]
+ * Frame layout on the wire (either direction): [start:u8][len_lo:u8][len_hi:u8][payload…]
  *
- * `start` is [STREAM_TX_START] (0x3C) for App → Device and
- * [STREAM_RX_START] (0x3E) for Device → App.
+ * `start` is [STREAM_TX_START] (0x3C) for App → Device and [STREAM_RX_START] (0x3E) for Device →
+ * App.
  */
 object StreamFrameCodec {
 
-    /** Wrap an outbound payload with the TX stream header. */
-    fun encodeTx(payload: ByteString): ByteString {
-        require(payload.size <= MAX_FRAME_SIZE) {
-            "payload exceeds $MAX_FRAME_SIZE bytes (${payload.size})"
-        }
-        return buildByteString {
-            writeByte(STREAM_TX_START)
-            writeShortLe(payload.size.toShort())
-            write(payload.toByteArray())
-        }
+  /** Wrap an outbound payload with the TX stream header. */
+  fun encodeTx(payload: ByteString): ByteString {
+    require(payload.size <= MAX_FRAME_SIZE) {
+      "payload exceeds $MAX_FRAME_SIZE bytes (${payload.size})"
+    }
+    return buildByteString {
+      writeByte(STREAM_TX_START)
+      writeShortLe(payload.size.toShort())
+      write(payload.toByteArray())
+    }
+  }
+
+  /**
+   * Stateful decoder: callers feed in bytes as they arrive from a stream transport, and get back
+   * zero or more fully-decoded payloads. Resyncs silently on stray bytes or oversized lengths.
+   * Internally buffers partial frames in a [Buffer].
+   */
+  class Decoder {
+    private val buf = Buffer()
+
+    fun reset() {
+      buf.clear()
     }
 
-    /**
-     * Stateful decoder: callers feed in bytes as they arrive from a
-     * stream transport, and get back zero or more fully-decoded payloads.
-     * Resyncs silently on stray bytes or oversized lengths. Internally
-     * buffers partial frames in a [Buffer].
-     */
-    class Decoder {
-        private val buf = Buffer()
-
-        fun reset() {
-            buf.clear()
-        }
-
-        fun ingest(bytes: ByteString): List<DecodedPacket> {
-            if (bytes.size == 0) return emptyList()
-            buf.write(bytes.toByteArray())
-            return drain()
-        }
-
-        fun ingest(bytes: ByteArray): List<DecodedPacket> {
-            if (bytes.isEmpty()) return emptyList()
-            buf.write(bytes)
-            return drain()
-        }
-
-        private fun drain(): List<DecodedPacket> {
-            val out = mutableListOf<DecodedPacket>()
-            while (true) {
-                if (buf.size == 0L) return out
-                // Peek the header without consuming.
-                val peek = buf.peek()
-                val head = peek.readByte()
-                if (head != STREAM_RX_START && head != STREAM_TX_START) {
-                    // Resync: drop a single byte and retry.
-                    buf.readByte()
-                    continue
-                }
-                if (buf.size < STREAM_HEADER_LEN.toLong()) return out
-                val lenPeek = buf.peek()
-                lenPeek.readByte() // skip start
-                val payloadLen = lenPeek.readU16Le()
-                if (payloadLen > MAX_FRAME_SIZE) {
-                    // Bogus length: drop start byte and resync.
-                    buf.readByte()
-                    continue
-                }
-                val total = STREAM_HEADER_LEN.toLong() + payloadLen.toLong()
-                if (buf.size < total) return out
-                // Consume one complete frame.
-                val start = buf.readByte()
-                buf.readShort() // length already validated
-                val payload = buf.readByteString(payloadLen)
-                out += DecodedPacket(start, payload)
-            }
-        }
+    fun ingest(bytes: ByteString): List<DecodedPacket> {
+      if (bytes.size == 0) return emptyList()
+      buf.write(bytes.toByteArray())
+      return drain()
     }
 
-    data class DecodedPacket(val start: Byte, val payload: ByteString) {
-        val isRx: Boolean get() = start == STREAM_RX_START
+    fun ingest(bytes: ByteArray): List<DecodedPacket> {
+      if (bytes.isEmpty()) return emptyList()
+      buf.write(bytes)
+      return drain()
     }
+
+    private fun drain(): List<DecodedPacket> {
+      val out = mutableListOf<DecodedPacket>()
+      while (true) {
+        if (buf.size == 0L) return out
+        // Peek the header without consuming.
+        val peek = buf.peek()
+        val head = peek.readByte()
+        if (head != STREAM_RX_START && head != STREAM_TX_START) {
+          // Resync: drop a single byte and retry.
+          buf.readByte()
+          continue
+        }
+        if (buf.size < STREAM_HEADER_LEN.toLong()) return out
+        val lenPeek = buf.peek()
+        lenPeek.readByte() // skip start
+        val payloadLen = lenPeek.readU16Le()
+        if (payloadLen > MAX_FRAME_SIZE) {
+          // Bogus length: drop start byte and resync.
+          buf.readByte()
+          continue
+        }
+        val total = STREAM_HEADER_LEN.toLong() + payloadLen.toLong()
+        if (buf.size < total) return out
+        // Consume one complete frame.
+        val start = buf.readByte()
+        buf.readShort() // length already validated
+        val payload = buf.readByteString(payloadLen)
+        out += DecodedPacket(start, payload)
+      }
+    }
+  }
+
+  data class DecodedPacket(val start: Byte, val payload: ByteString) {
+    val isRx: Boolean
+      get() = start == STREAM_RX_START
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/TextType.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/TextType.kt
@@ -1,22 +1,20 @@
 package ee.schimke.meshcore.core.protocol
 
 /**
- * Type of a text-message payload. The MeshCore protocol encodes this as
- * a single byte in both outbound `CMD_SEND_TXT_MSG` frames and inbound
- * message-receive responses.
+ * Type of a text-message payload. The MeshCore protocol encodes this as a single byte in both
+ * outbound `CMD_SEND_TXT_MSG` frames and inbound message-receive responses.
  */
 enum class TextType(val raw: Byte) {
-    Plain(0x00),
-    CliData(0x01);
+  Plain(0x00),
+  CliData(0x01);
 
-    companion object {
-        private val byRaw = entries.associateBy { it.raw }
+  companion object {
+    private val byRaw = entries.associateBy { it.raw }
 
-        /**
-         * Resolve [raw] to a known [TextType], or null if the protocol
-         * byte is not recognised. Callers decide whether to treat an
-         * unknown type as a parse error or a raw fallback.
-         */
-        fun fromRaw(raw: Int): TextType? = byRaw[(raw and 0xFF).toByte()]
-    }
+    /**
+     * Resolve [raw] to a known [TextType], or null if the protocol byte is not recognised. Callers
+     * decide whether to treat an unknown type as a parse error or a raw fallback.
+     */
+    fun fromRaw(raw: Int): TextType? = byRaw[(raw and 0xFF).toByte()]
+  }
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/transport/Transport.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/transport/Transport.kt
@@ -5,23 +5,22 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.io.bytestring.ByteString
 
 /**
- * Abstract I/O link to a MeshCore device. Concrete implementations wrap
- * BLE (Nordic UART), USB CDC-ACM, or TCP. Each [incoming] emission is one
- * complete MeshCore frame payload `[code][body...]` – stream-transport
- * framing has already been stripped.
+ * Abstract I/O link to a MeshCore device. Concrete implementations wrap BLE (Nordic UART), USB
+ * CDC-ACM, or TCP. Each [incoming] emission is one complete MeshCore frame payload (one `code` byte
+ * followed by body bytes) – stream-transport framing has already been stripped.
  */
 interface Transport {
-    val state: StateFlow<TransportState>
+  val state: StateFlow<TransportState>
 
-    /** Hot flow of decoded frame payloads. */
-    val incoming: SharedFlow<ByteString>
+  /** Hot flow of decoded frame payloads. */
+  val incoming: SharedFlow<ByteString>
 
-    /** Open the underlying link. Suspends until connected or throws. */
-    suspend fun connect()
+  /** Open the underlying link. Suspends until connected or throws. */
+  suspend fun connect()
 
-    /** Send a raw MeshCore frame `[code][body...]`. */
-    suspend fun send(frame: ByteString)
+  /** Send a raw MeshCore frame (one `code` byte followed by body bytes). */
+  suspend fun send(frame: ByteString)
 
-    /** Close the link and release resources. */
-    suspend fun close()
+  /** Close the link and release resources. */
+  suspend fun close()
 }

--- a/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/transport/TransportState.kt
+++ b/meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/transport/TransportState.kt
@@ -1,8 +1,11 @@
 package ee.schimke.meshcore.core.transport
 
 sealed class TransportState {
-    object Disconnected : TransportState()
-    object Connecting : TransportState()
-    object Connected : TransportState()
-    data class Error(val cause: Throwable) : TransportState()
+  object Disconnected : TransportState()
+
+  object Connecting : TransportState()
+
+  object Connected : TransportState()
+
+  data class Error(val cause: Throwable) : TransportState()
 }

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/client/MeshCoreClientTest.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/client/MeshCoreClientTest.kt
@@ -6,6 +6,12 @@ import ee.schimke.meshcore.core.model.SelfInfo
 import ee.schimke.meshcore.core.protocol.CommandCode
 import ee.schimke.meshcore.core.protocol.ResponseCode
 import ee.schimke.meshcore.core.test.FakeTransport
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -14,154 +20,155 @@ import kotlinx.io.Buffer
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.readByteString
 import kotlinx.io.writeIntLe
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class MeshCoreClientTest {
 
-    /**
-     * Build a minimal SelfInfo response frame:
-     *   [ResponseCode.SelfInfo][advType:u8][txPwr:i8][maxPwr:i8][pubkey:32][lat:i32le][lon:i32le]
-     *   [multiAcks:u8][advPolicy:u8][telemetry:u8][manualAdd:u8][freq:i32le][bw:i32le][sf:u8][cr:u8][name\0]
-     */
-    private fun selfInfoFrame(name: String = "test-node"): ByteString {
-        val buf = Buffer()
-        buf.writeByte(ResponseCode.SelfInfo.raw) // code
-        buf.writeByte(1)  // advType
-        buf.writeByte(14) // txPower
-        buf.writeByte(22) // maxPower
-        buf.write(ByteArray(32) { 0xAB.toByte() }) // public key
-        buf.writeIntLe(53_000_000)  // lat * 1_000_000
-        buf.writeIntLe(-1_500_000)  // lon * 1_000_000
-        buf.writeByte(0)  // multiAcks
-        buf.writeByte(0)  // advertLocationPolicy
-        buf.writeByte(0)  // telemetryFlags
-        buf.writeByte(0)  // manualAddContacts
-        buf.writeIntLe(869_525_000) // freq Hz
-        buf.writeIntLe(125_000)     // bandwidth Hz
-        buf.writeByte(10) // spreading factor
-        buf.writeByte(5)  // coding rate
-        buf.write(name.encodeToByteArray())
-        buf.writeByte(0)  // null terminator
-        return buf.readByteString()
+  /**
+   * Build a minimal SelfInfo response frame:
+   * [ResponseCode.SelfInfo][advType:u8][txPwr:i8][maxPwr:i8][pubkey:32][lat:i32le][lon:i32le]
+   * [multiAcks:u8][advPolicy:u8][telemetry:u8][manualAdd:u8][freq:i32le][bw:i32le][sf:u8][cr:u8][name\0]
+   */
+  private fun selfInfoFrame(name: String = "test-node"): ByteString {
+    val buf = Buffer()
+    buf.writeByte(ResponseCode.SelfInfo.raw) // code
+    buf.writeByte(1) // advType
+    buf.writeByte(14) // txPower
+    buf.writeByte(22) // maxPower
+    buf.write(ByteArray(32) { 0xAB.toByte() }) // public key
+    buf.writeIntLe(53_000_000) // lat * 1_000_000
+    buf.writeIntLe(-1_500_000) // lon * 1_000_000
+    buf.writeByte(0) // multiAcks
+    buf.writeByte(0) // advertLocationPolicy
+    buf.writeByte(0) // telemetryFlags
+    buf.writeByte(0) // manualAddContacts
+    buf.writeIntLe(869_525_000) // freq Hz
+    buf.writeIntLe(125_000) // bandwidth Hz
+    buf.writeByte(10) // spreading factor
+    buf.writeByte(5) // coding rate
+    buf.write(name.encodeToByteArray())
+    buf.writeByte(0) // null terminator
+    return buf.readByteString()
+  }
+
+  @Test
+  fun start_sendsAppStartFrame() =
+    runTest(UnconfinedTestDispatcher()) {
+      val transport = FakeTransport()
+      val client =
+        MeshCoreClient(transport, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+      // start() sends AppStart then waits for SelfInfo.
+      // With UnconfinedTestDispatcher the pump runs eagerly,
+      // so injecting a frame immediately satisfies the wait.
+      val job = launch { client.start(timeoutMs = 2_000) }
+      transport.receive(selfInfoFrame())
+      job.join()
+
+      // First sent frame should start with CommandCode.AppStart
+      assertTrue(transport.sentFrames.isNotEmpty(), "expected at least one sent frame")
+      assertEquals(CommandCode.AppStart.raw, transport.sentFrames[0][0])
+
+      client.stop()
     }
 
-    @Test
-    fun start_sendsAppStartFrame() = runTest(UnconfinedTestDispatcher()) {
-        val transport = FakeTransport()
-        val client = MeshCoreClient(transport, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+  @Test
+  fun start_timesOutWithoutSelfInfo() = runTest {
+    val transport = FakeTransport()
+    val client = MeshCoreClient(transport, backgroundScope)
 
-        // start() sends AppStart then waits for SelfInfo.
-        // With UnconfinedTestDispatcher the pump runs eagerly,
-        // so injecting a frame immediately satisfies the wait.
-        val job = launch {
-            client.start(timeoutMs = 2_000)
-        }
-        transport.receive(selfInfoFrame())
-        job.join()
+    // Don't inject any response — start() should throw
+    val ex = assertFailsWith<IllegalStateException> { client.start(timeoutMs = 500) }
+    assertTrue(ex.message!!.contains("No response"), "expected timeout message, got: ${ex.message}")
 
-        // First sent frame should start with CommandCode.AppStart
-        assertTrue(transport.sentFrames.isNotEmpty(), "expected at least one sent frame")
-        assertEquals(CommandCode.AppStart.raw, transport.sentFrames[0][0])
+    client.stop()
+  }
 
-        client.stop()
+  @Test
+  fun start_parsesSelfInfoResponse() =
+    runTest(UnconfinedTestDispatcher()) {
+      val transport = FakeTransport()
+      val client =
+        MeshCoreClient(transport, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+      assertNull(client.selfInfo.value, "selfInfo should be null before start")
+
+      val job = launch { client.start(timeoutMs = 2_000) }
+      transport.receive(selfInfoFrame("my-radio"))
+      job.join()
+
+      val info = client.selfInfo.value
+      assertNotNull(info, "selfInfo should be populated after start")
+      assertEquals("my-radio", info.name)
+      assertEquals(14, info.txPowerDbm)
+      assertEquals(869_525_000, info.radio.frequencyHz)
+
+      client.stop()
     }
 
-    @Test
-    fun start_timesOutWithoutSelfInfo() = runTest {
-        val transport = FakeTransport()
-        val client = MeshCoreClient(transport, backgroundScope)
+  @Test
+  fun seedFromCache_populatesEmptyStateFlows() = runTest {
+    val transport = FakeTransport()
+    val client = MeshCoreClient(transport, backgroundScope)
 
-        // Don't inject any response — start() should throw
-        val ex = assertFailsWith<IllegalStateException> {
-            client.start(timeoutMs = 500)
-        }
-        assertTrue(ex.message!!.contains("No response"), "expected timeout message, got: ${ex.message}")
+    val cachedSelf =
+      SelfInfo(
+        advertType = 1,
+        txPowerDbm = 10,
+        maxPowerDbm = 20,
+        publicKey =
+          ee.schimke.meshcore.core.model.PublicKey.fromBytes(ByteString(*ByteArray(32) { 0x01 })),
+        latitude = 51.0,
+        longitude = -0.1,
+        multiAcks = 0,
+        advertLocationPolicy = 0,
+        telemetryFlags = 0,
+        manualAddContacts = 0,
+        radio = RadioSettings(868_000_000, 125_000, 12, 5),
+        name = "cached-node",
+      )
+    val cachedBattery = BatteryInfo(3800, 100, 4096)
 
-        client.stop()
-    }
+    client.seedFromCache(selfInfo = cachedSelf, battery = cachedBattery)
 
-    @Test
-    fun start_parsesSelfInfoResponse() = runTest(UnconfinedTestDispatcher()) {
-        val transport = FakeTransport()
-        val client = MeshCoreClient(transport, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+    assertEquals("cached-node", client.selfInfo.value?.name)
+    assertEquals(3800, client.battery.value?.millivolts)
+    assertTrue(client.contacts.value.isEmpty(), "contacts should remain empty")
+  }
 
-        assertNull(client.selfInfo.value, "selfInfo should be null before start")
+  @Test
+  fun seedFromCache_doesNotOverrideLiveData() =
+    runTest(UnconfinedTestDispatcher()) {
+      val transport = FakeTransport()
+      val client =
+        MeshCoreClient(transport, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
 
-        val job = launch { client.start(timeoutMs = 2_000) }
-        transport.receive(selfInfoFrame("my-radio"))
-        job.join()
+      // Start and receive live SelfInfo
+      val job = launch { client.start(timeoutMs = 2_000) }
+      transport.receive(selfInfoFrame("live-node"))
+      job.join()
 
-        val info = client.selfInfo.value
-        assertNotNull(info, "selfInfo should be populated after start")
-        assertEquals("my-radio", info.name)
-        assertEquals(14, info.txPowerDbm)
-        assertEquals(869_525_000, info.radio.frequencyHz)
-
-        client.stop()
-    }
-
-    @Test
-    fun seedFromCache_populatesEmptyStateFlows() = runTest {
-        val transport = FakeTransport()
-        val client = MeshCoreClient(transport, backgroundScope)
-
-        val cachedSelf = SelfInfo(
-            advertType = 1,
-            txPowerDbm = 10,
-            maxPowerDbm = 20,
-            publicKey = ee.schimke.meshcore.core.model.PublicKey.fromBytes(
-                ByteString(*ByteArray(32) { 0x01 }),
-            ),
-            latitude = 51.0,
-            longitude = -0.1,
-            multiAcks = 0,
-            advertLocationPolicy = 0,
-            telemetryFlags = 0,
-            manualAddContacts = 0,
-            radio = RadioSettings(868_000_000, 125_000, 12, 5),
-            name = "cached-node",
+      // Now seed with different cached data — should NOT override
+      val cached =
+        SelfInfo(
+          advertType = 1,
+          txPowerDbm = 0,
+          maxPowerDbm = 0,
+          publicKey =
+            ee.schimke.meshcore.core.model.PublicKey.fromBytes(ByteString(*ByteArray(32) { 0x00 })),
+          latitude = 0.0,
+          longitude = 0.0,
+          multiAcks = 0,
+          advertLocationPolicy = 0,
+          telemetryFlags = 0,
+          manualAddContacts = 0,
+          radio = RadioSettings(0, 0, 0, 0),
+          name = "stale-cached",
         )
-        val cachedBattery = BatteryInfo(3800, 100, 4096)
+      client.seedFromCache(selfInfo = cached)
 
-        client.seedFromCache(selfInfo = cachedSelf, battery = cachedBattery)
+      assertEquals("live-node", client.selfInfo.value?.name, "live data should not be overridden")
 
-        assertEquals("cached-node", client.selfInfo.value?.name)
-        assertEquals(3800, client.battery.value?.millivolts)
-        assertTrue(client.contacts.value.isEmpty(), "contacts should remain empty")
-    }
-
-    @Test
-    fun seedFromCache_doesNotOverrideLiveData() = runTest(UnconfinedTestDispatcher()) {
-        val transport = FakeTransport()
-        val client = MeshCoreClient(transport, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
-
-        // Start and receive live SelfInfo
-        val job = launch { client.start(timeoutMs = 2_000) }
-        transport.receive(selfInfoFrame("live-node"))
-        job.join()
-
-        // Now seed with different cached data — should NOT override
-        val cached = SelfInfo(
-            advertType = 1, txPowerDbm = 0, maxPowerDbm = 0,
-            publicKey = ee.schimke.meshcore.core.model.PublicKey.fromBytes(
-                ByteString(*ByteArray(32) { 0x00 }),
-            ),
-            latitude = 0.0, longitude = 0.0,
-            multiAcks = 0, advertLocationPolicy = 0,
-            telemetryFlags = 0, manualAddContacts = 0,
-            radio = RadioSettings(0, 0, 0, 0),
-            name = "stale-cached",
-        )
-        client.seedFromCache(selfInfo = cached)
-
-        assertEquals("live-node", client.selfInfo.value?.name, "live data should not be overridden")
-
-        client.stop()
+      client.stop()
     }
 }

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/protocol/ParsersTest.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/protocol/ParsersTest.kt
@@ -1,68 +1,74 @@
 package ee.schimke.meshcore.core.protocol
 
 import ee.schimke.meshcore.core.model.MeshEvent
-import kotlinx.io.bytestring.ByteString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.io.bytestring.ByteString
 
 class ParsersTest {
 
-    @Test
-    fun parse_ok() {
-        val ev = Parsers.parse(ByteString(ResponseCode.Ok.raw))
-        assertTrue(ev is MeshEvent.Ok)
-    }
+  @Test
+  fun parse_ok() {
+    val ev = Parsers.parse(ByteString(ResponseCode.Ok.raw))
+    assertTrue(ev is MeshEvent.Ok)
+  }
 
-    @Test
-    fun parse_err_withCode() {
-        val ev = Parsers.parse(ByteString(ResponseCode.Err.raw, 2))
-        assertTrue(ev is MeshEvent.Err)
-        assertEquals(2, ev.code)
-    }
+  @Test
+  fun parse_err_withCode() {
+    val ev = Parsers.parse(ByteString(ResponseCode.Err.raw, 2))
+    assertTrue(ev is MeshEvent.Err)
+    assertEquals(2, ev.code)
+  }
 
-    @Test
-    fun parse_batteryAndStorage() {
-        val bytes = ByteArray(1 + 2 + 4 + 4)
-        bytes[0] = ResponseCode.BatteryAndStorage.raw
-        bytes[1] = (3800 and 0xFF).toByte()
-        bytes[2] = ((3800 shr 8) and 0xFF).toByte()
-        bytes[3] = 0; bytes[4] = 2; bytes[5] = 0; bytes[6] = 0
-        bytes[7] = 0; bytes[8] = 16; bytes[9] = 0; bytes[10] = 0
-        val ev = Parsers.parse(ByteString(*bytes)) as MeshEvent.Battery
-        assertEquals(3800, ev.info.millivolts)
-        assertEquals(512, ev.info.storageUsedKb)
-        assertEquals(4096, ev.info.storageTotalKb)
-    }
+  @Test
+  fun parse_batteryAndStorage() {
+    val bytes = ByteArray(1 + 2 + 4 + 4)
+    bytes[0] = ResponseCode.BatteryAndStorage.raw
+    bytes[1] = (3800 and 0xFF).toByte()
+    bytes[2] = ((3800 shr 8) and 0xFF).toByte()
+    bytes[3] = 0
+    bytes[4] = 2
+    bytes[5] = 0
+    bytes[6] = 0
+    bytes[7] = 0
+    bytes[8] = 16
+    bytes[9] = 0
+    bytes[10] = 0
+    val ev = Parsers.parse(ByteString(*bytes)) as MeshEvent.Battery
+    assertEquals(3800, ev.info.millivolts)
+    assertEquals(512, ev.info.storageUsedKb)
+    assertEquals(4096, ev.info.storageTotalKb)
+  }
 
-    @Test
-    fun parse_radioSettings() {
-        val bytes = ByteArray(1 + 4 + 4 + 1 + 1)
-        bytes[0] = ResponseCode.RadioSettings.raw
-        val freq = 915_000_000
-        bytes[1] = (freq and 0xFF).toByte()
-        bytes[2] = ((freq ushr 8) and 0xFF).toByte()
-        bytes[3] = ((freq ushr 16) and 0xFF).toByte()
-        bytes[4] = ((freq ushr 24) and 0xFF).toByte()
-        val bw = 125_000
-        bytes[5] = (bw and 0xFF).toByte()
-        bytes[6] = ((bw ushr 8) and 0xFF).toByte()
-        bytes[7] = ((bw ushr 16) and 0xFF).toByte()
-        bytes[8] = ((bw ushr 24) and 0xFF).toByte()
-        bytes[9] = 7
-        bytes[10] = 5
-        val ev = Parsers.parse(ByteString(*bytes)) as MeshEvent.Radio
-        assertEquals(915_000_000, ev.settings.frequencyHz)
-        assertEquals(125_000, ev.settings.bandwidthHz)
-        assertEquals(7, ev.settings.spreadingFactor)
-        assertEquals(5, ev.settings.codingRate)
-    }
+  @Test
+  fun parse_radioSettings() {
+    val bytes = ByteArray(1 + 4 + 4 + 1 + 1)
+    bytes[0] = ResponseCode.RadioSettings.raw
+    val freq = 915_000_000
+    bytes[1] = (freq and 0xFF).toByte()
+    bytes[2] = ((freq ushr 8) and 0xFF).toByte()
+    bytes[3] = ((freq ushr 16) and 0xFF).toByte()
+    bytes[4] = ((freq ushr 24) and 0xFF).toByte()
+    val bw = 125_000
+    bytes[5] = (bw and 0xFF).toByte()
+    bytes[6] = ((bw ushr 8) and 0xFF).toByte()
+    bytes[7] = ((bw ushr 16) and 0xFF).toByte()
+    bytes[8] = ((bw ushr 24) and 0xFF).toByte()
+    bytes[9] = 7
+    bytes[10] = 5
+    val ev = Parsers.parse(ByteString(*bytes)) as MeshEvent.Radio
+    assertEquals(915_000_000, ev.settings.frequencyHz)
+    assertEquals(125_000, ev.settings.bandwidthHz)
+    assertEquals(7, ev.settings.spreadingFactor)
+    assertEquals(5, ev.settings.codingRate)
+  }
 
-    @Test
-    fun parse_unknownBecomesRaw() {
-        val ev = Parsers.parse(ByteString(0x7F, 1, 2, 3))
-        assertTrue(ev is MeshEvent.Raw)
-        assertEquals(0x7F.toByte(), ev.code)
-        assertEquals(3, ev.body.size)
-    }
+  @Test
+  fun parse_unknownBecomesRaw() {
+    val ev = Parsers.parse(ByteString(0x7F, 1, 2, 3))
+    assertTrue(ev is MeshEvent.Raw)
+    assertEquals(0x7F.toByte(), ev.code)
+    assertEquals(3, ev.body.size)
+  }
 }

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/protocol/StreamFrameCodecTest.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/protocol/StreamFrameCodecTest.kt
@@ -1,158 +1,173 @@
 package ee.schimke.meshcore.core.protocol
 
-import kotlinx.io.bytestring.ByteString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlinx.io.bytestring.ByteString
 
 class StreamFrameCodecTest {
 
-    @Test
-    fun encodeTx_prependsHeader() {
-        val payload = ByteString(0x01, 0x02, 0x03)
-        val framed = StreamFrameCodec.encodeTx(payload).toByteArray()
-        assertEquals(6, framed.size)
-        assertEquals(MeshCoreConstants.STREAM_TX_START, framed[0])
-        assertEquals(3, framed[1].toInt())
-        assertEquals(0, framed[2].toInt())
-        assertTrue(payload.toByteArray().contentEquals(framed.copyOfRange(3, 6)))
-    }
+  @Test
+  fun encodeTx_prependsHeader() {
+    val payload = ByteString(0x01, 0x02, 0x03)
+    val framed = StreamFrameCodec.encodeTx(payload).toByteArray()
+    assertEquals(6, framed.size)
+    assertEquals(MeshCoreConstants.STREAM_TX_START, framed[0])
+    assertEquals(3, framed[1].toInt())
+    assertEquals(0, framed[2].toInt())
+    assertTrue(payload.toByteArray().contentEquals(framed.copyOfRange(3, 6)))
+  }
 
-    @Test
-    fun decoder_singleRxFrame() {
-        val payload = ByteString(0x05, 0x10, 0x20, 0x30)
-        val bytes = byteArrayOf(
-            MeshCoreConstants.STREAM_RX_START,
-            payload.size.toByte(), 0,
-            *payload.toByteArray(),
+  @Test
+  fun decoder_singleRxFrame() {
+    val payload = ByteString(0x05, 0x10, 0x20, 0x30)
+    val bytes =
+      byteArrayOf(
+        MeshCoreConstants.STREAM_RX_START,
+        payload.size.toByte(),
+        0,
+        *payload.toByteArray(),
+      )
+    val packets = StreamFrameCodec.Decoder().ingest(bytes)
+    assertEquals(1, packets.size)
+    assertTrue(packets[0].isRx)
+    assertEquals(payload, packets[0].payload)
+  }
+
+  @Test
+  fun decoder_splitAcrossIngests() {
+    val payload = ByteString(*ByteArray(10) { it.toByte() })
+    val full =
+      byteArrayOf(
+        MeshCoreConstants.STREAM_RX_START,
+        payload.size.toByte(),
+        0,
+        *payload.toByteArray(),
+      )
+    val decoder = StreamFrameCodec.Decoder()
+    assertEquals(0, decoder.ingest(full.copyOfRange(0, 4)).size)
+    val pkts = decoder.ingest(full.copyOfRange(4, full.size))
+    assertEquals(1, pkts.size)
+    assertEquals(payload, pkts[0].payload)
+  }
+
+  @Test
+  fun decoder_resyncsOnJunk() {
+    val payload = ByteString(0x05, 0x06)
+    val bytes =
+      byteArrayOf(
+        0x00,
+        0x11,
+        0x22, // junk
+        MeshCoreConstants.STREAM_RX_START,
+        payload.size.toByte(),
+        0,
+        *payload.toByteArray(),
+      )
+    val pkts = StreamFrameCodec.Decoder().ingest(bytes)
+    assertEquals(1, pkts.size)
+    assertEquals(payload, pkts[0].payload)
+  }
+
+  @Test
+  fun decoder_multipleFramesInOneIngest() {
+    fun frame(p: ByteArray): ByteArray =
+      byteArrayOf(MeshCoreConstants.STREAM_RX_START, p.size.toByte(), 0, *p)
+    val a = byteArrayOf(0x01, 0x02)
+    val b = byteArrayOf(0x0A, 0x0B, 0x0C)
+    val pkts = StreamFrameCodec.Decoder().ingest(frame(a) + frame(b))
+    assertEquals(2, pkts.size)
+    assertEquals(ByteString(*a), pkts[0].payload)
+    assertEquals(ByteString(*b), pkts[1].payload)
+  }
+
+  @Test
+  fun decoder_oversizedFrame_isDropped() {
+    // Build a frame whose length field exceeds MAX_FRAME_SIZE.
+    // The decoder should drop the start byte and resync.
+    val oversizedLen = MeshCoreConstants.MAX_FRAME_SIZE + 1
+    val header =
+      byteArrayOf(
+        MeshCoreConstants.STREAM_RX_START,
+        (oversizedLen and 0xFF).toByte(),
+        ((oversizedLen shr 8) and 0xFF).toByte(),
+      )
+    // Follow with a valid frame so we can verify resync worked
+    val validPayload = ByteString(0xAA.toByte())
+    val valid =
+      byteArrayOf(
+        MeshCoreConstants.STREAM_RX_START,
+        validPayload.size.toByte(),
+        0,
+        *validPayload.toByteArray(),
+      )
+    val pkts = StreamFrameCodec.Decoder().ingest(header + ByteArray(oversizedLen) + valid)
+    assertEquals(1, pkts.size)
+    assertEquals(validPayload, pkts[0].payload)
+  }
+
+  @Test
+  fun decoder_zeroLengthFrame() {
+    val bytes =
+      byteArrayOf(
+        MeshCoreConstants.STREAM_RX_START,
+        0,
+        0, // zero-length payload
+      )
+    val pkts = StreamFrameCodec.Decoder().ingest(bytes)
+    assertEquals(1, pkts.size)
+    assertEquals(ByteString(), pkts[0].payload)
+  }
+
+  @Test
+  fun decoder_partialHeaderOnly_returnsEmpty() {
+    val decoder = StreamFrameCodec.Decoder()
+    // Only 2 of the 3 header bytes — decoder should buffer and return nothing
+    val pkts = decoder.ingest(byteArrayOf(MeshCoreConstants.STREAM_RX_START, 0x05))
+    assertEquals(0, pkts.size)
+  }
+
+  @Test
+  fun decoder_interleavedJunkBetweenValidFrames() {
+    fun frame(vararg payload: Byte): ByteArray =
+      byteArrayOf(MeshCoreConstants.STREAM_RX_START, payload.size.toByte(), 0, *payload)
+    val input = frame(0x01) + byteArrayOf(0xFF.toByte(), 0xFE.toByte()) + frame(0x02)
+    val pkts = StreamFrameCodec.Decoder().ingest(input)
+    assertEquals(2, pkts.size)
+    assertEquals(ByteString(0x01), pkts[0].payload)
+    assertEquals(ByteString(0x02), pkts[1].payload)
+  }
+
+  @Test
+  fun encodeTx_maxSizeBoundary() {
+    val maxPayload = ByteString(*ByteArray(MeshCoreConstants.MAX_FRAME_SIZE) { 0x42 })
+    val framed = StreamFrameCodec.encodeTx(maxPayload)
+    assertEquals(MeshCoreConstants.MAX_FRAME_SIZE + 3, framed.size)
+
+    // One byte over should throw
+    val oversize = ByteString(*ByteArray(MeshCoreConstants.MAX_FRAME_SIZE + 1) { 0x42 })
+    assertFailsWith<IllegalArgumentException> { StreamFrameCodec.encodeTx(oversize) }
+  }
+
+  @Test
+  fun decoder_reset_clearsBufferedState() {
+    val decoder = StreamFrameCodec.Decoder()
+    // Feed a partial frame
+    decoder.ingest(byteArrayOf(MeshCoreConstants.STREAM_RX_START, 0x05, 0x00))
+    decoder.reset()
+    // Now feed a complete, different frame — should decode cleanly
+    val payload = ByteString(0xBB.toByte())
+    val pkts =
+      decoder.ingest(
+        byteArrayOf(
+          MeshCoreConstants.STREAM_RX_START,
+          payload.size.toByte(),
+          0,
+          *payload.toByteArray(),
         )
-        val packets = StreamFrameCodec.Decoder().ingest(bytes)
-        assertEquals(1, packets.size)
-        assertTrue(packets[0].isRx)
-        assertEquals(payload, packets[0].payload)
-    }
-
-    @Test
-    fun decoder_splitAcrossIngests() {
-        val payload = ByteString(*ByteArray(10) { it.toByte() })
-        val full = byteArrayOf(
-            MeshCoreConstants.STREAM_RX_START,
-            payload.size.toByte(), 0,
-            *payload.toByteArray(),
-        )
-        val decoder = StreamFrameCodec.Decoder()
-        assertEquals(0, decoder.ingest(full.copyOfRange(0, 4)).size)
-        val pkts = decoder.ingest(full.copyOfRange(4, full.size))
-        assertEquals(1, pkts.size)
-        assertEquals(payload, pkts[0].payload)
-    }
-
-    @Test
-    fun decoder_resyncsOnJunk() {
-        val payload = ByteString(0x05, 0x06)
-        val bytes = byteArrayOf(
-            0x00, 0x11, 0x22, // junk
-            MeshCoreConstants.STREAM_RX_START,
-            payload.size.toByte(), 0,
-            *payload.toByteArray(),
-        )
-        val pkts = StreamFrameCodec.Decoder().ingest(bytes)
-        assertEquals(1, pkts.size)
-        assertEquals(payload, pkts[0].payload)
-    }
-
-    @Test
-    fun decoder_multipleFramesInOneIngest() {
-        fun frame(p: ByteArray): ByteArray =
-            byteArrayOf(MeshCoreConstants.STREAM_RX_START, p.size.toByte(), 0, *p)
-        val a = byteArrayOf(0x01, 0x02)
-        val b = byteArrayOf(0x0A, 0x0B, 0x0C)
-        val pkts = StreamFrameCodec.Decoder().ingest(frame(a) + frame(b))
-        assertEquals(2, pkts.size)
-        assertEquals(ByteString(*a), pkts[0].payload)
-        assertEquals(ByteString(*b), pkts[1].payload)
-    }
-
-    @Test
-    fun decoder_oversizedFrame_isDropped() {
-        // Build a frame whose length field exceeds MAX_FRAME_SIZE.
-        // The decoder should drop the start byte and resync.
-        val oversizedLen = MeshCoreConstants.MAX_FRAME_SIZE + 1
-        val header = byteArrayOf(
-            MeshCoreConstants.STREAM_RX_START,
-            (oversizedLen and 0xFF).toByte(),
-            ((oversizedLen shr 8) and 0xFF).toByte(),
-        )
-        // Follow with a valid frame so we can verify resync worked
-        val validPayload = ByteString(0xAA.toByte())
-        val valid = byteArrayOf(
-            MeshCoreConstants.STREAM_RX_START,
-            validPayload.size.toByte(), 0,
-            *validPayload.toByteArray(),
-        )
-        val pkts = StreamFrameCodec.Decoder().ingest(header + ByteArray(oversizedLen) + valid)
-        assertEquals(1, pkts.size)
-        assertEquals(validPayload, pkts[0].payload)
-    }
-
-    @Test
-    fun decoder_zeroLengthFrame() {
-        val bytes = byteArrayOf(
-            MeshCoreConstants.STREAM_RX_START,
-            0, 0, // zero-length payload
-        )
-        val pkts = StreamFrameCodec.Decoder().ingest(bytes)
-        assertEquals(1, pkts.size)
-        assertEquals(ByteString(), pkts[0].payload)
-    }
-
-    @Test
-    fun decoder_partialHeaderOnly_returnsEmpty() {
-        val decoder = StreamFrameCodec.Decoder()
-        // Only 2 of the 3 header bytes — decoder should buffer and return nothing
-        val pkts = decoder.ingest(byteArrayOf(MeshCoreConstants.STREAM_RX_START, 0x05))
-        assertEquals(0, pkts.size)
-    }
-
-    @Test
-    fun decoder_interleavedJunkBetweenValidFrames() {
-        fun frame(vararg payload: Byte): ByteArray =
-            byteArrayOf(MeshCoreConstants.STREAM_RX_START, payload.size.toByte(), 0, *payload)
-        val input = frame(0x01) + byteArrayOf(0xFF.toByte(), 0xFE.toByte()) + frame(0x02)
-        val pkts = StreamFrameCodec.Decoder().ingest(input)
-        assertEquals(2, pkts.size)
-        assertEquals(ByteString(0x01), pkts[0].payload)
-        assertEquals(ByteString(0x02), pkts[1].payload)
-    }
-
-    @Test
-    fun encodeTx_maxSizeBoundary() {
-        val maxPayload = ByteString(*ByteArray(MeshCoreConstants.MAX_FRAME_SIZE) { 0x42 })
-        val framed = StreamFrameCodec.encodeTx(maxPayload)
-        assertEquals(MeshCoreConstants.MAX_FRAME_SIZE + 3, framed.size)
-
-        // One byte over should throw
-        val oversize = ByteString(*ByteArray(MeshCoreConstants.MAX_FRAME_SIZE + 1) { 0x42 })
-        assertFailsWith<IllegalArgumentException> {
-            StreamFrameCodec.encodeTx(oversize)
-        }
-    }
-
-    @Test
-    fun decoder_reset_clearsBufferedState() {
-        val decoder = StreamFrameCodec.Decoder()
-        // Feed a partial frame
-        decoder.ingest(byteArrayOf(MeshCoreConstants.STREAM_RX_START, 0x05, 0x00))
-        decoder.reset()
-        // Now feed a complete, different frame — should decode cleanly
-        val payload = ByteString(0xBB.toByte())
-        val pkts = decoder.ingest(byteArrayOf(
-            MeshCoreConstants.STREAM_RX_START,
-            payload.size.toByte(), 0,
-            *payload.toByteArray(),
-        ))
-        assertEquals(1, pkts.size)
-        assertEquals(payload, pkts[0].payload)
-    }
+      )
+    assertEquals(1, pkts.size)
+    assertEquals(payload, pkts[0].payload)
+  }
 }

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/test/FakeTransport.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/test/FakeTransport.kt
@@ -11,32 +11,32 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.io.bytestring.ByteString
 
 /**
- * In-memory [Transport] for tests. Records outbound frames in [sentFrames]
- * and lets the test inject inbound frames via [receive].
+ * In-memory [Transport] for tests. Records outbound frames in [sentFrames] and lets the test inject
+ * inbound frames via [receive].
  */
 class FakeTransport : Transport {
-    private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
-    override val state: StateFlow<TransportState> = _state.asStateFlow()
+  private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
+  override val state: StateFlow<TransportState> = _state.asStateFlow()
 
-    private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
-    override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
+  private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
+  override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
 
-    val sentFrames = mutableListOf<ByteString>()
+  val sentFrames = mutableListOf<ByteString>()
 
-    override suspend fun connect() {
-        _state.value = TransportState.Connected
-    }
+  override suspend fun connect() {
+    _state.value = TransportState.Connected
+  }
 
-    override suspend fun send(frame: ByteString) {
-        sentFrames += frame
-    }
+  override suspend fun send(frame: ByteString) {
+    sentFrames += frame
+  }
 
-    override suspend fun close() {
-        _state.value = TransportState.Disconnected
-    }
+  override suspend fun close() {
+    _state.value = TransportState.Disconnected
+  }
 
-    /** Simulate a frame arriving from the device side. */
-    suspend fun receive(frame: ByteString) {
-        _incoming.emit(frame)
-    }
+  /** Simulate a frame arriving from the device side. */
+  suspend fun receive(frame: ByteString) {
+    _incoming.emit(frame)
+  }
 }

--- a/meshcore-core/src/jvmTest/kotlin/ee/schimke/meshcore/core/protocol/TraceParsersTest.kt
+++ b/meshcore-core/src/jvmTest/kotlin/ee/schimke/meshcore/core/protocol/TraceParsersTest.kt
@@ -1,81 +1,79 @@
 package ee.schimke.meshcore.core.protocol
 
 import ee.schimke.meshcore.core.model.MeshEvent
-import kotlinx.io.bytestring.ByteString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.io.bytestring.ByteString
 
 /**
- * Replays real wire traces captured from the upstream Python `meshcore-cli`
- * against our parser and verifies the expected event sequence. The fixtures
- * under `resources/traces/` contain one received hex frame per line;
- * outgoing frames are captured locally under `traces/` (gitignored) but are
- * not shipped.
+ * Replays real wire traces captured from the upstream Python `meshcore-cli` against our parser and
+ * verifies the expected event sequence. The fixtures under `resources/traces/` contain one received
+ * hex frame per line; outgoing frames are captured locally under `traces/` (gitignored) but are not
+ * shipped.
  */
 class TraceParsersTest {
 
-    @Test
-    fun startup_yields_selfInfo_and_deviceInfo() {
-        val events = parseTrace("startup.rx")
-        // A typical infos run is: SelfInfo, DeviceInfo, [SelfInfo again].
-        assertTrue(events.any { it is MeshEvent.SelfInfoEvent }, "expected SelfInfo in startup trace")
-        assertTrue(events.any { it is MeshEvent.Device }, "expected DeviceInfo in startup trace")
-    }
+  @Test
+  fun startup_yields_selfInfo_and_deviceInfo() {
+    val events = parseTrace("startup.rx")
+    // A typical infos run is: SelfInfo, DeviceInfo, [SelfInfo again].
+    assertTrue(events.any { it is MeshEvent.SelfInfoEvent }, "expected SelfInfo in startup trace")
+    assertTrue(events.any { it is MeshEvent.Device }, "expected DeviceInfo in startup trace")
+  }
 
-    @Test
-    fun all_features_trace_has_no_raws_for_known_codes() {
-        val events = parseTrace("all_features.rx")
-        // Count the flavours we expect to see.
-        val contactStarts = events.count { it is MeshEvent.ContactsStart }
-        val contacts = events.count { it is MeshEvent.ContactEvent }
-        val eocs = events.count { it is MeshEvent.EndOfContacts }
-        val channels = events.count { it is MeshEvent.ChannelInfoEvent }
-        assertTrue(contactStarts >= 1, "ContactsStart missing")
-        assertTrue(contacts >= 1, "no Contact events parsed")
-        assertTrue(eocs >= 1, "EndOfContacts missing")
-        assertTrue(channels >= 1, "no ChannelInfo events parsed")
-    }
+  @Test
+  fun all_features_trace_has_no_raws_for_known_codes() {
+    val events = parseTrace("all_features.rx")
+    // Count the flavours we expect to see.
+    val contactStarts = events.count { it is MeshEvent.ContactsStart }
+    val contacts = events.count { it is MeshEvent.ContactEvent }
+    val eocs = events.count { it is MeshEvent.EndOfContacts }
+    val channels = events.count { it is MeshEvent.ChannelInfoEvent }
+    assertTrue(contactStarts >= 1, "ContactsStart missing")
+    assertTrue(contacts >= 1, "no Contact events parsed")
+    assertTrue(eocs >= 1, "EndOfContacts missing")
+    assertTrue(channels >= 1, "no ChannelInfo events parsed")
+  }
 
-    @Test
-    fun login_room_trace_has_loginSuccess_with_expected_prefix() {
-        val events = parseTrace("login_room.rx")
-        val ok = events.filterIsInstance<MeshEvent.LoginSuccess>()
-        assertEquals(1, ok.size, "expected exactly one LoginSuccess in successful-login trace")
-        // Kodu Room pubkey prefix is the first six bytes of f1f680c13cb6…
-        assertEquals("f1f680c13cb6", ok[0].publicKey.toHex())
-    }
+  @Test
+  fun login_room_trace_has_loginSuccess_with_expected_prefix() {
+    val events = parseTrace("login_room.rx")
+    val ok = events.filterIsInstance<MeshEvent.LoginSuccess>()
+    assertEquals(1, ok.size, "expected exactly one LoginSuccess in successful-login trace")
+    // Kodu Room pubkey prefix is the first six bytes of f1f680c13cb6…
+    assertEquals("f1f680c13cb6", ok[0].publicKey.toHex())
+  }
 
-    @Test
-    fun login_fail_trace_contains_no_loginSuccess() {
-        val events = parseTrace("login_fail.rx")
-        // Real room servers silently drop bad passwords, so we see RX-log pushes
-        // (0x88 → Raw) but never a LoginSuccess nor LoginFail.
-        assertTrue(
-            events.none { it is MeshEvent.LoginSuccess },
-            "unexpected LoginSuccess in login-fail trace",
-        )
-    }
+  @Test
+  fun login_fail_trace_contains_no_loginSuccess() {
+    val events = parseTrace("login_fail.rx")
+    // Real room servers silently drop bad passwords, so we see RX-log pushes
+    // (0x88 → Raw) but never a LoginSuccess nor LoginFail.
+    assertTrue(
+      events.none { it is MeshEvent.LoginSuccess },
+      "unexpected LoginSuccess in login-fail trace",
+    )
+  }
 
-    // ── Helpers ─────────────────────────────────────────────────────────────
+  // ── Helpers ─────────────────────────────────────────────────────────────
 
-    private fun parseTrace(name: String): List<MeshEvent> {
-        val stream = javaClass.classLoader.getResourceAsStream("traces/$name")
-            ?: fail("fixture not found on classpath: traces/$name")
-        return stream.bufferedReader().useLines { lines ->
-            lines.filter { it.isNotBlank() }
-                .map { Parsers.parse(hexDecode(it.trim())) }
-                .toList()
-        }
+  private fun parseTrace(name: String): List<MeshEvent> {
+    val stream =
+      javaClass.classLoader.getResourceAsStream("traces/$name")
+        ?: fail("fixture not found on classpath: traces/$name")
+    return stream.bufferedReader().useLines { lines ->
+      lines.filter { it.isNotBlank() }.map { Parsers.parse(hexDecode(it.trim())) }.toList()
     }
+  }
 
-    private fun hexDecode(hex: String): ByteString {
-        require(hex.length % 2 == 0) { "odd-length hex: '$hex'" }
-        val out = ByteArray(hex.length / 2)
-        for (i in out.indices) {
-            out[i] = ((hex[2 * i].digitToInt(16) shl 4) or hex[2 * i + 1].digitToInt(16)).toByte()
-        }
-        return ByteString(*out)
+  private fun hexDecode(hex: String): ByteString {
+    require(hex.length % 2 == 0) { "odd-length hex: '$hex'" }
+    val out = ByteArray(hex.length / 2)
+    for (i in out.indices) {
+      out[i] = ((hex[2 * i].digitToInt(16) shl 4) or hex[2 * i + 1].digitToInt(16)).toByte()
     }
+    return ByteString(*out)
+  }
 }

--- a/meshcore-data/build.gradle.kts
+++ b/meshcore-data/build.gradle.kts
@@ -1,34 +1,30 @@
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKotlinMultiplatformLibrary)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.room)
+  alias(libs.plugins.kotlinMultiplatform)
+  alias(libs.plugins.androidKotlinMultiplatformLibrary)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.room)
 }
 
 kotlin {
-    jvmToolchain(21)
+  jvmToolchain(21)
 
-    android {
-        namespace = "ee.schimke.meshcore.data"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
+  android {
+    namespace = "ee.schimke.meshcore.data"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  jvm()
+
+  sourceSets {
+    commonMain.dependencies {
+      api(projects.meshcoreCore)
+      implementation(libs.room.runtime)
+      implementation(libs.sqlite.bundled)
+      implementation(libs.kotlinx.coroutines.core)
     }
-    jvm()
-
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.meshcoreCore)
-            implementation(libs.room.runtime)
-            implementation(libs.sqlite.bundled)
-            implementation(libs.kotlinx.coroutines.core)
-        }
-    }
+  }
 }
 
-room {
-    schemaDirectory("$projectDir/schemas")
-}
+room { schemaDirectory("$projectDir/schemas") }
 
-dependencies {
-    ksp(libs.room.compiler)
-}
+dependencies { ksp(libs.room.compiler) }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/MeshcoreDatabase.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/MeshcoreDatabase.kt
@@ -16,21 +16,26 @@ import ee.schimke.meshcore.data.entity.DeviceStateEntity
 import ee.schimke.meshcore.data.entity.MessageEntity
 
 @Database(
-    entities = [
-        DeviceEntity::class,
-        DeviceStateEntity::class,
-        ContactEntity::class,
-        ChannelEntity::class,
-        MessageEntity::class,
+  entities =
+    [
+      DeviceEntity::class,
+      DeviceStateEntity::class,
+      ContactEntity::class,
+      ChannelEntity::class,
+      MessageEntity::class,
     ],
-    version = 1,
-    exportSchema = true,
+  version = 1,
+  exportSchema = true,
 )
 @TypeConverters(MeshConverters::class)
 abstract class MeshcoreDatabase : RoomDatabase() {
-    abstract fun deviceDao(): DeviceDao
-    abstract fun deviceStateDao(): DeviceStateDao
-    abstract fun contactDao(): ContactDao
-    abstract fun channelDao(): ChannelDao
-    abstract fun messageDao(): MessageDao
+  abstract fun deviceDao(): DeviceDao
+
+  abstract fun deviceStateDao(): DeviceStateDao
+
+  abstract fun contactDao(): ContactDao
+
+  abstract fun channelDao(): ChannelDao
+
+  abstract fun messageDao(): MessageDao
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/converter/MeshConverters.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/converter/MeshConverters.kt
@@ -7,15 +7,19 @@ import ee.schimke.meshcore.data.entity.MessageStatus
 import ee.schimke.meshcore.data.entity.TransportType
 
 class MeshConverters {
-    @TypeConverter fun fromTransportType(v: TransportType): String = v.name
-    @TypeConverter fun toTransportType(v: String): TransportType = TransportType.valueOf(v)
+  @TypeConverter fun fromTransportType(v: TransportType): String = v.name
 
-    @TypeConverter fun fromMessageKind(v: MessageKind): String = v.name
-    @TypeConverter fun toMessageKind(v: String): MessageKind = MessageKind.valueOf(v)
+  @TypeConverter fun toTransportType(v: String): TransportType = TransportType.valueOf(v)
 
-    @TypeConverter fun fromMessageDirection(v: MessageDirection): String = v.name
-    @TypeConverter fun toMessageDirection(v: String): MessageDirection = MessageDirection.valueOf(v)
+  @TypeConverter fun fromMessageKind(v: MessageKind): String = v.name
 
-    @TypeConverter fun fromMessageStatus(v: MessageStatus): String = v.name
-    @TypeConverter fun toMessageStatus(v: String): MessageStatus = MessageStatus.valueOf(v)
+  @TypeConverter fun toMessageKind(v: String): MessageKind = MessageKind.valueOf(v)
+
+  @TypeConverter fun fromMessageDirection(v: MessageDirection): String = v.name
+
+  @TypeConverter fun toMessageDirection(v: String): MessageDirection = MessageDirection.valueOf(v)
+
+  @TypeConverter fun fromMessageStatus(v: MessageStatus): String = v.name
+
+  @TypeConverter fun toMessageStatus(v: String): MessageStatus = MessageStatus.valueOf(v)
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/ChannelDao.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/ChannelDao.kt
@@ -9,21 +9,20 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChannelDao {
-    @Query("SELECT * FROM channel WHERE deviceId = :deviceId ORDER BY channelIndex ASC")
-    fun observeByDevice(deviceId: String): Flow<List<ChannelEntity>>
+  @Query("SELECT * FROM channel WHERE deviceId = :deviceId ORDER BY channelIndex ASC")
+  fun observeByDevice(deviceId: String): Flow<List<ChannelEntity>>
 
-    @Query("SELECT * FROM channel WHERE deviceId = :deviceId")
-    suspend fun getByDevice(deviceId: String): List<ChannelEntity>
+  @Query("SELECT * FROM channel WHERE deviceId = :deviceId")
+  suspend fun getByDevice(deviceId: String): List<ChannelEntity>
 
-    @Upsert
-    suspend fun upsertAll(channels: List<ChannelEntity>)
+  @Upsert suspend fun upsertAll(channels: List<ChannelEntity>)
 
-    @Query("DELETE FROM channel WHERE deviceId = :deviceId")
-    suspend fun deleteByDevice(deviceId: String)
+  @Query("DELETE FROM channel WHERE deviceId = :deviceId")
+  suspend fun deleteByDevice(deviceId: String)
 
-    @Transaction
-    suspend fun replaceAll(deviceId: String, channels: List<ChannelEntity>) {
-        deleteByDevice(deviceId)
-        upsertAll(channels)
-    }
+  @Transaction
+  suspend fun replaceAll(deviceId: String, channels: List<ChannelEntity>) {
+    deleteByDevice(deviceId)
+    upsertAll(channels)
+  }
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/ContactDao.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/ContactDao.kt
@@ -9,24 +9,23 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ContactDao {
-    @Query("SELECT * FROM contact WHERE deviceId = :deviceId ORDER BY name ASC")
-    fun observeByDevice(deviceId: String): Flow<List<ContactEntity>>
+  @Query("SELECT * FROM contact WHERE deviceId = :deviceId ORDER BY name ASC")
+  fun observeByDevice(deviceId: String): Flow<List<ContactEntity>>
 
-    @Query("SELECT * FROM contact WHERE deviceId = :deviceId")
-    suspend fun getByDevice(deviceId: String): List<ContactEntity>
+  @Query("SELECT * FROM contact WHERE deviceId = :deviceId")
+  suspend fun getByDevice(deviceId: String): List<ContactEntity>
 
-    @Query("SELECT COUNT(*) FROM contact WHERE deviceId = :deviceId")
-    fun countByDevice(deviceId: String): Flow<Int>
+  @Query("SELECT COUNT(*) FROM contact WHERE deviceId = :deviceId")
+  fun countByDevice(deviceId: String): Flow<Int>
 
-    @Upsert
-    suspend fun upsertAll(contacts: List<ContactEntity>)
+  @Upsert suspend fun upsertAll(contacts: List<ContactEntity>)
 
-    @Query("DELETE FROM contact WHERE deviceId = :deviceId")
-    suspend fun deleteByDevice(deviceId: String)
+  @Query("DELETE FROM contact WHERE deviceId = :deviceId")
+  suspend fun deleteByDevice(deviceId: String)
 
-    @Transaction
-    suspend fun replaceAll(deviceId: String, contacts: List<ContactEntity>) {
-        deleteByDevice(deviceId)
-        upsertAll(contacts)
-    }
+  @Transaction
+  suspend fun replaceAll(deviceId: String, contacts: List<ContactEntity>) {
+    deleteByDevice(deviceId)
+    upsertAll(contacts)
+  }
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/DeviceDao.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/DeviceDao.kt
@@ -9,31 +9,26 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface DeviceDao {
-    @Query("SELECT * FROM device ORDER BY isFavorite DESC, lastConnectedAtMs DESC")
-    fun observeAll(): Flow<List<DeviceEntity>>
+  @Query("SELECT * FROM device ORDER BY isFavorite DESC, lastConnectedAtMs DESC")
+  fun observeAll(): Flow<List<DeviceEntity>>
 
-    @Query("SELECT * FROM device WHERE isFavorite = 1 LIMIT 1")
-    fun observeFavorite(): Flow<DeviceEntity?>
+  @Query("SELECT * FROM device WHERE isFavorite = 1 LIMIT 1")
+  fun observeFavorite(): Flow<DeviceEntity?>
 
-    @Query("SELECT * FROM device WHERE id = :id")
-    suspend fun getById(id: String): DeviceEntity?
+  @Query("SELECT * FROM device WHERE id = :id") suspend fun getById(id: String): DeviceEntity?
 
-    @Upsert
-    suspend fun upsert(device: DeviceEntity)
+  @Upsert suspend fun upsert(device: DeviceEntity)
 
-    @Query("DELETE FROM device WHERE id = :id")
-    suspend fun delete(id: String)
+  @Query("DELETE FROM device WHERE id = :id") suspend fun delete(id: String)
 
-    @Query("UPDATE device SET isFavorite = 0")
-    suspend fun clearAllFavorites()
+  @Query("UPDATE device SET isFavorite = 0") suspend fun clearAllFavorites()
 
-    @Query("UPDATE device SET isFavorite = 1 WHERE id = :id")
-    suspend fun setFavorite(id: String)
+  @Query("UPDATE device SET isFavorite = 1 WHERE id = :id") suspend fun setFavorite(id: String)
 
-    @Transaction
-    suspend fun toggleFavorite(id: String) {
-        val current = getById(id) ?: return
-        clearAllFavorites()
-        if (!current.isFavorite) setFavorite(id)
-    }
+  @Transaction
+  suspend fun toggleFavorite(id: String) {
+    val current = getById(id) ?: return
+    clearAllFavorites()
+    if (!current.isFavorite) setFavorite(id)
+  }
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/DeviceStateDao.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/DeviceStateDao.kt
@@ -8,15 +8,14 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface DeviceStateDao {
-    @Query("SELECT * FROM device_state WHERE deviceId = :deviceId")
-    suspend fun getByDeviceId(deviceId: String): DeviceStateEntity?
+  @Query("SELECT * FROM device_state WHERE deviceId = :deviceId")
+  suspend fun getByDeviceId(deviceId: String): DeviceStateEntity?
 
-    @Query("SELECT * FROM device_state WHERE deviceId = :deviceId")
-    fun observeByDeviceId(deviceId: String): Flow<DeviceStateEntity?>
+  @Query("SELECT * FROM device_state WHERE deviceId = :deviceId")
+  fun observeByDeviceId(deviceId: String): Flow<DeviceStateEntity?>
 
-    @Query("SELECT deviceId FROM device_state WHERE selfPublicKey = :pubkey LIMIT 1")
-    suspend fun findDeviceIdByPublicKey(pubkey: ByteArray): String?
+  @Query("SELECT deviceId FROM device_state WHERE selfPublicKey = :pubkey LIMIT 1")
+  suspend fun findDeviceIdByPublicKey(pubkey: ByteArray): String?
 
-    @Upsert
-    suspend fun upsert(state: DeviceStateEntity)
+  @Upsert suspend fun upsert(state: DeviceStateEntity)
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/MessageDao.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/dao/MessageDao.kt
@@ -10,70 +10,82 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MessageDao {
-    @Query("""
+  @Query(
+    """
         SELECT * FROM message
         WHERE deviceId = :deviceId AND kind = 'DM' AND contactPublicKeyHex = :contactKeyHex
         ORDER BY timestampEpochMs ASC
-    """)
-    fun observeDms(deviceId: String, contactKeyHex: String): Flow<List<MessageEntity>>
+    """
+  )
+  fun observeDms(deviceId: String, contactKeyHex: String): Flow<List<MessageEntity>>
 
-    @Query("""
+  @Query(
+    """
         SELECT * FROM message
         WHERE deviceId = :deviceId AND kind = 'CHANNEL' AND channelIndex = :channelIndex
         ORDER BY timestampEpochMs ASC
-    """)
-    fun observeChannelMessages(deviceId: String, channelIndex: Int): Flow<List<MessageEntity>>
+    """
+  )
+  fun observeChannelMessages(deviceId: String, channelIndex: Int): Flow<List<MessageEntity>>
 
-    @Insert
-    suspend fun insert(message: MessageEntity): Long
+  @Insert suspend fun insert(message: MessageEntity): Long
 
-    @Query("UPDATE message SET status = :status WHERE ackHash = :ackHash AND direction = 'SENT'")
-    suspend fun updateStatusByAckHash(ackHash: Int, status: MessageStatus)
+  @Query("UPDATE message SET status = :status WHERE ackHash = :ackHash AND direction = 'SENT'")
+  suspend fun updateStatusByAckHash(ackHash: Int, status: MessageStatus)
 
-    @Query("UPDATE message SET status = :status, ackHash = :ackHash WHERE rowId = :rowId")
-    suspend fun updateStatusAndAckByRowId(rowId: Long, status: MessageStatus, ackHash: Int?)
+  @Query("UPDATE message SET status = :status, ackHash = :ackHash WHERE rowId = :rowId")
+  suspend fun updateStatusAndAckByRowId(rowId: Long, status: MessageStatus, ackHash: Int?)
 
-    @Query("UPDATE message SET status = :status WHERE rowId = :rowId")
-    suspend fun updateStatusByRowId(rowId: Long, status: MessageStatus)
+  @Query("UPDATE message SET status = :status WHERE rowId = :rowId")
+  suspend fun updateStatusByRowId(rowId: Long, status: MessageStatus)
 
-    @Query("""
+  @Query(
+    """
         SELECT * FROM message
         WHERE deviceId = :deviceId
         ORDER BY timestampEpochMs DESC
         LIMIT :limit
-    """)
-    suspend fun getRecentMessages(deviceId: String, limit: Int): List<MessageEntity>
+    """
+  )
+  suspend fun getRecentMessages(deviceId: String, limit: Int): List<MessageEntity>
 
-    @Query("""
+  @Query(
+    """
         SELECT * FROM message
         WHERE deviceId = :deviceId
         ORDER BY timestampEpochMs DESC
         LIMIT 1
-    """)
-    fun observeLatestMessage(deviceId: String): Flow<MessageEntity?>
+    """
+  )
+  fun observeLatestMessage(deviceId: String): Flow<MessageEntity?>
 
-    @Query("""
+  @Query(
+    """
         SELECT DISTINCT contactPublicKeyHex FROM message
         WHERE deviceId = :deviceId AND kind = 'DM' AND contactPublicKeyHex IS NOT NULL
-    """)
-    fun observeContactedKeys(deviceId: String): Flow<List<String>>
+    """
+  )
+  fun observeContactedKeys(deviceId: String): Flow<List<String>>
 
-    @Query("""
+  @Query(
+    """
         SELECT DISTINCT channelIndex FROM message
         WHERE deviceId = :deviceId AND kind = 'CHANNEL' AND channelIndex IS NOT NULL
-    """)
-    fun observeContactedChannelIndices(deviceId: String): Flow<List<Int>>
+    """
+  )
+  fun observeContactedChannelIndices(deviceId: String): Flow<List<Int>>
 
-    @Query("""
+  @Query(
+    """
         SELECT COUNT(*) FROM message
         WHERE deviceId = :deviceId AND kind = :kind
           AND timestampEpochMs = :timestampMs AND text = :text
-    """)
-    suspend fun countDuplicates(
-        deviceId: String,
-        kind: MessageKind,
-        timestampMs: Long,
-        text: String,
-    ): Int
-
+    """
+  )
+  suspend fun countDuplicates(
+    deviceId: String,
+    kind: MessageKind,
+    timestampMs: Long,
+    text: String,
+  ): Int
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/ChannelEntity.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/ChannelEntity.kt
@@ -5,20 +5,23 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 
 @Entity(
-    tableName = "channel",
-    primaryKeys = ["deviceId", "channelIndex"],
-    foreignKeys = [ForeignKey(
+  tableName = "channel",
+  primaryKeys = ["deviceId", "channelIndex"],
+  foreignKeys =
+    [
+      ForeignKey(
         entity = DeviceEntity::class,
         parentColumns = ["id"],
         childColumns = ["deviceId"],
         onDelete = ForeignKey.CASCADE,
-    )],
-    indices = [Index("deviceId")],
+      )
+    ],
+  indices = [Index("deviceId")],
 )
 data class ChannelEntity(
-    val deviceId: String,
-    val channelIndex: Int,
-    val name: String,
-    val psk: ByteArray,
-    val fetchedAtMs: Long,
+  val deviceId: String,
+  val channelIndex: Int,
+  val name: String,
+  val psk: ByteArray,
+  val fetchedAtMs: Long,
 )

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/ContactEntity.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/ContactEntity.kt
@@ -5,27 +5,30 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 
 @Entity(
-    tableName = "contact",
-    primaryKeys = ["deviceId", "publicKeyHex"],
-    foreignKeys = [ForeignKey(
+  tableName = "contact",
+  primaryKeys = ["deviceId", "publicKeyHex"],
+  foreignKeys =
+    [
+      ForeignKey(
         entity = DeviceEntity::class,
         parentColumns = ["id"],
         childColumns = ["deviceId"],
         onDelete = ForeignKey.CASCADE,
-    )],
-    indices = [Index("deviceId")],
+      )
+    ],
+  indices = [Index("deviceId")],
 )
 data class ContactEntity(
-    val deviceId: String,
-    val publicKeyHex: String,
-    val publicKeyBytes: ByteArray,
-    val type: Int,
-    val flags: Int,
-    val pathLength: Int,
-    val name: String,
-    val advertTimestampEpochS: Long,
-    val latitude: Double,
-    val longitude: Double,
-    val lastModifiedEpochS: Long,
-    val fetchedAtMs: Long,
+  val deviceId: String,
+  val publicKeyHex: String,
+  val publicKeyBytes: ByteArray,
+  val type: Int,
+  val flags: Int,
+  val pathLength: Int,
+  val name: String,
+  val advertTimestampEpochS: Long,
+  val latitude: Double,
+  val longitude: Double,
+  val lastModifiedEpochS: Long,
+  val fetchedAtMs: Long,
 )

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/DeviceEntity.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/DeviceEntity.kt
@@ -3,23 +3,27 @@ package ee.schimke.meshcore.data.entity
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-enum class TransportType { BLE, TCP, USB }
+enum class TransportType {
+  BLE,
+  TCP,
+  USB,
+}
 
 @Entity(tableName = "device")
 data class DeviceEntity(
-    @PrimaryKey val id: String,
-    val label: String,
-    val isFavorite: Boolean = false,
-    val lastConnectedAtMs: Long = 0L,
-    val transportType: TransportType,
-    // BLE
-    val bleIdentifier: String? = null,
-    val bleAdvertName: String? = null,
-    // TCP
-    val tcpHost: String? = null,
-    val tcpPort: Int? = null,
-    // USB
-    val usbClassName: String? = null,
-    val usbVendorId: Int? = null,
-    val usbProductId: Int? = null,
+  @PrimaryKey val id: String,
+  val label: String,
+  val isFavorite: Boolean = false,
+  val lastConnectedAtMs: Long = 0L,
+  val transportType: TransportType,
+  // BLE
+  val bleIdentifier: String? = null,
+  val bleAdvertName: String? = null,
+  // TCP
+  val tcpHost: String? = null,
+  val tcpPort: Int? = null,
+  // USB
+  val usbClassName: String? = null,
+  val usbVendorId: Int? = null,
+  val usbProductId: Int? = null,
 )

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/DeviceStateEntity.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/DeviceStateEntity.kt
@@ -5,39 +5,42 @@ import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 
 @Entity(
-    tableName = "device_state",
-    foreignKeys = [ForeignKey(
+  tableName = "device_state",
+  foreignKeys =
+    [
+      ForeignKey(
         entity = DeviceEntity::class,
         parentColumns = ["id"],
         childColumns = ["deviceId"],
         onDelete = ForeignKey.CASCADE,
-    )],
+      )
+    ],
 )
 data class DeviceStateEntity(
-    @PrimaryKey val deviceId: String,
-    // SelfInfo
-    val selfName: String? = null,
-    val selfAdvertType: Int? = null,
-    val selfTxPowerDbm: Int? = null,
-    val selfMaxPowerDbm: Int? = null,
-    val selfPublicKey: ByteArray? = null,
-    val selfLatitude: Double? = null,
-    val selfLongitude: Double? = null,
-    val selfInfoFetchedAtMs: Long = 0L,
-    // Battery
-    val batteryMillivolts: Int? = null,
-    val storageUsedKb: Long? = null,
-    val storageTotalKb: Long? = null,
-    val batteryFetchedAtMs: Long = 0L,
-    // Radio
-    val radioFrequencyHz: Int? = null,
-    val radioBandwidthHz: Int? = null,
-    val radioSpreadingFactor: Int? = null,
-    val radioCodingRate: Int? = null,
-    val radioFetchedAtMs: Long = 0L,
-    // DeviceInfo
-    val protocolVersion: Int? = null,
-    val maxContacts: Int? = null,
-    val maxChannels: Int? = null,
-    val deviceInfoFetchedAtMs: Long = 0L,
+  @PrimaryKey val deviceId: String,
+  // SelfInfo
+  val selfName: String? = null,
+  val selfAdvertType: Int? = null,
+  val selfTxPowerDbm: Int? = null,
+  val selfMaxPowerDbm: Int? = null,
+  val selfPublicKey: ByteArray? = null,
+  val selfLatitude: Double? = null,
+  val selfLongitude: Double? = null,
+  val selfInfoFetchedAtMs: Long = 0L,
+  // Battery
+  val batteryMillivolts: Int? = null,
+  val storageUsedKb: Long? = null,
+  val storageTotalKb: Long? = null,
+  val batteryFetchedAtMs: Long = 0L,
+  // Radio
+  val radioFrequencyHz: Int? = null,
+  val radioBandwidthHz: Int? = null,
+  val radioSpreadingFactor: Int? = null,
+  val radioCodingRate: Int? = null,
+  val radioFetchedAtMs: Long = 0L,
+  // DeviceInfo
+  val protocolVersion: Int? = null,
+  val maxContacts: Int? = null,
+  val maxChannels: Int? = null,
+  val deviceInfoFetchedAtMs: Long = 0L,
 )

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/MessageEntity.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/entity/MessageEntity.kt
@@ -5,42 +5,59 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
-enum class MessageKind { DM, CHANNEL }
-enum class MessageDirection { SENT, RECEIVED }
-enum class MessageStatus { SENDING, SENT, CONFIRMED, FAILED }
+enum class MessageKind {
+  DM,
+  CHANNEL,
+}
+
+enum class MessageDirection {
+  SENT,
+  RECEIVED,
+}
+
+enum class MessageStatus {
+  SENDING,
+  SENT,
+  CONFIRMED,
+  FAILED,
+}
 
 @Entity(
-    tableName = "message",
-    foreignKeys = [ForeignKey(
+  tableName = "message",
+  foreignKeys =
+    [
+      ForeignKey(
         entity = DeviceEntity::class,
         parentColumns = ["id"],
         childColumns = ["deviceId"],
         onDelete = ForeignKey.CASCADE,
-    )],
-    indices = [
-        Index("deviceId", "contactPublicKeyHex"),
-        Index("deviceId", "channelIndex"),
-        Index("deviceId", "timestampEpochMs"),
+      )
+    ],
+  indices =
+    [
+      Index("deviceId", "contactPublicKeyHex"),
+      Index("deviceId", "channelIndex"),
+      Index("deviceId", "timestampEpochMs"),
     ],
 )
 data class MessageEntity(
-    @PrimaryKey(autoGenerate = true) val rowId: Long = 0,
-    val deviceId: String,
-    val kind: MessageKind,
-    val direction: MessageDirection,
-    // DM fields (null for channel messages)
-    val contactPublicKeyHex: String? = null,
-    // Channel fields (null for DMs)
-    val channelIndex: Int? = null,
-    // Content
-    val senderName: String? = null,
-    val text: String,
-    val timestampEpochMs: Long,
-    val textType: Int = 0,
-    // Received metadata
-    val snr: Int? = null,
-    val pathLength: Int? = null,
-    // Sent tracking
-    val ackHash: Int? = null,
-    val status: MessageStatus = MessageStatus.SENT,
+  @PrimaryKey(autoGenerate = true) val rowId: Long = 0,
+  val deviceId: String,
+  val kind: MessageKind,
+  val direction: MessageDirection,
+  // DM fields (null for channel messages)
+  val contactPublicKeyHex: String? = null,
+  // Channel fields (null for DMs)
+  val channelIndex: Int? = null,
+  // Content
+  val senderName: String? = null,
+  val text: String,
+  val timestampEpochMs: Long,
+  val textType: Int = 0,
+  // Received metadata
+  val snr: Int? = null,
+  val pathLength: Int? = null,
+  // Sent tracking
+  val ackHash: Int? = null,
+  val status: MessageStatus = MessageStatus.SENT,
 )

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/repository/MeshcoreRepository.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/repository/MeshcoreRepository.kt
@@ -20,379 +20,409 @@ import ee.schimke.meshcore.data.entity.MessageEntity
 import ee.schimke.meshcore.data.entity.MessageKind
 import ee.schimke.meshcore.data.entity.MessageStatus
 import ee.schimke.meshcore.data.entity.TransportType
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.io.bytestring.ByteString
-import kotlin.time.Instant
 
 /** Reusable transport descriptor (same as the old SavedTransport). */
 sealed class SavedTransport {
-    data class Ble(val identifier: String, val advertName: String?) : SavedTransport()
-    data class Tcp(val host: String, val port: Int) : SavedTransport()
-    data class Usb(val className: String, val vendorId: Int, val productId: Int) : SavedTransport()
+  data class Ble(val identifier: String, val advertName: String?) : SavedTransport()
+
+  data class Tcp(val host: String, val port: Int) : SavedTransport()
+
+  data class Usb(val className: String, val vendorId: Int, val productId: Int) : SavedTransport()
 }
 
 /** Domain-level saved device. */
 data class SavedDevice(
-    val id: String,
-    val label: String,
-    val transport: SavedTransport,
-    val favorite: Boolean,
-    val lastConnectedAtMs: Long,
+  val id: String,
+  val label: String,
+  val transport: SavedTransport,
+  val favorite: Boolean,
+  val lastConnectedAtMs: Long,
 )
 
 /** Saved device enriched with cached state from Room. */
 data class SavedDeviceWithState(
-    val device: SavedDevice,
-    val batteryMillivolts: Int? = null,
-    val contactsCount: Int = 0,
+  val device: SavedDevice,
+  val batteryMillivolts: Int? = null,
+  val contactsCount: Int = 0,
 )
 
 fun bleDeviceId(identifier: String): String = "ble:$identifier"
+
 fun tcpDeviceId(host: String, port: Int): String = "tcp:$host:$port"
+
 fun usbDeviceId(className: String, vid: Int, pid: Int): String = "usb:$className:$vid:$pid"
 
 class MeshcoreRepository(private val db: MeshcoreDatabase) {
 
-    // --- Devices ---
+  // --- Devices ---
 
-    fun observeDevices(): Flow<List<SavedDevice>> =
-        db.deviceDao().observeAll().map { list -> list.map { it.toDomain() } }
+  fun observeDevices(): Flow<List<SavedDevice>> =
+    db.deviceDao().observeAll().map { list -> list.map { it.toDomain() } }
 
-    /** Saved devices enriched with cached battery + contact count from Room. */
-    @Suppress("OPT_IN_USAGE")
-    fun observeDevicesWithState(): Flow<List<SavedDeviceWithState>> =
-        db.deviceDao().observeAll().flatMapLatest { devices ->
-            if (devices.isEmpty()) return@flatMapLatest flowOf(emptyList())
-            val flows = devices.map { entity ->
-                combine(
-                    db.deviceStateDao().observeByDeviceId(entity.id),
-                    db.contactDao().countByDevice(entity.id),
-                ) { state, count ->
-                    SavedDeviceWithState(
-                        device = entity.toDomain(),
-                        batteryMillivolts = state?.batteryMillivolts,
-                        contactsCount = count,
-                    )
-                }
-            }
-            combine(flows) { it.toList() }
+  /** Saved devices enriched with cached battery + contact count from Room. */
+  @Suppress("OPT_IN_USAGE")
+  fun observeDevicesWithState(): Flow<List<SavedDeviceWithState>> =
+    db.deviceDao().observeAll().flatMapLatest { devices ->
+      if (devices.isEmpty()) return@flatMapLatest flowOf(emptyList())
+      val flows = devices.map { entity ->
+        combine(
+          db.deviceStateDao().observeByDeviceId(entity.id),
+          db.contactDao().countByDevice(entity.id),
+        ) { state, count ->
+          SavedDeviceWithState(
+            device = entity.toDomain(),
+            batteryMillivolts = state?.batteryMillivolts,
+            contactsCount = count,
+          )
         }
+      }
+      combine(flows) { it.toList() }
+    }
 
-    fun observeFavorite(): Flow<SavedDevice?> =
-        db.deviceDao().observeFavorite().map { it?.toDomain() }
+  fun observeFavorite(): Flow<SavedDevice?> =
+    db.deviceDao().observeFavorite().map { it?.toDomain() }
 
-    suspend fun getDevice(id: String): SavedDevice? =
-        db.deviceDao().getById(id)?.toDomain()
+  suspend fun getDevice(id: String): SavedDevice? = db.deviceDao().getById(id)?.toDomain()
 
-    /**
-     * Find an existing device by its public key (from SelfInfo).
-     * Returns the device ID if found, null otherwise.
-     * Used to merge devices connected via different transports (BLE vs USB).
-     */
-    suspend fun findDeviceIdByPublicKey(publicKey: ee.schimke.meshcore.core.model.PublicKey): String? =
-        db.deviceStateDao().findDeviceIdByPublicKey(publicKey.bytes.toByteArray())
+  /**
+   * Find an existing device by its public key (from SelfInfo). Returns the device ID if found, null
+   * otherwise. Used to merge devices connected via different transports (BLE vs USB).
+   */
+  suspend fun findDeviceIdByPublicKey(
+    publicKey: ee.schimke.meshcore.core.model.PublicKey
+  ): String? = db.deviceStateDao().findDeviceIdByPublicKey(publicKey.bytes.toByteArray())
 
-    /**
-     * Merge a transport-specific device entry into an existing canonical entry.
-     * Moves the transport details and deletes the old entry.
-     */
-    suspend fun mergeDevice(fromId: String, intoId: String, transport: SavedTransport) {
-        val into = db.deviceDao().getById(intoId) ?: return
-        // Update the canonical entry with the new transport details
-        db.deviceDao().upsert(
-            into.copy(
-                transportType = transport.toType(),
-                bleIdentifier = (transport as? SavedTransport.Ble)?.identifier ?: into.bleIdentifier,
-                bleAdvertName = (transport as? SavedTransport.Ble)?.advertName ?: into.bleAdvertName,
-                tcpHost = (transport as? SavedTransport.Tcp)?.host ?: into.tcpHost,
-                tcpPort = (transport as? SavedTransport.Tcp)?.port ?: into.tcpPort,
-                usbClassName = (transport as? SavedTransport.Usb)?.className ?: into.usbClassName,
-                usbVendorId = (transport as? SavedTransport.Usb)?.vendorId ?: into.usbVendorId,
-                usbProductId = (transport as? SavedTransport.Usb)?.productId ?: into.usbProductId,
-                lastConnectedAtMs = System.currentTimeMillis(),
-            ),
+  /**
+   * Merge a transport-specific device entry into an existing canonical entry. Moves the transport
+   * details and deletes the old entry.
+   */
+  suspend fun mergeDevice(fromId: String, intoId: String, transport: SavedTransport) {
+    val into = db.deviceDao().getById(intoId) ?: return
+    // Update the canonical entry with the new transport details
+    db
+      .deviceDao()
+      .upsert(
+        into.copy(
+          transportType = transport.toType(),
+          bleIdentifier = (transport as? SavedTransport.Ble)?.identifier ?: into.bleIdentifier,
+          bleAdvertName = (transport as? SavedTransport.Ble)?.advertName ?: into.bleAdvertName,
+          tcpHost = (transport as? SavedTransport.Tcp)?.host ?: into.tcpHost,
+          tcpPort = (transport as? SavedTransport.Tcp)?.port ?: into.tcpPort,
+          usbClassName = (transport as? SavedTransport.Usb)?.className ?: into.usbClassName,
+          usbVendorId = (transport as? SavedTransport.Usb)?.vendorId ?: into.usbVendorId,
+          usbProductId = (transport as? SavedTransport.Usb)?.productId ?: into.usbProductId,
+          lastConnectedAtMs = System.currentTimeMillis(),
         )
-        // Delete the transport-specific entry (CASCADE removes its state/contacts/etc)
-        if (fromId != intoId) {
-            db.deviceDao().delete(fromId)
-        }
+      )
+    // Delete the transport-specific entry (CASCADE removes its state/contacts/etc)
+    if (fromId != intoId) {
+      db.deviceDao().delete(fromId)
     }
+  }
 
-    suspend fun upsertDevice(
-        id: String,
-        label: String,
-        transport: SavedTransport,
-        markConnectedNow: Boolean = true,
-    ) {
-        val existing = db.deviceDao().getById(id)
-        db.deviceDao().upsert(
-            DeviceEntity(
-                id = id,
-                label = label,
-                isFavorite = existing?.isFavorite ?: false,
-                lastConnectedAtMs = if (markConnectedNow) System.currentTimeMillis() else (existing?.lastConnectedAtMs ?: 0L),
-                transportType = transport.toType(),
-                bleIdentifier = (transport as? SavedTransport.Ble)?.identifier,
-                bleAdvertName = (transport as? SavedTransport.Ble)?.advertName,
-                tcpHost = (transport as? SavedTransport.Tcp)?.host,
-                tcpPort = (transport as? SavedTransport.Tcp)?.port,
-                usbClassName = (transport as? SavedTransport.Usb)?.className,
-                usbVendorId = (transport as? SavedTransport.Usb)?.vendorId,
-                usbProductId = (transport as? SavedTransport.Usb)?.productId,
-            ),
+  suspend fun upsertDevice(
+    id: String,
+    label: String,
+    transport: SavedTransport,
+    markConnectedNow: Boolean = true,
+  ) {
+    val existing = db.deviceDao().getById(id)
+    db
+      .deviceDao()
+      .upsert(
+        DeviceEntity(
+          id = id,
+          label = label,
+          isFavorite = existing?.isFavorite ?: false,
+          lastConnectedAtMs =
+            if (markConnectedNow) System.currentTimeMillis()
+            else (existing?.lastConnectedAtMs ?: 0L),
+          transportType = transport.toType(),
+          bleIdentifier = (transport as? SavedTransport.Ble)?.identifier,
+          bleAdvertName = (transport as? SavedTransport.Ble)?.advertName,
+          tcpHost = (transport as? SavedTransport.Tcp)?.host,
+          tcpPort = (transport as? SavedTransport.Tcp)?.port,
+          usbClassName = (transport as? SavedTransport.Usb)?.className,
+          usbVendorId = (transport as? SavedTransport.Usb)?.vendorId,
+          usbProductId = (transport as? SavedTransport.Usb)?.productId,
         )
-    }
+      )
+  }
 
-    suspend fun forgetDevice(id: String) {
-        db.deviceDao().delete(id) // CASCADE deletes contacts, channels, messages, state
-    }
+  suspend fun forgetDevice(id: String) {
+    db.deviceDao().delete(id) // CASCADE deletes contacts, channels, messages, state
+  }
 
-    suspend fun toggleFavorite(id: String) {
-        db.deviceDao().toggleFavorite(id)
-    }
+  suspend fun toggleFavorite(id: String) {
+    db.deviceDao().toggleFavorite(id)
+  }
 
-    // --- Device State ---
+  // --- Device State ---
 
-    suspend fun getDeviceState(deviceId: String): DeviceStateEntity? =
-        db.deviceStateDao().getByDeviceId(deviceId)
+  suspend fun getDeviceState(deviceId: String): DeviceStateEntity? =
+    db.deviceStateDao().getByDeviceId(deviceId)
 
-    fun observeDeviceState(deviceId: String): Flow<DeviceStateEntity?> =
-        db.deviceStateDao().observeByDeviceId(deviceId)
+  fun observeDeviceState(deviceId: String): Flow<DeviceStateEntity?> =
+    db.deviceStateDao().observeByDeviceId(deviceId)
 
-    suspend fun updateSelfInfo(deviceId: String, selfInfo: SelfInfo, fetchedAtMs: Long) {
-        val existing = db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
-        db.deviceStateDao().upsert(
-            existing.copy(
-                selfName = selfInfo.name,
-                selfAdvertType = selfInfo.advertType,
-                selfTxPowerDbm = selfInfo.txPowerDbm,
-                selfMaxPowerDbm = selfInfo.maxPowerDbm,
-                selfPublicKey = selfInfo.publicKey.bytes.toByteArray(),
-                selfLatitude = selfInfo.latitude,
-                selfLongitude = selfInfo.longitude,
-                selfInfoFetchedAtMs = fetchedAtMs,
-            ),
+  suspend fun updateSelfInfo(deviceId: String, selfInfo: SelfInfo, fetchedAtMs: Long) {
+    val existing =
+      db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
+    db
+      .deviceStateDao()
+      .upsert(
+        existing.copy(
+          selfName = selfInfo.name,
+          selfAdvertType = selfInfo.advertType,
+          selfTxPowerDbm = selfInfo.txPowerDbm,
+          selfMaxPowerDbm = selfInfo.maxPowerDbm,
+          selfPublicKey = selfInfo.publicKey.bytes.toByteArray(),
+          selfLatitude = selfInfo.latitude,
+          selfLongitude = selfInfo.longitude,
+          selfInfoFetchedAtMs = fetchedAtMs,
         )
-        // Also update the device label with the actual name
-        db.deviceDao().getById(deviceId)?.let { device ->
-            db.deviceDao().upsert(device.copy(label = selfInfo.name))
-        }
+      )
+    // Also update the device label with the actual name
+    db.deviceDao().getById(deviceId)?.let { device ->
+      db.deviceDao().upsert(device.copy(label = selfInfo.name))
     }
+  }
 
-    suspend fun updateBattery(deviceId: String, battery: BatteryInfo, fetchedAtMs: Long) {
-        val existing = db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
-        db.deviceStateDao().upsert(
-            existing.copy(
-                batteryMillivolts = battery.millivolts,
-                storageUsedKb = battery.storageUsedKb,
-                storageTotalKb = battery.storageTotalKb,
-                batteryFetchedAtMs = fetchedAtMs,
-            ),
+  suspend fun updateBattery(deviceId: String, battery: BatteryInfo, fetchedAtMs: Long) {
+    val existing =
+      db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
+    db
+      .deviceStateDao()
+      .upsert(
+        existing.copy(
+          batteryMillivolts = battery.millivolts,
+          storageUsedKb = battery.storageUsedKb,
+          storageTotalKb = battery.storageTotalKb,
+          batteryFetchedAtMs = fetchedAtMs,
         )
-    }
+      )
+  }
 
-    suspend fun updateRadio(deviceId: String, radio: RadioSettings, fetchedAtMs: Long) {
-        val existing = db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
-        db.deviceStateDao().upsert(
-            existing.copy(
-                radioFrequencyHz = radio.frequencyHz,
-                radioBandwidthHz = radio.bandwidthHz,
-                radioSpreadingFactor = radio.spreadingFactor,
-                radioCodingRate = radio.codingRate,
-                radioFetchedAtMs = fetchedAtMs,
-            ),
+  suspend fun updateRadio(deviceId: String, radio: RadioSettings, fetchedAtMs: Long) {
+    val existing =
+      db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
+    db
+      .deviceStateDao()
+      .upsert(
+        existing.copy(
+          radioFrequencyHz = radio.frequencyHz,
+          radioBandwidthHz = radio.bandwidthHz,
+          radioSpreadingFactor = radio.spreadingFactor,
+          radioCodingRate = radio.codingRate,
+          radioFetchedAtMs = fetchedAtMs,
         )
-    }
+      )
+  }
 
-    suspend fun updateDeviceInfo(deviceId: String, deviceInfo: DeviceInfo, fetchedAtMs: Long) {
-        val existing = db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
-        db.deviceStateDao().upsert(
-            existing.copy(
-                protocolVersion = deviceInfo.protocolVersion,
-                maxContacts = deviceInfo.maxContacts,
-                maxChannels = deviceInfo.maxChannels,
-                deviceInfoFetchedAtMs = fetchedAtMs,
-            ),
+  suspend fun updateDeviceInfo(deviceId: String, deviceInfo: DeviceInfo, fetchedAtMs: Long) {
+    val existing =
+      db.deviceStateDao().getByDeviceId(deviceId) ?: DeviceStateEntity(deviceId = deviceId)
+    db
+      .deviceStateDao()
+      .upsert(
+        existing.copy(
+          protocolVersion = deviceInfo.protocolVersion,
+          maxContacts = deviceInfo.maxContacts,
+          maxChannels = deviceInfo.maxChannels,
+          deviceInfoFetchedAtMs = fetchedAtMs,
         )
-    }
+      )
+  }
 
-    // --- Contacts ---
+  // --- Contacts ---
 
-    fun observeContacts(deviceId: String): Flow<List<Contact>> =
-        db.contactDao().observeByDevice(deviceId).map { list -> list.map { it.toDomain() } }
+  fun observeContacts(deviceId: String): Flow<List<Contact>> =
+    db.contactDao().observeByDevice(deviceId).map { list -> list.map { it.toDomain() } }
 
-    suspend fun getContacts(deviceId: String): List<Contact> =
-        db.contactDao().getByDevice(deviceId).map { it.toDomain() }
+  suspend fun getContacts(deviceId: String): List<Contact> =
+    db.contactDao().getByDevice(deviceId).map { it.toDomain() }
 
-    suspend fun replaceContacts(deviceId: String, contacts: List<Contact>, fetchedAtMs: Long) {
-        db.contactDao().replaceAll(
-            deviceId,
-            contacts.map { it.toEntity(deviceId, fetchedAtMs) },
-        )
-    }
+  suspend fun replaceContacts(deviceId: String, contacts: List<Contact>, fetchedAtMs: Long) {
+    db.contactDao().replaceAll(deviceId, contacts.map { it.toEntity(deviceId, fetchedAtMs) })
+  }
 
-    // --- Channels ---
+  // --- Channels ---
 
-    fun observeChannels(deviceId: String): Flow<List<ChannelInfo>> =
-        db.channelDao().observeByDevice(deviceId).map { list -> list.map { it.toDomain() } }
+  fun observeChannels(deviceId: String): Flow<List<ChannelInfo>> =
+    db.channelDao().observeByDevice(deviceId).map { list -> list.map { it.toDomain() } }
 
-    suspend fun getChannels(deviceId: String): List<ChannelInfo> =
-        db.channelDao().getByDevice(deviceId).map { it.toDomain() }
+  suspend fun getChannels(deviceId: String): List<ChannelInfo> =
+    db.channelDao().getByDevice(deviceId).map { it.toDomain() }
 
-    suspend fun replaceChannels(deviceId: String, channels: List<ChannelInfo>, fetchedAtMs: Long) {
-        db.channelDao().replaceAll(
-            deviceId,
-            channels.map { it.toEntity(deviceId, fetchedAtMs) },
-        )
-    }
+  suspend fun replaceChannels(deviceId: String, channels: List<ChannelInfo>, fetchedAtMs: Long) {
+    db.channelDao().replaceAll(deviceId, channels.map { it.toEntity(deviceId, fetchedAtMs) })
+  }
 
-    // --- Messages ---
+  // --- Messages ---
 
-    suspend fun getRecentMessages(deviceId: String, limit: Int = 20): List<MessageEntity> =
-        db.messageDao().getRecentMessages(deviceId, limit)
+  suspend fun getRecentMessages(deviceId: String, limit: Int = 20): List<MessageEntity> =
+    db.messageDao().getRecentMessages(deviceId, limit)
 
-    fun observeDms(deviceId: String, contactKeyHex: String): Flow<List<MessageEntity>> =
-        db.messageDao().observeDms(deviceId, contactKeyHex)
+  fun observeDms(deviceId: String, contactKeyHex: String): Flow<List<MessageEntity>> =
+    db.messageDao().observeDms(deviceId, contactKeyHex)
 
-    fun observeChannelMessages(deviceId: String, channelIndex: Int): Flow<List<MessageEntity>> =
-        db.messageDao().observeChannelMessages(deviceId, channelIndex)
+  fun observeChannelMessages(deviceId: String, channelIndex: Int): Flow<List<MessageEntity>> =
+    db.messageDao().observeChannelMessages(deviceId, channelIndex)
 
-    fun observeLatestMessage(deviceId: String): Flow<MessageEntity?> =
-        db.messageDao().observeLatestMessage(deviceId)
+  fun observeLatestMessage(deviceId: String): Flow<MessageEntity?> =
+    db.messageDao().observeLatestMessage(deviceId)
 
-    fun observeContactedKeys(deviceId: String): Flow<List<String>> =
-        db.messageDao().observeContactedKeys(deviceId)
+  fun observeContactedKeys(deviceId: String): Flow<List<String>> =
+    db.messageDao().observeContactedKeys(deviceId)
 
-    fun observeContactedChannelIndices(deviceId: String): Flow<List<Int>> =
-        db.messageDao().observeContactedChannelIndices(deviceId)
+  fun observeContactedChannelIndices(deviceId: String): Flow<List<Int>> =
+    db.messageDao().observeContactedChannelIndices(deviceId)
 
-    suspend fun insertReceivedDm(
-        deviceId: String,
-        msg: ReceivedDirectMessage,
-        resolvedContactKeyHex: String,
-    ) {
-        val timestampMs = msg.timestamp.toEpochMilliseconds()
-        if (db.messageDao().countDuplicates(deviceId, MessageKind.DM, timestampMs, msg.text) > 0) return
-        db.messageDao().insert(
-            MessageEntity(
-                deviceId = deviceId,
-                kind = MessageKind.DM,
-                direction = MessageDirection.RECEIVED,
-                contactPublicKeyHex = resolvedContactKeyHex,
-                text = msg.text,
-                timestampEpochMs = timestampMs,
-                textType = msg.textType.raw.toInt(),
-                snr = msg.snr,
-                pathLength = msg.pathLength,
-            ),
-        )
-    }
-
-    suspend fun insertReceivedChannelMessage(deviceId: String, msg: ReceivedChannelMessage) {
-        val timestampMs = msg.timestamp.toEpochMilliseconds()
-        if (db.messageDao().countDuplicates(deviceId, MessageKind.CHANNEL, timestampMs, msg.text) > 0) return
-        db.messageDao().insert(
-            MessageEntity(
-                deviceId = deviceId,
-                kind = MessageKind.CHANNEL,
-                direction = MessageDirection.RECEIVED,
-                channelIndex = msg.channelIndex,
-                senderName = msg.sender,
-                text = msg.text,
-                timestampEpochMs = timestampMs,
-                textType = msg.textType.raw.toInt(),
-                snr = msg.snr,
-                pathLength = msg.pathLength,
-            ),
-        )
-    }
-
-    suspend fun insertSentDm(
-        deviceId: String,
-        contactKeyHex: String,
-        text: String,
-        timestamp: Instant,
-        ackHash: Int?,
-        status: MessageStatus = MessageStatus.SENT,
-    ) {
-        db.messageDao().insert(
-            MessageEntity(
-                deviceId = deviceId,
-                kind = MessageKind.DM,
-                direction = MessageDirection.SENT,
-                contactPublicKeyHex = contactKeyHex,
-                text = text,
-                timestampEpochMs = timestamp.toEpochMilliseconds(),
-                ackHash = ackHash,
-                status = status,
-            ),
-        )
-    }
-
-    suspend fun insertSentChannelMessage(
-        deviceId: String,
-        channelIndex: Int,
-        senderName: String?,
-        text: String,
-        timestamp: Instant,
-        ackHash: Int?,
-        status: MessageStatus = MessageStatus.SENT,
-    ): Long = db.messageDao().insert(
+  suspend fun insertReceivedDm(
+    deviceId: String,
+    msg: ReceivedDirectMessage,
+    resolvedContactKeyHex: String,
+  ) {
+    val timestampMs = msg.timestamp.toEpochMilliseconds()
+    if (db.messageDao().countDuplicates(deviceId, MessageKind.DM, timestampMs, msg.text) > 0) return
+    db
+      .messageDao()
+      .insert(
         MessageEntity(
-            deviceId = deviceId,
-            kind = MessageKind.CHANNEL,
-            direction = MessageDirection.SENT,
-            channelIndex = channelIndex,
-            senderName = senderName,
-            text = text,
-            timestampEpochMs = timestamp.toEpochMilliseconds(),
-            ackHash = ackHash,
-            status = status,
-        ),
-    )
+          deviceId = deviceId,
+          kind = MessageKind.DM,
+          direction = MessageDirection.RECEIVED,
+          contactPublicKeyHex = resolvedContactKeyHex,
+          text = msg.text,
+          timestampEpochMs = timestampMs,
+          textType = msg.textType.raw.toInt(),
+          snr = msg.snr,
+          pathLength = msg.pathLength,
+        )
+      )
+  }
 
-    suspend fun updateMessageStatus(rowId: Long, status: MessageStatus) {
-        db.messageDao().updateStatusByRowId(rowId, status)
-    }
+  suspend fun insertReceivedChannelMessage(deviceId: String, msg: ReceivedChannelMessage) {
+    val timestampMs = msg.timestamp.toEpochMilliseconds()
+    if (db.messageDao().countDuplicates(deviceId, MessageKind.CHANNEL, timestampMs, msg.text) > 0)
+      return
+    db
+      .messageDao()
+      .insert(
+        MessageEntity(
+          deviceId = deviceId,
+          kind = MessageKind.CHANNEL,
+          direction = MessageDirection.RECEIVED,
+          channelIndex = msg.channelIndex,
+          senderName = msg.sender,
+          text = msg.text,
+          timestampEpochMs = timestampMs,
+          textType = msg.textType.raw.toInt(),
+          snr = msg.snr,
+          pathLength = msg.pathLength,
+        )
+      )
+  }
 
-    suspend fun updateMessageStatusAndAck(rowId: Long, status: MessageStatus, ackHash: Int?) {
-        db.messageDao().updateStatusAndAckByRowId(rowId, status, ackHash)
-    }
+  suspend fun insertSentDm(
+    deviceId: String,
+    contactKeyHex: String,
+    text: String,
+    timestamp: Instant,
+    ackHash: Int?,
+    status: MessageStatus = MessageStatus.SENT,
+  ) {
+    db
+      .messageDao()
+      .insert(
+        MessageEntity(
+          deviceId = deviceId,
+          kind = MessageKind.DM,
+          direction = MessageDirection.SENT,
+          contactPublicKeyHex = contactKeyHex,
+          text = text,
+          timestampEpochMs = timestamp.toEpochMilliseconds(),
+          ackHash = ackHash,
+          status = status,
+        )
+      )
+  }
 
-    suspend fun markConfirmed(ackHash: Int) {
-        db.messageDao().updateStatusByAckHash(ackHash, MessageStatus.CONFIRMED)
-    }
+  suspend fun insertSentChannelMessage(
+    deviceId: String,
+    channelIndex: Int,
+    senderName: String?,
+    text: String,
+    timestamp: Instant,
+    ackHash: Int?,
+    status: MessageStatus = MessageStatus.SENT,
+  ): Long =
+    db
+      .messageDao()
+      .insert(
+        MessageEntity(
+          deviceId = deviceId,
+          kind = MessageKind.CHANNEL,
+          direction = MessageDirection.SENT,
+          channelIndex = channelIndex,
+          senderName = senderName,
+          text = text,
+          timestampEpochMs = timestamp.toEpochMilliseconds(),
+          ackHash = ackHash,
+          status = status,
+        )
+      )
 
-    suspend fun markFailed(ackHash: Int) {
-        db.messageDao().updateStatusByAckHash(ackHash, MessageStatus.FAILED)
-    }
+  suspend fun updateMessageStatus(rowId: Long, status: MessageStatus) {
+    db.messageDao().updateStatusByRowId(rowId, status)
+  }
+
+  suspend fun updateMessageStatusAndAck(rowId: Long, status: MessageStatus, ackHash: Int?) {
+    db.messageDao().updateStatusAndAckByRowId(rowId, status, ackHash)
+  }
+
+  suspend fun markConfirmed(ackHash: Int) {
+    db.messageDao().updateStatusByAckHash(ackHash, MessageStatus.CONFIRMED)
+  }
+
+  suspend fun markFailed(ackHash: Int) {
+    db.messageDao().updateStatusByAckHash(ackHash, MessageStatus.FAILED)
+  }
 }
 
 // --- Entity ↔ Domain mapping ------------------------------------------------
 
-private fun DeviceEntity.toDomain(): SavedDevice = SavedDevice(
+private fun DeviceEntity.toDomain(): SavedDevice =
+  SavedDevice(
     id = id,
     label = label,
-    transport = when (transportType) {
+    transport =
+      when (transportType) {
         TransportType.BLE -> SavedTransport.Ble(bleIdentifier ?: id, bleAdvertName)
         TransportType.TCP -> SavedTransport.Tcp(tcpHost ?: "", tcpPort ?: 0)
-        TransportType.USB -> SavedTransport.Usb(usbClassName ?: "", usbVendorId ?: -1, usbProductId ?: -1)
-    },
+        TransportType.USB ->
+          SavedTransport.Usb(usbClassName ?: "", usbVendorId ?: -1, usbProductId ?: -1)
+      },
     favorite = isFavorite,
     lastConnectedAtMs = lastConnectedAtMs,
-)
+  )
 
-private fun SavedTransport.toType(): TransportType = when (this) {
+private fun SavedTransport.toType(): TransportType =
+  when (this) {
     is SavedTransport.Ble -> TransportType.BLE
     is SavedTransport.Tcp -> TransportType.TCP
     is SavedTransport.Usb -> TransportType.USB
-}
+  }
 
-private fun ContactEntity.toDomain(): Contact = Contact(
+private fun ContactEntity.toDomain(): Contact =
+  Contact(
     publicKey = PublicKey.fromBytes(ByteString(publicKeyBytes)),
     type = ContactType.fromRaw(type),
     flags = flags,
@@ -403,9 +433,10 @@ private fun ContactEntity.toDomain(): Contact = Contact(
     latitude = latitude,
     longitude = longitude,
     lastModified = Instant.fromEpochSeconds(lastModifiedEpochS),
-)
+  )
 
-private fun Contact.toEntity(deviceId: String, fetchedAtMs: Long): ContactEntity = ContactEntity(
+private fun Contact.toEntity(deviceId: String, fetchedAtMs: Long): ContactEntity =
+  ContactEntity(
     deviceId = deviceId,
     publicKeyHex = publicKey.toHex(),
     publicKeyBytes = publicKey.bytes.toByteArray(),
@@ -418,53 +449,57 @@ private fun Contact.toEntity(deviceId: String, fetchedAtMs: Long): ContactEntity
     longitude = longitude,
     lastModifiedEpochS = lastModified.epochSeconds,
     fetchedAtMs = fetchedAtMs,
-)
+  )
 
-private fun ChannelEntity.toDomain(): ChannelInfo = ChannelInfo(
-    index = channelIndex,
-    name = name,
-    psk = ByteString(psk),
-)
+private fun ChannelEntity.toDomain(): ChannelInfo =
+  ChannelInfo(index = channelIndex, name = name, psk = ByteString(psk))
 
-private fun ChannelInfo.toEntity(deviceId: String, fetchedAtMs: Long): ChannelEntity = ChannelEntity(
+private fun ChannelInfo.toEntity(deviceId: String, fetchedAtMs: Long): ChannelEntity =
+  ChannelEntity(
     deviceId = deviceId,
     channelIndex = index,
     name = name,
     psk = psk.toByteArray(),
     fetchedAtMs = fetchedAtMs,
-)
+  )
 
 /** Reconstruct SelfInfo from DeviceStateEntity (for seedFromCache). */
 fun DeviceStateEntity.toSelfInfo(): SelfInfo? {
-    if (selfName == null) return null
-    return SelfInfo(
-        advertType = selfAdvertType ?: 0,
-        txPowerDbm = selfTxPowerDbm ?: 0,
-        maxPowerDbm = selfMaxPowerDbm ?: 0,
-        publicKey = selfPublicKey?.let { PublicKey.fromBytes(ByteString(it)) }
-            ?: PublicKey.fromBytes(ByteString(ByteArray(32))),
-        latitude = selfLatitude ?: 0.0,
-        longitude = selfLongitude ?: 0.0,
-        multiAcks = 0,
-        advertLocationPolicy = 0,
-        telemetryFlags = 0,
-        manualAddContacts = 0,
-        radio = toRadio() ?: RadioSettings(0, 0, 0, 0),
-        name = selfName,
-    )
+  if (selfName == null) return null
+  return SelfInfo(
+    advertType = selfAdvertType ?: 0,
+    txPowerDbm = selfTxPowerDbm ?: 0,
+    maxPowerDbm = selfMaxPowerDbm ?: 0,
+    publicKey =
+      selfPublicKey?.let { PublicKey.fromBytes(ByteString(it)) }
+        ?: PublicKey.fromBytes(ByteString(ByteArray(32))),
+    latitude = selfLatitude ?: 0.0,
+    longitude = selfLongitude ?: 0.0,
+    multiAcks = 0,
+    advertLocationPolicy = 0,
+    telemetryFlags = 0,
+    manualAddContacts = 0,
+    radio = toRadio() ?: RadioSettings(0, 0, 0, 0),
+    name = selfName,
+  )
 }
 
 fun DeviceStateEntity.toBattery(): BatteryInfo? {
-    if (batteryMillivolts == null) return null
-    return BatteryInfo(batteryMillivolts, storageUsedKb ?: 0, storageTotalKb ?: 0)
+  if (batteryMillivolts == null) return null
+  return BatteryInfo(batteryMillivolts, storageUsedKb ?: 0, storageTotalKb ?: 0)
 }
 
 fun DeviceStateEntity.toRadio(): RadioSettings? {
-    if (radioFrequencyHz == null) return null
-    return RadioSettings(radioFrequencyHz, radioBandwidthHz ?: 0, radioSpreadingFactor ?: 0, radioCodingRate ?: 0)
+  if (radioFrequencyHz == null) return null
+  return RadioSettings(
+    radioFrequencyHz,
+    radioBandwidthHz ?: 0,
+    radioSpreadingFactor ?: 0,
+    radioCodingRate ?: 0,
+  )
 }
 
 fun DeviceStateEntity.toDeviceInfo(): DeviceInfo? {
-    if (protocolVersion == null) return null
-    return DeviceInfo(protocolVersion, maxContacts ?: 0, maxChannels ?: 0)
+  if (protocolVersion == null) return null
+  return DeviceInfo(protocolVersion, maxContacts ?: 0, maxChannels ?: 0)
 }

--- a/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/sync/MessagePersister.kt
+++ b/meshcore-data/src/commonMain/kotlin/ee/schimke/meshcore/data/sync/MessagePersister.kt
@@ -6,31 +6,30 @@ import ee.schimke.meshcore.data.repository.MeshcoreRepository
 import kotlinx.coroutines.flow.SharedFlow
 
 /**
- * Collects [MeshEvent]s from a connected client and persists messages
- * to Room. Launch this on a coroutine scope that lives as long as the
- * connection.
+ * Collects [MeshEvent]s from a connected client and persists messages to Room. Launch this on a
+ * coroutine scope that lives as long as the connection.
  */
 class MessagePersister(
-    private val repository: MeshcoreRepository,
-    private val deviceId: String,
-    private val contactResolver: (PublicKey) -> String?,
+  private val repository: MeshcoreRepository,
+  private val deviceId: String,
+  private val contactResolver: (PublicKey) -> String?,
 ) {
-    suspend fun collect(events: SharedFlow<MeshEvent>) {
-        events.collect { event ->
-            when (event) {
-                is MeshEvent.DirectMessage -> {
-                    val msg = event.message
-                    val fullHex = contactResolver(msg.senderPrefix) ?: msg.senderPrefix.toHex()
-                    repository.insertReceivedDm(deviceId, msg, fullHex)
-                }
-                is MeshEvent.ChannelMessage -> {
-                    repository.insertReceivedChannelMessage(deviceId, event.message)
-                }
-                is MeshEvent.SendConfirmedEvent -> {
-                    repository.markConfirmed(event.confirmed.ackHash)
-                }
-                else -> Unit
-            }
+  suspend fun collect(events: SharedFlow<MeshEvent>) {
+    events.collect { event ->
+      when (event) {
+        is MeshEvent.DirectMessage -> {
+          val msg = event.message
+          val fullHex = contactResolver(msg.senderPrefix) ?: msg.senderPrefix.toHex()
+          repository.insertReceivedDm(deviceId, msg, fullHex)
         }
+        is MeshEvent.ChannelMessage -> {
+          repository.insertReceivedChannelMessage(deviceId, event.message)
+        }
+        is MeshEvent.SendConfirmedEvent -> {
+          repository.markConfirmed(event.confirmed.ackHash)
+        }
+        else -> Unit
+      }
     }
+  }
 }

--- a/meshcore-data/src/jvmMain/kotlin/ee/schimke/meshcore/data/DatabaseFactory.jvm.kt
+++ b/meshcore-data/src/jvmMain/kotlin/ee/schimke/meshcore/data/DatabaseFactory.jvm.kt
@@ -5,11 +5,9 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import java.io.File
 
 actual fun createMeshcoreDatabase(platformContext: Any?): MeshcoreDatabase {
-    val dbFile = File(System.getProperty("user.home"), ".meshcore/meshcore.db")
-    dbFile.parentFile?.mkdirs()
-    return Room.databaseBuilder<MeshcoreDatabase>(
-        name = dbFile.absolutePath,
-    )
-        .setDriver(BundledSQLiteDriver())
-        .build()
+  val dbFile = File(System.getProperty("user.home"), ".meshcore/meshcore.db")
+  dbFile.parentFile?.mkdirs()
+  return Room.databaseBuilder<MeshcoreDatabase>(name = dbFile.absolutePath)
+    .setDriver(BundledSQLiteDriver())
+    .build()
 }

--- a/meshcore-devices-proto/build.gradle.kts
+++ b/meshcore-devices-proto/build.gradle.kts
@@ -1,19 +1,15 @@
 plugins {
-    alias(libs.plugins.kotlinJvm)
-    alias(libs.plugins.wire)
+  alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.wire)
 }
 
-kotlin {
-    jvmToolchain(21)
-}
+kotlin { jvmToolchain(21) }
 
 wire {
-    // Pure-Kotlin output: Wire generates idiomatic Kotlin data classes
-    // with ADAPTER companions that DataStore's Serializer can use
-    // directly.
-    kotlin {}
+  // Pure-Kotlin output: Wire generates idiomatic Kotlin data classes
+  // with ADAPTER companions that DataStore's Serializer can use
+  // directly.
+  kotlin {}
 }
 
-dependencies {
-    api(libs.wire.runtime)
-}
+dependencies { api(libs.wire.runtime) }

--- a/meshcore-grpc-service/build.gradle.kts
+++ b/meshcore-grpc-service/build.gradle.kts
@@ -1,53 +1,37 @@
 plugins {
-    alias(libs.plugins.kotlinJvm)
-    alias(libs.plugins.protobuf)
+  alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.protobuf)
 }
 
-kotlin {
-    jvmToolchain(21)
-}
+kotlin { jvmToolchain(21) }
 
 dependencies {
-    api(projects.meshcoreCore)
-    api(libs.grpc.stub)
-    api(libs.grpc.protobuf.lite)
-    api(libs.grpc.kotlin.stub)
-    implementation(libs.protobuf.kotlin.lite)
-    implementation(libs.javax.annotation.api)
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.io.bytestring)
+  api(projects.meshcoreCore)
+  api(libs.grpc.stub)
+  api(libs.grpc.protobuf.lite)
+  api(libs.grpc.kotlin.stub)
+  implementation(libs.protobuf.kotlin.lite)
+  implementation(libs.javax.annotation.api)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.io.bytestring)
 }
 
 protobuf {
-    protoc {
-        artifact = libs.protobuf.protoc.get().toString()
+  protoc { artifact = libs.protobuf.protoc.get().toString() }
+  plugins {
+    create("grpc") { artifact = libs.grpc.protoc.gen.java.get().toString() }
+    create("grpckt") { artifact = "${libs.grpc.protoc.gen.kotlin.get()}:jdk8@jar" }
+  }
+  generateProtoTasks {
+    all().forEach { task ->
+      task.builtins {
+        named("java") { option("lite") }
+        create("kotlin") { option("lite") }
+      }
+      task.plugins {
+        create("grpc") { option("lite") }
+        create("grpckt") { option("lite") }
+      }
     }
-    plugins {
-        create("grpc") {
-            artifact = libs.grpc.protoc.gen.java.get().toString()
-        }
-        create("grpckt") {
-            artifact = "${libs.grpc.protoc.gen.kotlin.get()}:jdk8@jar"
-        }
-    }
-    generateProtoTasks {
-        all().forEach { task ->
-            task.builtins {
-                named("java") {
-                    option("lite")
-                }
-                create("kotlin") {
-                    option("lite")
-                }
-            }
-            task.plugins {
-                create("grpc") {
-                    option("lite")
-                }
-                create("grpckt") {
-                    option("lite")
-                }
-            }
-        }
-    }
+  }
 }

--- a/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshServiceBridge.kt
+++ b/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshServiceBridge.kt
@@ -2,23 +2,22 @@ package ee.schimke.meshcore.grpc
 
 import ee.schimke.meshcore.core.client.MeshCoreClient
 import ee.schimke.meshcore.core.manager.ManagerState
-import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Instant
+import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Bridge interface that decouples the gRPC service implementation from
- * app-level DI. The app module's LifecycleService implements this by
- * delegating to MeshcoreApp's MeshCoreManager.
+ * Bridge interface that decouples the gRPC service implementation from app-level DI. The app
+ * module's LifecycleService implements this by delegating to MeshcoreApp's MeshCoreManager.
  */
 interface MeshServiceBridge {
-    val managerState: StateFlow<ManagerState>
-    val client: MeshCoreClient?
+  val managerState: StateFlow<ManagerState>
+  val client: MeshCoreClient?
 
-    /** Persist a sent DM to the local message store. */
-    suspend fun persistSentDm(
-        contactKeyHex: String,
-        text: String,
-        timestamp: Instant,
-        ackHash: Int?,
-    ) {}
+  /** Persist a sent DM to the local message store. */
+  suspend fun persistSentDm(
+    contactKeyHex: String,
+    text: String,
+    timestamp: Instant,
+    ackHash: Int?,
+  ) {}
 }

--- a/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshcoreGrpcServiceImpl.kt
+++ b/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/MeshcoreGrpcServiceImpl.kt
@@ -2,124 +2,120 @@ package ee.schimke.meshcore.grpc
 
 import ee.schimke.meshcore.core.model.MeshEvent
 import ee.schimke.meshcore.core.model.PublicKey
+import kotlin.time.Clock
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlin.time.Clock
 
-class MeshcoreGrpcServiceImpl(
-    private val bridge: MeshServiceBridge,
-) : MeshcoreServiceGrpcKt.MeshcoreServiceCoroutineImplBase() {
+class MeshcoreGrpcServiceImpl(private val bridge: MeshServiceBridge) :
+  MeshcoreServiceGrpcKt.MeshcoreServiceCoroutineImplBase() {
 
-    override suspend fun getConnectionStatus(request: Empty): ConnectionStatus =
-        bridge.managerState.value.toConnectionStatus()
+  override suspend fun getConnectionStatus(request: Empty): ConnectionStatus =
+    bridge.managerState.value.toConnectionStatus()
 
-    override fun subscribeConnectionStatus(request: Empty): Flow<ConnectionStatus> =
-        bridge.managerState.map { it.toConnectionStatus() }
+  override fun subscribeConnectionStatus(request: Empty): Flow<ConnectionStatus> =
+    bridge.managerState.map { it.toConnectionStatus() }
 
-    override suspend fun getSelfInfo(request: Empty): SelfInfoResponse {
-        val info = bridge.client?.selfInfo?.value
-            ?: return SelfInfoResponse.newBuilder().setAvailable(false).build()
-        return info.toProto()
+  override suspend fun getSelfInfo(request: Empty): SelfInfoResponse {
+    val info =
+      bridge.client?.selfInfo?.value
+        ?: return SelfInfoResponse.newBuilder().setAvailable(false).build()
+    return info.toProto()
+  }
+
+  override suspend fun getContacts(request: GetContactsRequest): ContactList {
+    val client = bridge.client
+    if (request.refresh && client != null) {
+      runCatching { client.getContacts() }
     }
+    val contacts = client?.contacts?.value ?: emptyList()
+    return ContactList.newBuilder().addAllContacts(contacts.map { it.toProto() }).build()
+  }
 
-    override suspend fun getContacts(request: GetContactsRequest): ContactList {
-        val client = bridge.client
-        if (request.refresh && client != null) {
-            runCatching { client.getContacts() }
+  override suspend fun getChannels(request: Empty): ChannelList {
+    val channels = bridge.client?.channels?.value ?: emptyList()
+    return ChannelList.newBuilder().addAllChannels(channels.map { it.toProto() }).build()
+  }
+
+  override suspend fun getBatteryInfo(request: Empty): BatteryInfoResponse {
+    val info =
+      bridge.client?.battery?.value
+        ?: return BatteryInfoResponse.newBuilder().setAvailable(false).build()
+    return info.toProto()
+  }
+
+  override suspend fun sendDirectMessage(request: SendDirectMessageRequest): SendAckResponse {
+    val client =
+      bridge.client
+        ?: return SendAckResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMessage("Not connected")
+          .build()
+    return try {
+      val recipient = PublicKey.fromBytes(request.recipientPublicKey.toByteArray())
+      val now = Clock.System.now()
+      val ack = client.sendText(recipient = recipient, text = request.text, timestamp = now)
+      bridge.persistSentDm(
+        contactKeyHex = recipient.toHex(),
+        text = request.text,
+        timestamp = now,
+        ackHash = ack.ackHash,
+      )
+      SendAckResponse.newBuilder()
+        .setSuccess(true)
+        .setAckHash(ack.ackHash)
+        .setIsFlood(ack.isFlood)
+        .build()
+    } catch (e: Exception) {
+      SendAckResponse.newBuilder()
+        .setSuccess(false)
+        .setErrorMessage(e.message ?: "Send failed")
+        .build()
+    }
+  }
+
+  override suspend fun sendChannelMessage(request: SendChannelMessageRequest): SendAckResponse {
+    val client =
+      bridge.client
+        ?: return SendAckResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMessage("Not connected")
+          .build()
+    return try {
+      val now = Clock.System.now()
+      val ack =
+        client.sendChannelText(
+          channelIdx = request.channelIndex,
+          text = request.text,
+          timestamp = now,
+        )
+      // Message appears in history when the device echoes it back
+      SendAckResponse.newBuilder()
+        .setSuccess(true)
+        .setAckHash(ack.ackHash)
+        .setIsFlood(ack.isFlood)
+        .build()
+    } catch (e: Exception) {
+      SendAckResponse.newBuilder()
+        .setSuccess(false)
+        .setErrorMessage(e.message ?: "Send failed")
+        .build()
+    }
+  }
+
+  override fun subscribeMessages(request: Empty): Flow<MeshMessage> {
+    val client = bridge.client ?: return emptyFlow()
+    return client.events
+      .filter { it is MeshEvent.DirectMessage || it is MeshEvent.ChannelMessage }
+      .map { event ->
+        val builder = MeshMessage.newBuilder()
+        when (event) {
+          is MeshEvent.DirectMessage -> builder.setDirectMessage(event.message.toProto())
+          is MeshEvent.ChannelMessage -> builder.setChannelMessage(event.message.toProto())
+          else -> error("unreachable")
         }
-        val contacts = client?.contacts?.value ?: emptyList()
-        return ContactList.newBuilder()
-            .addAllContacts(contacts.map { it.toProto() })
-            .build()
-    }
-
-    override suspend fun getChannels(request: Empty): ChannelList {
-        val channels = bridge.client?.channels?.value ?: emptyList()
-        return ChannelList.newBuilder()
-            .addAllChannels(channels.map { it.toProto() })
-            .build()
-    }
-
-    override suspend fun getBatteryInfo(request: Empty): BatteryInfoResponse {
-        val info = bridge.client?.battery?.value
-            ?: return BatteryInfoResponse.newBuilder().setAvailable(false).build()
-        return info.toProto()
-    }
-
-    override suspend fun sendDirectMessage(request: SendDirectMessageRequest): SendAckResponse {
-        val client = bridge.client
-            ?: return SendAckResponse.newBuilder()
-                .setSuccess(false)
-                .setErrorMessage("Not connected")
-                .build()
-        return try {
-            val recipient = PublicKey.fromBytes(request.recipientPublicKey.toByteArray())
-            val now = Clock.System.now()
-            val ack = client.sendText(
-                recipient = recipient,
-                text = request.text,
-                timestamp = now,
-            )
-            bridge.persistSentDm(
-                contactKeyHex = recipient.toHex(),
-                text = request.text,
-                timestamp = now,
-                ackHash = ack.ackHash,
-            )
-            SendAckResponse.newBuilder()
-                .setSuccess(true)
-                .setAckHash(ack.ackHash)
-                .setIsFlood(ack.isFlood)
-                .build()
-        } catch (e: Exception) {
-            SendAckResponse.newBuilder()
-                .setSuccess(false)
-                .setErrorMessage(e.message ?: "Send failed")
-                .build()
-        }
-    }
-
-    override suspend fun sendChannelMessage(request: SendChannelMessageRequest): SendAckResponse {
-        val client = bridge.client
-            ?: return SendAckResponse.newBuilder()
-                .setSuccess(false)
-                .setErrorMessage("Not connected")
-                .build()
-        return try {
-            val now = Clock.System.now()
-            val ack = client.sendChannelText(
-                channelIdx = request.channelIndex,
-                text = request.text,
-                timestamp = now,
-            )
-            // Message appears in history when the device echoes it back
-            SendAckResponse.newBuilder()
-                .setSuccess(true)
-                .setAckHash(ack.ackHash)
-                .setIsFlood(ack.isFlood)
-                .build()
-        } catch (e: Exception) {
-            SendAckResponse.newBuilder()
-                .setSuccess(false)
-                .setErrorMessage(e.message ?: "Send failed")
-                .build()
-        }
-    }
-
-    override fun subscribeMessages(request: Empty): Flow<MeshMessage> {
-        val client = bridge.client ?: return emptyFlow()
-        return client.events
-            .filter { it is MeshEvent.DirectMessage || it is MeshEvent.ChannelMessage }
-            .map { event ->
-                val builder = MeshMessage.newBuilder()
-                when (event) {
-                    is MeshEvent.DirectMessage -> builder.setDirectMessage(event.message.toProto())
-                    is MeshEvent.ChannelMessage -> builder.setChannelMessage(event.message.toProto())
-                    else -> error("unreachable")
-                }
-                builder.build()
-            }
-    }
+        builder.build()
+      }
+  }
 }

--- a/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/ProtoMappers.kt
+++ b/meshcore-grpc-service/src/main/kotlin/ee/schimke/meshcore/grpc/ProtoMappers.kt
@@ -1,5 +1,6 @@
 package ee.schimke.meshcore.grpc
 
+import com.google.protobuf.ByteString as ProtoByteString
 import ee.schimke.meshcore.core.manager.ManagerState
 import ee.schimke.meshcore.core.model.BatteryInfo
 import ee.schimke.meshcore.core.model.ChannelInfo
@@ -9,96 +10,91 @@ import ee.schimke.meshcore.core.model.RadioSettings
 import ee.schimke.meshcore.core.model.ReceivedChannelMessage
 import ee.schimke.meshcore.core.model.ReceivedDirectMessage
 import ee.schimke.meshcore.core.model.SelfInfo
-import com.google.protobuf.ByteString as ProtoByteString
 
 fun ManagerState.toConnectionStatus(): ConnectionStatus {
-    val (state, error) = when (this) {
-        is ManagerState.Idle -> ConnectionState.DISCONNECTED to ""
-        is ManagerState.Connecting -> ConnectionState.CONNECTING to ""
-        is ManagerState.Connected -> ConnectionState.CONNECTED to ""
-        is ManagerState.Failed -> ConnectionState.FAILED to (cause.message ?: "Unknown error")
+  val (state, error) =
+    when (this) {
+      is ManagerState.Idle -> ConnectionState.DISCONNECTED to ""
+      is ManagerState.Connecting -> ConnectionState.CONNECTING to ""
+      is ManagerState.Connected -> ConnectionState.CONNECTED to ""
+      is ManagerState.Failed -> ConnectionState.FAILED to (cause.message ?: "Unknown error")
     }
-    return ConnectionStatus.newBuilder()
-        .setState(state)
-        .setErrorMessage(error)
-        .build()
+  return ConnectionStatus.newBuilder().setState(state).setErrorMessage(error).build()
 }
 
 fun SelfInfo.toProto(): SelfInfoResponse =
-    SelfInfoResponse.newBuilder()
-        .setAvailable(true)
-        .setName(name)
-        .setPublicKey(publicKey.bytes.toProtoBytes())
-        .setLatitude(latitude)
-        .setLongitude(longitude)
-        .setTxPowerDbm(txPowerDbm)
-        .setMaxPowerDbm(maxPowerDbm)
-        .setRadio(radio.toProto())
-        .build()
+  SelfInfoResponse.newBuilder()
+    .setAvailable(true)
+    .setName(name)
+    .setPublicKey(publicKey.bytes.toProtoBytes())
+    .setLatitude(latitude)
+    .setLongitude(longitude)
+    .setTxPowerDbm(txPowerDbm)
+    .setMaxPowerDbm(maxPowerDbm)
+    .setRadio(radio.toProto())
+    .build()
 
 fun RadioSettings.toProto(): RadioSettingsMsg =
-    RadioSettingsMsg.newBuilder()
-        .setFrequencyHz(frequencyHz)
-        .setBandwidthHz(bandwidthHz)
-        .setSpreadingFactor(spreadingFactor)
-        .setCodingRate(codingRate)
-        .build()
+  RadioSettingsMsg.newBuilder()
+    .setFrequencyHz(frequencyHz)
+    .setBandwidthHz(bandwidthHz)
+    .setSpreadingFactor(spreadingFactor)
+    .setCodingRate(codingRate)
+    .build()
 
 fun Contact.toProto(): ContactMsg =
-    ContactMsg.newBuilder()
-        .setPublicKey(publicKey.bytes.toProtoBytes())
-        .setType(type.toProto())
-        .setName(name)
-        .setLatitude(latitude)
-        .setLongitude(longitude)
-        .setAdvertTimestampEpochSeconds(advertTimestamp.epochSeconds)
-        .setLastModifiedEpochSeconds(lastModified.epochSeconds)
-        .setPathLength(pathLength)
-        .setIsFlood(isFlood)
-        .build()
+  ContactMsg.newBuilder()
+    .setPublicKey(publicKey.bytes.toProtoBytes())
+    .setType(type.toProto())
+    .setName(name)
+    .setLatitude(latitude)
+    .setLongitude(longitude)
+    .setAdvertTimestampEpochSeconds(advertTimestamp.epochSeconds)
+    .setLastModifiedEpochSeconds(lastModified.epochSeconds)
+    .setPathLength(pathLength)
+    .setIsFlood(isFlood)
+    .build()
 
-fun ContactType.toProto(): ee.schimke.meshcore.grpc.ContactType = when (this) {
+fun ContactType.toProto(): ee.schimke.meshcore.grpc.ContactType =
+  when (this) {
     ContactType.CHAT -> ee.schimke.meshcore.grpc.ContactType.CHAT
     ContactType.REPEATER -> ee.schimke.meshcore.grpc.ContactType.REPEATER
     ContactType.ROOM -> ee.schimke.meshcore.grpc.ContactType.ROOM
     ContactType.SENSOR -> ee.schimke.meshcore.grpc.ContactType.SENSOR
     ContactType.UNKNOWN -> ee.schimke.meshcore.grpc.ContactType.CONTACT_TYPE_UNKNOWN
-}
+  }
 
 fun ChannelInfo.toProto(): ChannelMsg =
-    ChannelMsg.newBuilder()
-        .setIndex(index)
-        .setName(name)
-        .build()
+  ChannelMsg.newBuilder().setIndex(index).setName(name).build()
 
 fun BatteryInfo.toProto(): BatteryInfoResponse =
-    BatteryInfoResponse.newBuilder()
-        .setAvailable(true)
-        .setMillivolts(millivolts)
-        .setStorageUsedKb(storageUsedKb)
-        .setStorageTotalKb(storageTotalKb)
-        .setEstimatedPercent(estimatePercent())
-        .build()
+  BatteryInfoResponse.newBuilder()
+    .setAvailable(true)
+    .setMillivolts(millivolts)
+    .setStorageUsedKb(storageUsedKb)
+    .setStorageTotalKb(storageTotalKb)
+    .setEstimatedPercent(estimatePercent())
+    .build()
 
 fun ReceivedDirectMessage.toProto(): DirectMessageMsg =
-    DirectMessageMsg.newBuilder()
-        .setSenderPrefix(senderPrefix.bytes.toProtoBytes())
-        .setText(text)
-        .setTimestampEpochSeconds(timestamp.epochSeconds)
-        .setSnr(snr)
-        .setPathLength(pathLength)
-        .build()
+  DirectMessageMsg.newBuilder()
+    .setSenderPrefix(senderPrefix.bytes.toProtoBytes())
+    .setText(text)
+    .setTimestampEpochSeconds(timestamp.epochSeconds)
+    .setSnr(snr)
+    .setPathLength(pathLength)
+    .build()
 
 fun ReceivedChannelMessage.toProto(): ChannelMessageMsg =
-    ChannelMessageMsg.newBuilder()
-        .setChannelIndex(channelIndex)
-        .setSender(sender ?: "")
-        .setText(text)
-        .setTimestampEpochSeconds(timestamp.epochSeconds)
-        .setSnr(snr)
-        .setPathLength(pathLength)
-        .build()
+  ChannelMessageMsg.newBuilder()
+    .setChannelIndex(channelIndex)
+    .setSender(sender ?: "")
+    .setText(text)
+    .setTimestampEpochSeconds(timestamp.epochSeconds)
+    .setSnr(snr)
+    .setPathLength(pathLength)
+    .build()
 
 /** Convert kotlinx-io ByteString (used by PublicKey) to protobuf ByteString. */
 private fun kotlinx.io.bytestring.ByteString.toProtoBytes(): ProtoByteString =
-    ProtoByteString.copyFrom(toByteArray())
+  ProtoByteString.copyFrom(toByteArray())

--- a/meshcore-mobile/build.gradle.kts
+++ b/meshcore-mobile/build.gradle.kts
@@ -1,32 +1,32 @@
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKotlinMultiplatformLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.metro)
+  alias(libs.plugins.kotlinMultiplatform)
+  alias(libs.plugins.androidKotlinMultiplatformLibrary)
+  alias(libs.plugins.composeMultiplatform)
+  alias(libs.plugins.composeCompiler)
+  alias(libs.plugins.metro)
 }
 
 kotlin {
-    jvmToolchain(21)
+  jvmToolchain(21)
 
-    android {
-        namespace = "ee.schimke.meshcore.mobile"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
+  android {
+    namespace = "ee.schimke.meshcore.mobile"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
 
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.meshcoreCore)
-            implementation(libs.kotlinx.coroutines.core)
-        }
-        val androidMain by getting {
-            dependencies {
-                api(projects.meshcoreComponents)
-                implementation(libs.kotlinx.coroutines.android)
-                api(projects.meshcoreTransportBle)
-                api(projects.meshcoreTransportUsb)
-            }
-        }
+  sourceSets {
+    commonMain.dependencies {
+      api(projects.meshcoreCore)
+      implementation(libs.kotlinx.coroutines.core)
     }
+    val androidMain by getting {
+      dependencies {
+        api(projects.meshcoreComponents)
+        implementation(libs.kotlinx.coroutines.android)
+        api(projects.meshcoreTransportBle)
+        api(projects.meshcoreTransportUsb)
+      }
+    }
+  }
 }

--- a/meshcore-transport-ble/build.gradle.kts
+++ b/meshcore-transport-ble/build.gradle.kts
@@ -1,23 +1,23 @@
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKotlinMultiplatformLibrary)
+  alias(libs.plugins.kotlinMultiplatform)
+  alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
 kotlin {
-    jvmToolchain(21)
+  jvmToolchain(21)
 
-    android {
-        namespace = "ee.schimke.meshcore.transport.ble"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    jvm()
+  android {
+    namespace = "ee.schimke.meshcore.transport.ble"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  jvm()
 
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.meshcoreCore)
-            implementation(libs.kotlinx.coroutines.core)
-            api(libs.kable.core)
-        }
+  sourceSets {
+    commonMain.dependencies {
+      api(projects.meshcoreCore)
+      implementation(libs.kotlinx.coroutines.core)
+      api(libs.kable.core)
     }
+  }
 }

--- a/meshcore-transport-ble/src/commonMain/kotlin/ee/schimke/meshcore/transport/ble/BleTransport.kt
+++ b/meshcore-transport-ble/src/commonMain/kotlin/ee/schimke/meshcore/transport/ble/BleTransport.kt
@@ -11,6 +11,8 @@ import com.juul.kable.characteristicOf
 import ee.schimke.meshcore.core.protocol.MeshCoreConstants
 import ee.schimke.meshcore.core.transport.Transport
 import ee.schimke.meshcore.core.transport.TransportState
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -19,7 +21,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,45 +30,46 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.ByteString
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalUuidApi::class)
 private val serviceUuid = Uuid.parse(MeshCoreConstants.BLE_SERVICE_UUID)
 @OptIn(ExperimentalUuidApi::class)
-private val txCharacteristic = characteristicOf(
+private val txCharacteristic =
+  characteristicOf(
     service = serviceUuid,
     characteristic = Uuid.parse(MeshCoreConstants.BLE_TX_CHAR_UUID),
-)
+  )
 @OptIn(ExperimentalUuidApi::class)
-private val rxCharacteristic = characteristicOf(
+private val rxCharacteristic =
+  characteristicOf(
     service = serviceUuid,
     characteristic = Uuid.parse(MeshCoreConstants.BLE_RX_CHAR_UUID),
-)
+  )
 
 /** Cross-platform summary of a MeshCore device seen during a BLE scan. */
 data class BleAdvertisement(
-    val identifier: String,
-    val name: String?,
-    val rssi: Int,
-    internal val raw: Advertisement,
+  val identifier: String,
+  val name: String?,
+  val rssi: Int,
+  internal val raw: Advertisement,
 )
 
 internal expect fun com.juul.kable.ScannerBuilder.applyMeshCoreScannerDefaults()
 
 class BleScanner {
-    private val scanner = Scanner { applyMeshCoreScannerDefaults() }
+  private val scanner = Scanner { applyMeshCoreScannerDefaults() }
 
-    val advertisements: Flow<BleAdvertisement> = scanner.advertisements
-        .map { adv ->
-            BleAdvertisement(
-                identifier = adv.identifier.toString(),
-                name = adv.name,
-                rssi = adv.rssi,
-                raw = adv,
-            )
-        }
+  val advertisements: Flow<BleAdvertisement> =
+    scanner.advertisements.map { adv ->
+      BleAdvertisement(
+        identifier = adv.identifier.toString(),
+        name = adv.name,
+        rssi = adv.rssi,
+        raw = adv,
+      )
+    }
 }
 
 internal expect fun PeripheralBuilder.applyMeshCoreDefaults(autoConnect: Boolean)
@@ -75,112 +77,115 @@ internal expect fun PeripheralBuilder.applyMeshCoreDefaults(autoConnect: Boolean
 internal expect suspend fun requestLargerMtu(peripheral: Peripheral)
 
 private sealed interface BleTarget {
-    fun create(): Peripheral
-    class Advert(private val adv: Advertisement) : BleTarget {
-        override fun create(): Peripheral =
-            Peripheral(adv) { applyMeshCoreDefaults(autoConnect = false) }
-    }
-    class ById(private val id: Identifier) : BleTarget {
-        override fun create(): Peripheral =
-            Peripheral(id) { applyMeshCoreDefaults(autoConnect = true) }
-    }
+  fun create(): Peripheral
+
+  class Advert(private val adv: Advertisement) : BleTarget {
+    override fun create(): Peripheral =
+      Peripheral(adv) { applyMeshCoreDefaults(autoConnect = false) }
+  }
+
+  class ById(private val id: Identifier) : BleTarget {
+    override fun create(): Peripheral = Peripheral(id) { applyMeshCoreDefaults(autoConnect = true) }
+  }
 }
 
 /**
- * BLE transport over the MeshCore Nordic UART Service, backed by Kable.
- * Each GATT write / characteristic notification delivers one complete
- * MeshCore frame, so no stream codec is required.
+ * BLE transport over the MeshCore Nordic UART Service, backed by Kable. Each GATT write /
+ * characteristic notification delivers one complete MeshCore frame, so no stream codec is required.
  */
-class BleTransport private constructor(
-    private val target: BleTarget,
-) : Transport {
+class BleTransport private constructor(private val target: BleTarget) : Transport {
 
-    constructor(advertisement: BleAdvertisement) : this(BleTarget.Advert(advertisement.raw))
+  constructor(advertisement: BleAdvertisement) : this(BleTarget.Advert(advertisement.raw))
 
-    private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
-    override val state: StateFlow<TransportState> = _state.asStateFlow()
+  private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
+  override val state: StateFlow<TransportState> = _state.asStateFlow()
 
-    private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
-    override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
+  private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
+  override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
 
-    private var sessionScope: CoroutineScope? = null
-    private var peripheral: Peripheral? = null
-    private var observerJob: Job? = null
-    private var stateJob: Job? = null
+  private var sessionScope: CoroutineScope? = null
+  private var peripheral: Peripheral? = null
+  private var observerJob: Job? = null
+  private var stateJob: Job? = null
 
-    override suspend fun connect() {
-        if (_state.value is TransportState.Connected) return
-        _state.value = TransportState.Connecting
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        sessionScope = scope
+  override suspend fun connect() {
+    if (_state.value is TransportState.Connected) return
+    _state.value = TransportState.Connecting
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    sessionScope = scope
+    try {
+      val p = target.create()
+      peripheral = p
+      stateJob = scope.launch {
+        p.state.collect { s ->
+          when (s) {
+            is State.Connected -> _state.value = TransportState.Connected
+            is State.Disconnected -> _state.value = TransportState.Disconnected
+            else -> Unit
+          }
+        }
+      }
+      p.connect()
+      // Negotiate a larger MTU so MeshCore frames (up to 172 bytes)
+      // fit in a single BLE notification. Without this, the default
+      // ATT MTU of 23 (20-byte payload) splits frames across
+      // multiple notifications and the parser sees garbage.
+      runCatching { requestLargerMtu(p) }
+      observerJob =
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+          p.observe(txCharacteristic).collect { bytes -> _incoming.emit(ByteString(bytes)) }
+        }
+      _state.value = TransportState.Connected
+    } catch (t: CancellationException) {
+      closeQuietly()
+      _state.value = TransportState.Disconnected
+      throw t
+    } catch (t: Throwable) {
+      closeQuietly()
+      _state.value = TransportState.Error(t)
+      throw t
+    }
+  }
+
+  override suspend fun send(frame: ByteString) {
+    val p = peripheral ?: error("BLE transport not connected")
+    p.write(rxCharacteristic, frame.toByteArray(), WriteType.WithoutResponse)
+  }
+
+  override suspend fun close() {
+    closeQuietly()
+    _state.value = TransportState.Disconnected
+  }
+
+  private suspend fun closeQuietly() {
+    observerJob?.cancel()
+    observerJob = null
+    stateJob?.cancel()
+    stateJob = null
+    val p = peripheral
+    peripheral = null
+    // Kable only releases the BluetoothGatt when the Peripheral itself is
+    // torn down — cancelling sessionScope (our observer scope) is not
+    // enough. disconnect() suspends until State.Disconnected, close()
+    // cancels Peripheral's internal scope to free the GATT handle.
+    // NonCancellable so teardown completes even when close() is called
+    // from a cancelled coroutine (e.g. cancel() path after timeout).
+    if (p != null) {
+      withContext(NonCancellable) {
         try {
-            val p = target.create()
-            peripheral = p
-            stateJob = scope.launch {
-                p.state.collect { s ->
-                    when (s) {
-                        is State.Connected -> _state.value = TransportState.Connected
-                        is State.Disconnected -> _state.value = TransportState.Disconnected
-                        else -> Unit
-                    }
-                }
-            }
-            p.connect()
-            // Negotiate a larger MTU so MeshCore frames (up to 172 bytes)
-            // fit in a single BLE notification. Without this, the default
-            // ATT MTU of 23 (20-byte payload) splits frames across
-            // multiple notifications and the parser sees garbage.
-            runCatching { requestLargerMtu(p) }
-            observerJob = scope.launch(start = CoroutineStart.UNDISPATCHED) {
-                p.observe(txCharacteristic).collect { bytes ->
-                    _incoming.emit(ByteString(bytes))
-                }
-            }
-            _state.value = TransportState.Connected
-        } catch (t: CancellationException) {
-            closeQuietly()
-            _state.value = TransportState.Disconnected
-            throw t
-        } catch (t: Throwable) {
-            closeQuietly()
-            _state.value = TransportState.Error(t)
-            throw t
-        }
+          p.disconnect()
+        } catch (_: Throwable) {}
+        try {
+          p.close()
+        } catch (_: Throwable) {}
+      }
     }
+    sessionScope?.cancel()
+    sessionScope = null
+  }
 
-    override suspend fun send(frame: ByteString) {
-        val p = peripheral ?: error("BLE transport not connected")
-        p.write(rxCharacteristic, frame.toByteArray(), WriteType.WithoutResponse)
-    }
-
-    override suspend fun close() {
-        closeQuietly()
-        _state.value = TransportState.Disconnected
-    }
-
-    private suspend fun closeQuietly() {
-        observerJob?.cancel(); observerJob = null
-        stateJob?.cancel(); stateJob = null
-        val p = peripheral
-        peripheral = null
-        // Kable only releases the BluetoothGatt when the Peripheral itself is
-        // torn down — cancelling sessionScope (our observer scope) is not
-        // enough. disconnect() suspends until State.Disconnected, close()
-        // cancels Peripheral's internal scope to free the GATT handle.
-        // NonCancellable so teardown completes even when close() is called
-        // from a cancelled coroutine (e.g. cancel() path after timeout).
-        if (p != null) {
-            withContext(NonCancellable) {
-                try { p.disconnect() } catch (_: Throwable) {}
-                try { p.close() } catch (_: Throwable) {}
-            }
-        }
-        sessionScope?.cancel()
-        sessionScope = null
-    }
-
-    companion object {
-        fun fromIdentifier(identifier: Identifier): BleTransport =
-            BleTransport(BleTarget.ById(identifier))
-    }
+  companion object {
+    fun fromIdentifier(identifier: Identifier): BleTransport =
+      BleTransport(BleTarget.ById(identifier))
+  }
 }

--- a/meshcore-transport-ble/src/jvmMain/kotlin/ee/schimke/meshcore/transport/ble/BleTransport.jvm.kt
+++ b/meshcore-transport-ble/src/jvmMain/kotlin/ee/schimke/meshcore/transport/ble/BleTransport.jvm.kt
@@ -6,19 +6,19 @@ import com.juul.kable.ScannerBuilder
 import com.juul.kable.logs.Logging
 
 internal actual suspend fun requestLargerMtu(peripheral: Peripheral) {
-    // JVM BLE (btleplug) doesn't support MTU negotiation
+  // JVM BLE (btleplug) doesn't support MTU negotiation
 }
 
 internal actual fun PeripheralBuilder.applyMeshCoreDefaults(autoConnect: Boolean) {
-    logging {
-        level = Logging.Level.Events
-        identifier = "meshcore-ble"
-    }
+  logging {
+    level = Logging.Level.Events
+    identifier = "meshcore-ble"
+  }
 }
 
 internal actual fun ScannerBuilder.applyMeshCoreScannerDefaults() {
-    logging {
-        level = Logging.Level.Events
-        identifier = "meshcore-scan"
-    }
+  logging {
+    level = Logging.Level.Events
+    identifier = "meshcore-scan"
+  }
 }

--- a/meshcore-transport-tcp/build.gradle.kts
+++ b/meshcore-transport-tcp/build.gradle.kts
@@ -1,19 +1,11 @@
-plugins {
-    alias(libs.plugins.kotlinJvm)
-}
+plugins { alias(libs.plugins.kotlinJvm) }
 
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-    }
-}
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 dependencies {
-    api(projects.meshcoreCore)
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.ktor.network)
+  api(projects.meshcoreCore)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.ktor.network)
 }

--- a/meshcore-transport-tcp/src/main/kotlin/ee/schimke/meshcore/transport/tcp/TcpTransport.kt
+++ b/meshcore-transport-tcp/src/main/kotlin/ee/schimke/meshcore/transport/tcp/TcpTransport.kt
@@ -29,90 +29,89 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
 
 /**
- * TCP transport built on ktor-network. Frames are wrapped with the
- * 0x3C/0x3E length-prefixed codec shared with the USB serial transport.
+ * TCP transport built on ktor-network. Frames are wrapped with the 0x3C/0x3E length-prefixed codec
+ * shared with the USB serial transport.
  */
-class TcpTransport(
-    private val host: String,
-    private val port: Int,
-) : Transport {
+class TcpTransport(private val host: String, private val port: Int) : Transport {
 
-    private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
-    override val state: StateFlow<TransportState> = _state.asStateFlow()
+  private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
+  override val state: StateFlow<TransportState> = _state.asStateFlow()
 
-    private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
-    override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
+  private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
+  override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
 
-    private val decoder = StreamFrameCodec.Decoder()
-    private val writeMutex = Mutex()
-    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private val decoder = StreamFrameCodec.Decoder()
+  private val writeMutex = Mutex()
+  private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    private var selector: SelectorManager? = null
-    private var socket: Socket? = null
-    private var readChannel: ByteReadChannel? = null
-    private var writeChannel: ByteWriteChannel? = null
-    private var readerJob: Job? = null
+  private var selector: SelectorManager? = null
+  private var socket: Socket? = null
+  private var readChannel: ByteReadChannel? = null
+  private var writeChannel: ByteWriteChannel? = null
+  private var readerJob: Job? = null
 
-    override suspend fun connect() {
-        if (_state.value is TransportState.Connected) return
-        _state.value = TransportState.Connecting
+  override suspend fun connect() {
+    if (_state.value is TransportState.Connected) return
+    _state.value = TransportState.Connecting
+    try {
+      val sel = SelectorManager(Dispatchers.Default)
+      val s = aSocket(sel).tcp().connect(host, port) { noDelay = true }
+      selector = sel
+      socket = s
+      readChannel = s.openReadChannel()
+      writeChannel = s.openWriteChannel(autoFlush = true)
+      decoder.reset()
+      readerJob = ioScope.launch {
+        val rc = readChannel ?: return@launch
+        val buf = ByteArray(1024)
         try {
-            val sel = SelectorManager(Dispatchers.Default)
-            val s = aSocket(sel).tcp().connect(host, port) { noDelay = true }
-            selector = sel
-            socket = s
-            readChannel = s.openReadChannel()
-            writeChannel = s.openWriteChannel(autoFlush = true)
-            decoder.reset()
-            readerJob = ioScope.launch {
-                val rc = readChannel ?: return@launch
-                val buf = ByteArray(1024)
-                try {
-                    while (isActive && !rc.isClosedForRead) {
-                        val n = rc.readAvailable(buf, 0, buf.size)
-                        if (n <= 0) break
-                        val chunk = buf.copyOf(n)
-                        for (pkt in decoder.ingest(chunk)) {
-                            if (pkt.isRx) _incoming.emit(pkt.payload)
-                        }
-                    }
-                } catch (t: Throwable) {
-                    _state.value = TransportState.Error(t)
-                } finally {
-                    if (_state.value !is TransportState.Error) {
-                        _state.value = TransportState.Disconnected
-                    }
-                }
+          while (isActive && !rc.isClosedForRead) {
+            val n = rc.readAvailable(buf, 0, buf.size)
+            if (n <= 0) break
+            val chunk = buf.copyOf(n)
+            for (pkt in decoder.ingest(chunk)) {
+              if (pkt.isRx) _incoming.emit(pkt.payload)
             }
-            _state.value = TransportState.Connected
+          }
         } catch (t: Throwable) {
-            closeQuietly()
-            _state.value = TransportState.Error(t)
-            throw t
+          _state.value = TransportState.Error(t)
+        } finally {
+          if (_state.value !is TransportState.Error) {
+            _state.value = TransportState.Disconnected
+          }
         }
+      }
+      _state.value = TransportState.Connected
+    } catch (t: Throwable) {
+      closeQuietly()
+      _state.value = TransportState.Error(t)
+      throw t
     }
+  }
 
-    override suspend fun send(frame: ByteString) {
-        val wc = writeChannel ?: error("TCP transport not connected")
-        val packet = StreamFrameCodec.encodeTx(frame).toByteArray()
-        writeMutex.withLock {
-            wc.writeFully(packet)
-        }
-    }
+  override suspend fun send(frame: ByteString) {
+    val wc = writeChannel ?: error("TCP transport not connected")
+    val packet = StreamFrameCodec.encodeTx(frame).toByteArray()
+    writeMutex.withLock { wc.writeFully(packet) }
+  }
 
-    override suspend fun close() {
-        closeQuietly()
-        _state.value = TransportState.Disconnected
-    }
+  override suspend fun close() {
+    closeQuietly()
+    _state.value = TransportState.Disconnected
+  }
 
-    private fun closeQuietly() {
-        try { socket?.close() } catch (_: Throwable) {}
-        try { selector?.close() } catch (_: Throwable) {}
-        socket = null
-        selector = null
-        readChannel = null
-        writeChannel = null
-        readerJob?.cancel()
-        readerJob = null
-    }
+  private fun closeQuietly() {
+    try {
+      socket?.close()
+    } catch (_: Throwable) {}
+    try {
+      selector?.close()
+    } catch (_: Throwable) {}
+    socket = null
+    selector = null
+    readChannel = null
+    writeChannel = null
+    readerJob?.cancel()
+    readerJob = null
+  }
 }

--- a/meshcore-transport-usb/build.gradle.kts
+++ b/meshcore-transport-usb/build.gradle.kts
@@ -1,33 +1,25 @@
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKotlinMultiplatformLibrary)
+  alias(libs.plugins.kotlinMultiplatform)
+  alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
 kotlin {
-    jvmToolchain(21)
+  jvmToolchain(21)
 
-    android {
-        namespace = "ee.schimke.meshcore.transport.usb"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    jvm()
+  android {
+    namespace = "ee.schimke.meshcore.transport.usb"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  jvm()
 
-    sourceSets {
-        commonMain.dependencies {
-            api(projects.meshcoreCore)
-            implementation(libs.kotlinx.coroutines.core)
-            api(libs.mcarr.usb)
-        }
-        val androidMain by getting {
-            dependencies {
-                implementation(libs.mcarr.usb.android)
-            }
-        }
-        val jvmMain by getting {
-            dependencies {
-                implementation(libs.jserialcomm)
-            }
-        }
+  sourceSets {
+    commonMain.dependencies {
+      api(projects.meshcoreCore)
+      implementation(libs.kotlinx.coroutines.core)
+      api(libs.mcarr.usb)
     }
+    val androidMain by getting { dependencies { implementation(libs.mcarr.usb.android) } }
+    val jvmMain by getting { dependencies { implementation(libs.jserialcomm) } }
+  }
 }

--- a/meshcore-transport-usb/src/commonMain/kotlin/ee/schimke/meshcore/transport/usb/UsbSerialTransport.kt
+++ b/meshcore-transport-usb/src/commonMain/kotlin/ee/schimke/meshcore/transport/usb/UsbSerialTransport.kt
@@ -23,81 +23,82 @@ import kotlinx.coroutines.yield
 import kotlinx.io.bytestring.ByteString
 
 /**
- * Serial transport built on [ISerialPortWrapper]. The port is opened in
- * [connect] (with [baudRate] applied), and frames are wrapped with the
- * shared 0x3C/0x3E length-prefixed codec.
+ * Serial transport built on [ISerialPortWrapper]. The port is opened in [connect] (with [baudRate]
+ * applied), and frames are wrapped with the shared 0x3C/0x3E length-prefixed codec.
  *
- * On Android, construct with a `UsfaPortWrapper` from mcarr-usb-android.
- * On JVM, construct with a JvmSerialPort backed by jSerialComm.
+ * On Android, construct with a `UsfaPortWrapper` from mcarr-usb-android. On JVM, construct with a
+ * JvmSerialPort backed by jSerialComm.
  */
 class UsbSerialTransport(
-    private val port: ISerialPortWrapper,
-    private val baudRate: Int = 115200,
-    private val readChunkSize: Int = 256,
+  private val port: ISerialPortWrapper,
+  private val baudRate: Int = 115200,
+  private val readChunkSize: Int = 256,
 ) : Transport {
 
-    private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
-    override val state: StateFlow<TransportState> = _state.asStateFlow()
+  private val _state = MutableStateFlow<TransportState>(TransportState.Disconnected)
+  override val state: StateFlow<TransportState> = _state.asStateFlow()
 
-    private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
-    override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
+  private val _incoming = MutableSharedFlow<ByteString>(extraBufferCapacity = 64)
+  override val incoming: SharedFlow<ByteString> = _incoming.asSharedFlow()
 
-    private val decoder = StreamFrameCodec.Decoder()
-    private val writeMutex = Mutex()
-    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private var readerJob: Job? = null
+  private val decoder = StreamFrameCodec.Decoder()
+  private val writeMutex = Mutex()
+  private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private var readerJob: Job? = null
 
-    override suspend fun connect() {
-        if (_state.value is TransportState.Connected) return
-        _state.value = TransportState.Connecting
+  override suspend fun connect() {
+    if (_state.value is TransportState.Connected) return
+    _state.value = TransportState.Connecting
+    try {
+      port.open()
+      port.setBaudRate(baudRate)
+      decoder.reset()
+      readerJob = ioScope.launch {
         try {
-            port.open()
-            port.setBaudRate(baudRate)
-            decoder.reset()
-            readerJob = ioScope.launch {
-                try {
-                    while (isActive && port.isOpen()) {
-                        val chunk = try {
-                            port.read(readChunkSize, 250L)
-                        } catch (_: CancellationException) {
-                            yield()
-                            continue
-                        }
-                        if (chunk.isEmpty()) {
-                            yield()
-                            continue
-                        }
-                        for (pkt in decoder.ingest(chunk)) {
-                            if (pkt.isRx) _incoming.emit(pkt.payload)
-                        }
-                    }
-                } catch (t: Throwable) {
-                    _state.value = TransportState.Error(t)
-                }
+          while (isActive && port.isOpen()) {
+            val chunk =
+              try {
+                port.read(readChunkSize, 250L)
+              } catch (_: CancellationException) {
+                yield()
+                continue
+              }
+            if (chunk.isEmpty()) {
+              yield()
+              continue
             }
-            _state.value = TransportState.Connected
+            for (pkt in decoder.ingest(chunk)) {
+              if (pkt.isRx) _incoming.emit(pkt.payload)
+            }
+          }
         } catch (t: Throwable) {
-            closeQuietly()
-            _state.value = TransportState.Error(t)
-            throw t
+          _state.value = TransportState.Error(t)
         }
+      }
+      _state.value = TransportState.Connected
+    } catch (t: Throwable) {
+      closeQuietly()
+      _state.value = TransportState.Error(t)
+      throw t
     }
+  }
 
-    override suspend fun send(frame: ByteString) {
-        if (!port.isOpen()) error("USB transport not connected")
-        val packet = StreamFrameCodec.encodeTx(frame)
-        writeMutex.withLock {
-            port.write(packet.toByteArray(), 1000L)
-        }
-    }
+  override suspend fun send(frame: ByteString) {
+    if (!port.isOpen()) error("USB transport not connected")
+    val packet = StreamFrameCodec.encodeTx(frame)
+    writeMutex.withLock { port.write(packet.toByteArray(), 1000L) }
+  }
 
-    override suspend fun close() {
-        closeQuietly()
-        _state.value = TransportState.Disconnected
-    }
+  override suspend fun close() {
+    closeQuietly()
+    _state.value = TransportState.Disconnected
+  }
 
-    private fun closeQuietly() {
-        readerJob?.cancel(); readerJob = null
-        try { if (port.isOpen()) port.close() } catch (_: Throwable) {}
-    }
+  private fun closeQuietly() {
+    readerJob?.cancel()
+    readerJob = null
+    try {
+      if (port.isOpen()) port.close()
+    } catch (_: Throwable) {}
+  }
 }

--- a/meshcore-transport-usb/src/jvmMain/kotlin/ee/schimke/meshcore/transport/usb/JvmSerialPort.kt
+++ b/meshcore-transport-usb/src/jvmMain/kotlin/ee/schimke/meshcore/transport/usb/JvmSerialPort.kt
@@ -9,80 +9,91 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.withTimeout
 
 /**
- * JVM implementation of [ISerialPortWrapper] backed by jSerialComm.
- * Use [listPorts] to enumerate available serial ports.
+ * JVM implementation of [ISerialPortWrapper] backed by jSerialComm. Use [listPorts] to enumerate
+ * available serial ports.
  */
-class JvmSerialPort(
-    private val port: SerialPort,
-) : ISerialPortWrapper {
+class JvmSerialPort(private val port: SerialPort) : ISerialPortWrapper {
 
-    override var defaultReadTimeout: Long = 1000L
-    override var defaultWriteTimeout: Long = 1000L
-    override var vendorId: Int = port.vendorID
-    override var productId: Int = port.productID
+  override var defaultReadTimeout: Long = 1000L
+  override var defaultWriteTimeout: Long = 1000L
+  override var vendorId: Int = port.vendorID
+  override var productId: Int = port.productID
 
-    val portName: String get() = port.systemPortName
-    val descriptivePortName: String get() = port.descriptivePortName
+  val portName: String
+    get() = port.systemPortName
 
-    override suspend fun <T> use(callback: suspend (ISerialPortWrapper) -> T): T {
-        open()
-        return try { callback(this) } finally { close() }
+  val descriptivePortName: String
+    get() = port.descriptivePortName
+
+  override suspend fun <T> use(callback: suspend (ISerialPortWrapper) -> T): T {
+    open()
+    return try {
+      callback(this)
+    } finally {
+      close()
+    }
+  }
+
+  override fun setDefaultTimeouts(readTimeout: Long, writeTimeout: Long) {
+    defaultReadTimeout = readTimeout
+    defaultWriteTimeout = writeTimeout
+  }
+
+  override suspend fun read(numBytes: Int): ByteArray = read(numBytes, defaultReadTimeout)
+
+  override suspend fun read(numBytes: Int, timeout: Long): ByteArray =
+    withTimeout(timeout) {
+      val buf = ByteArray(numBytes)
+      val n = port.readBytes(buf, numBytes)
+      if (n <= 0) ByteArray(0) else buf.copyOf(n)
     }
 
-    override fun setDefaultTimeouts(readTimeout: Long, writeTimeout: Long) {
-        defaultReadTimeout = readTimeout
-        defaultWriteTimeout = writeTimeout
+  override fun read(numBytes: Int, scope: CoroutineScope): Deferred<ByteArray> = scope.async {
+    read(numBytes)
+  }
+
+  override fun read(numBytes: Int, timeout: Long, scope: CoroutineScope): Deferred<ByteArray> =
+    scope.async {
+      read(numBytes, timeout)
     }
 
-    override suspend fun read(numBytes: Int): ByteArray = read(numBytes, defaultReadTimeout)
+  override suspend fun write(bytes: ByteArray): Int = write(bytes, defaultWriteTimeout)
 
-    override suspend fun read(numBytes: Int, timeout: Long): ByteArray = withTimeout(timeout) {
-        val buf = ByteArray(numBytes)
-        val n = port.readBytes(buf, numBytes)
-        if (n <= 0) ByteArray(0) else buf.copyOf(n)
+  override suspend fun write(bytes: ByteArray, timeout: Long): Int =
+    withTimeout(timeout) { port.writeBytes(bytes, bytes.size) }
+
+  override fun write(bytes: ByteArray, scope: CoroutineScope): Deferred<Int> = scope.async {
+    write(bytes)
+  }
+
+  override fun write(bytes: ByteArray, timeout: Long, scope: CoroutineScope): Deferred<Int> =
+    scope.async {
+      write(bytes, timeout)
     }
 
-    override fun read(numBytes: Int, scope: CoroutineScope): Deferred<ByteArray> =
-        scope.async { read(numBytes) }
+  override fun open() {
+    port.setComPortTimeouts(
+      SerialPort.TIMEOUT_READ_BLOCKING or SerialPort.TIMEOUT_WRITE_BLOCKING,
+      250,
+      1000,
+    )
+    if (!port.openPort()) error("Failed to open ${port.systemPortName}")
+  }
 
-    override fun read(numBytes: Int, timeout: Long, scope: CoroutineScope): Deferred<ByteArray> =
-        scope.async { read(numBytes, timeout) }
+  override fun close() {
+    port.closePort()
+  }
 
-    override suspend fun write(bytes: ByteArray): Int = write(bytes, defaultWriteTimeout)
+  override fun isOpen(): Boolean = port.isOpen
 
-    override suspend fun write(bytes: ByteArray, timeout: Long): Int = withTimeout(timeout) {
-        port.writeBytes(bytes, bytes.size)
-    }
+  override fun setBaudRate(rate: Int) {
+    port.setBaudRate(rate)
+  }
 
-    override fun write(bytes: ByteArray, scope: CoroutineScope): Deferred<Int> =
-        scope.async { write(bytes) }
+  override fun bytesAvailable(): Int = port.bytesAvailable()
 
-    override fun write(bytes: ByteArray, timeout: Long, scope: CoroutineScope): Deferred<Int> =
-        scope.async { write(bytes, timeout) }
-
-    override fun open() {
-        port.setComPortTimeouts(
-            SerialPort.TIMEOUT_READ_BLOCKING or SerialPort.TIMEOUT_WRITE_BLOCKING,
-            250, 1000,
-        )
-        if (!port.openPort()) error("Failed to open ${port.systemPortName}")
-    }
-
-    override fun close() {
-        port.closePort()
-    }
-
-    override fun isOpen(): Boolean = port.isOpen
-
-    override fun setBaudRate(rate: Int) {
-        port.setBaudRate(rate)
-    }
-
-    override fun bytesAvailable(): Int = port.bytesAvailable()
-
-    companion object {
-        /** List all available serial ports on this JVM host. */
-        fun listPorts(): List<JvmSerialPort> =
-            SerialPort.getCommPorts().map { JvmSerialPort(it) }
-    }
+  companion object {
+    /** List all available serial ports on this JVM host. */
+    fun listPorts(): List<JvmSerialPort> = SerialPort.getCommPorts().map { JvmSerialPort(it) }
+  }
 }

--- a/meshcore-tui/build.gradle.kts
+++ b/meshcore-tui/build.gradle.kts
@@ -1,73 +1,66 @@
-import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import java.nio.file.Files
+import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 
 plugins {
-    alias(libs.plugins.kotlinJvm)
-    application
-    alias(libs.plugins.graalvmNative)
+  alias(libs.plugins.kotlinJvm)
+  application
+  alias(libs.plugins.graalvmNative)
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-    }
-}
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 dependencies {
-    implementation(projects.meshcoreCore)
-    implementation(projects.meshcoreTransportTcp)
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.clikt)
-    implementation(libs.mordant)
-    implementation(libs.mordant.coroutines)
+  implementation(projects.meshcoreCore)
+  implementation(projects.meshcoreTransportTcp)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.clikt)
+  implementation(libs.mordant)
+  implementation(libs.mordant.coroutines)
 }
 
-application {
-    mainClass.set("ee.schimke.meshcore.tui.MainKt")
-}
+application { mainClass.set("ee.schimke.meshcore.tui.MainKt") }
 
 graalvmNative {
-    binaries {
-        named("main") {
-            mainClass.set("ee.schimke.meshcore.tui.MainKt")
-            imageName.set("meshcore-tui")
-            buildArgs.addAll(
-                "--no-fallback",
-                "-H:+UnlockExperimentalVMOptions",
-                "-H:+ReportExceptionStackTraces",
-            )
-            javaLauncher.set(
-                javaToolchains.launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(25))
-                    vendor.set(JvmVendorSpec.GRAAL_VM)
-                },
-            )
+  binaries {
+    named("main") {
+      mainClass.set("ee.schimke.meshcore.tui.MainKt")
+      imageName.set("meshcore-tui")
+      buildArgs.addAll(
+        "--no-fallback",
+        "-H:+UnlockExperimentalVMOptions",
+        "-H:+ReportExceptionStackTraces",
+      )
+      javaLauncher.set(
+        javaToolchains.launcherFor {
+          languageVersion.set(JavaLanguageVersion.of(25))
+          vendor.set(JvmVendorSpec.GRAAL_VM)
         }
+      )
     }
-    metadataRepository { enabled.set(true) }
+  }
+  metadataRepository { enabled.set(true) }
 }
 
 // square/okhttp#9393 — recreate symlinks broken by Gradle toolchain provisioning
 // (https://github.com/gradle/gradle/issues/28583).
 tasks.named<BuildNativeImageTask>("nativeCompile") {
-    val toolchainDir = options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
-        if (name == "bin") parentFile else this
+  val toolchainDir =
+    options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
+      if (name == "bin") parentFile else this
     }
-    val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
-    val emptyFiles = toolchainFiles.filter { it.length() == 0L }
-    val links = toolchainFiles.mapNotNull { file ->
-        emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
+  val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
+  val emptyFiles = toolchainFiles.filter { it.length() == 0L }
+  val links = toolchainFiles.mapNotNull { file ->
+    emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
+  }
+  links.forEach { (target, link) ->
+    logger.quiet("Fixing up '$link' to link to '$target'.")
+    if (link.delete()) {
+      Files.createSymbolicLink(link.toPath(), target.toPath())
+    } else {
+      logger.warn("Unable to delete '$link'.")
     }
-    links.forEach { (target, link) ->
-        logger.quiet("Fixing up '$link' to link to '$target'.")
-        if (link.delete()) {
-            Files.createSymbolicLink(link.toPath(), target.toPath())
-        } else {
-            logger.warn("Unable to delete '$link'.")
-        }
-    }
+  }
 }

--- a/meshcore-tui/src/main/kotlin/ee/schimke/meshcore/tui/Dashboard.kt
+++ b/meshcore-tui/src/main/kotlin/ee/schimke/meshcore/tui/Dashboard.kt
@@ -23,84 +23,92 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
- * Live terminal dashboard for a connected MeshCore device. Repaints on
- * a 500ms tick using Mordant's text animation; keeps a rolling log of
- * the most recent [historySize] events parsed from the device.
+ * Live terminal dashboard for a connected MeshCore device. Repaints on a 500ms tick using Mordant's
+ * text animation; keeps a rolling log of the most recent [historySize] events parsed from the
+ * device.
  */
-class Dashboard(
-    private val host: String,
-    private val port: Int,
-    private val historySize: Int,
-) {
-    private val terminal = Terminal()
-    private val events = ArrayDeque<String>()
+class Dashboard(private val host: String, private val port: Int, private val historySize: Int) {
+  private val terminal = Terminal()
+  private val events = ArrayDeque<String>()
 
-    fun run(): Unit = runBlocking {
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val transport = TcpTransport(host, port)
-        try {
-            transport.connect()
-        } catch (t: Throwable) {
-            terminal.println("Failed to connect to $host:$port — ${t.message}")
-            return@runBlocking
-        }
-        val client = MeshCoreClient(transport, scope)
-        client.start()
-
-        val animation = terminal.textAnimation<Unit> { render(client) }
-        val collectorJob: Job = scope.launch { collectEvents(client) }
-        try {
-            while (true) {
-                animation.update(Unit)
-                delay(500)
-            }
-        } finally {
-            collectorJob.cancel()
-            animation.stop()
-            client.stop()
-            transport.close()
-            scope.cancel()
-        }
+  fun run(): Unit = runBlocking {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val transport = TcpTransport(host, port)
+    try {
+      transport.connect()
+    } catch (t: Throwable) {
+      terminal.println("Failed to connect to $host:$port — ${t.message}")
+      return@runBlocking
     }
+    val client = MeshCoreClient(transport, scope)
+    client.start()
 
-    private suspend fun collectEvents(client: MeshCoreClient) {
-        client.events.collect { ev ->
-            val line = when (ev) {
-                is MeshEvent.DirectMessage -> "${brightGreen("DM")} ${ev.message.senderPrefix} ${ev.message.text}"
-                is MeshEvent.ChannelMessage -> "${brightMagenta("CH${ev.message.channelIndex}")} ${ev.message.body}"
-                is MeshEvent.Advert -> "${brightYellow("ADV")} ${ev.info.publicKey}"
-                is MeshEvent.NewAdvert -> "${brightYellow("NEW")} ${ev.info.publicKey}"
-                is MeshEvent.SendConfirmedEvent -> "${brightGreen("ACK")} rtt=${ev.confirmed.tripTimeMs}ms"
-                MeshEvent.MessagesWaiting -> gray("messages waiting…")
-                else -> null
-            } ?: return@collect
-            events.addLast(line)
-            while (events.size > historySize) events.removeFirst()
-        }
+    val animation = terminal.textAnimation<Unit> { render(client) }
+    val collectorJob: Job = scope.launch { collectEvents(client) }
+    try {
+      while (true) {
+        animation.update(Unit)
+        delay(500)
+      }
+    } finally {
+      collectorJob.cancel()
+      animation.stop()
+      client.stop()
+      transport.close()
+      scope.cancel()
     }
+  }
 
-    private fun render(client: MeshCoreClient): String {
-        val self = client.selfInfo.value
-        val battery = client.battery.value
-        val radio = client.radio.value
-        val contacts = client.contacts.value
-
-        val header = (bold + brightBlue)("MeshCore — ${self?.name ?: "(connecting)"}")
-        val statusTable = table {
-            header { row("field", "value") }
-            body {
-                row("pubkey", self?.publicKey?.toString()?.take(12)?.plus("…") ?: "—")
-                row("radio", radio?.let { "${it.frequencyHz / 1_000_000.0} MHz SF${it.spreadingFactor} BW${it.bandwidthHz / 1_000}" } ?: "—")
-                row("battery", battery?.let { cyan("${it.estimatePercent()}% (${it.millivolts} mV)") } ?: "—")
-                row("contacts", contacts.size.toString())
-            }
-        }
-        val log = if (events.isEmpty()) gray("(no events yet)") else events.joinToString("\n")
-        return buildString {
-            appendLine(header)
-            appendLine(terminal.render(statusTable))
-            appendLine(bold("Events"))
-            append(log)
-        }
+  private suspend fun collectEvents(client: MeshCoreClient) {
+    client.events.collect { ev ->
+      val line =
+        when (ev) {
+          is MeshEvent.DirectMessage ->
+            "${brightGreen("DM")} ${ev.message.senderPrefix} ${ev.message.text}"
+          is MeshEvent.ChannelMessage ->
+            "${brightMagenta("CH${ev.message.channelIndex}")} ${ev.message.body}"
+          is MeshEvent.Advert -> "${brightYellow("ADV")} ${ev.info.publicKey}"
+          is MeshEvent.NewAdvert -> "${brightYellow("NEW")} ${ev.info.publicKey}"
+          is MeshEvent.SendConfirmedEvent ->
+            "${brightGreen("ACK")} rtt=${ev.confirmed.tripTimeMs}ms"
+          MeshEvent.MessagesWaiting -> gray("messages waiting…")
+          else -> null
+        } ?: return@collect
+      events.addLast(line)
+      while (events.size > historySize) events.removeFirst()
     }
+  }
+
+  private fun render(client: MeshCoreClient): String {
+    val self = client.selfInfo.value
+    val battery = client.battery.value
+    val radio = client.radio.value
+    val contacts = client.contacts.value
+
+    val header = (bold + brightBlue)("MeshCore — ${self?.name ?: "(connecting)"}")
+    val statusTable = table {
+      header { row("field", "value") }
+      body {
+        row("pubkey", self?.publicKey?.toString()?.take(12)?.plus("…") ?: "—")
+        row(
+          "radio",
+          radio?.let {
+            "${it.frequencyHz / 1_000_000.0} MHz SF${it.spreadingFactor} BW${it.bandwidthHz / 1_000}"
+          } ?: "—",
+        )
+        row(
+          "battery",
+          battery?.let { cyan("${it.estimatePercent()}% (${it.millivolts} mV)") } ?: "—",
+        )
+        row("contacts", contacts.size.toString())
+      }
+    }
+    val log = if (events.isEmpty()) gray("(no events yet)") else events.joinToString("\n")
+    return buildString {
+      appendLine(header)
+      appendLine(terminal.render(statusTable))
+      appendLine(bold("Events"))
+      append(log)
+    }
+  }
 }

--- a/meshcore-tui/src/main/kotlin/ee/schimke/meshcore/tui/Main.kt
+++ b/meshcore-tui/src/main/kotlin/ee/schimke/meshcore/tui/Main.kt
@@ -9,20 +9,18 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 
 /**
- * Single-command entry point. The TUI is inherently one screen – there
- * are no subcommands – so it's a plain [CliktCommand] rather than a
- * multi-command tree.
+ * Single-command entry point. The TUI is inherently one screen – there are no subcommands – so it's
+ * a plain [CliktCommand] rather than a multi-command tree.
  */
 class MeshcoreTui : CliktCommand(name = "meshcore-tui") {
-    override fun help(context: Context): String =
-        "Interactive MeshCore dashboard backed by Mordant."
+  override fun help(context: Context): String = "Interactive MeshCore dashboard backed by Mordant."
 
-    val host by option("--host", "-h").default("127.0.0.1").help("TCP host")
-    val port by option("--port", "-p").int().default(5000).help("TCP port")
-    val historySize by option("--history").int().default(20)
-        .help("How many recent events to keep on screen")
+  val host by option("--host", "-h").default("127.0.0.1").help("TCP host")
+  val port by option("--port", "-p").int().default(5000).help("TCP port")
+  val historySize by
+    option("--history").int().default(20).help("How many recent events to keep on screen")
 
-    override fun run() = Dashboard(host, port, historySize).run()
+  override fun run() = Dashboard(host, port, historySize).run()
 }
 
 fun main(args: Array<String>) = MeshcoreTui().main(args)

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,81 +1,73 @@
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.kotlinSerialization)
-    alias(libs.plugins.aboutlibraries)
-    id("ee.schimke.composeai.preview") version "0.7.5"
+  alias(libs.plugins.androidApplication)
+  alias(libs.plugins.composeMultiplatform)
+  alias(libs.plugins.composeCompiler)
+  alias(libs.plugins.kotlinSerialization)
+  alias(libs.plugins.aboutlibraries)
+  id("ee.schimke.composeai.preview") version "0.7.5"
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-    }
-}
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
 android {
-    namespace = "ee.schimke.meshcore.wear"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        applicationId = "ee.schimke.meshcore.wear"
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1"
-    }
-    buildTypes {
-        getByName("release") { isMinifyEnabled = false }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-    testOptions.unitTests {
-        isIncludeAndroidResources = true
-    }
+  namespace = "ee.schimke.meshcore.wear"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    applicationId = "ee.schimke.meshcore.wear"
+    minSdk = libs.versions.android.minSdk.get().toInt()
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    versionCode = 1
+    versionName = "0.1"
+  }
+  buildTypes { getByName("release") { isMinifyEnabled = false } }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+  }
+  testOptions.unitTests { isIncludeAndroidResources = true }
 }
 
 dependencies {
-    // gRPC proto stubs — the watch is a pure gRPC consumer
-    implementation(projects.meshcoreGrpcService)
+  // gRPC proto stubs — the watch is a pure gRPC consumer
+  implementation(projects.meshcoreGrpcService)
 
-    // Horologist: gRPC transport over Wearable Data Layer (NOT Compose)
-    implementation(libs.horologist.datalayer.grpc)
-    implementation(libs.horologist.datalayer.watch)
-    implementation(libs.playservices.wearable)
+  // Horologist: gRPC transport over Wearable Data Layer (NOT Compose)
+  implementation(libs.horologist.datalayer.grpc)
+  implementation(libs.horologist.datalayer.watch)
+  implementation(libs.playservices.wearable)
 
-    // Wear Compose Material 3 (direct, no Horologist UI)
-    implementation(libs.wear.compose.material3)
-    implementation(libs.wear.compose.foundation)
-    implementation(libs.wear.compose.navigation)
-    implementation(libs.wear.compose.navigation3)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
+  // Wear Compose Material 3 (direct, no Horologist UI)
+  implementation(libs.wear.compose.material3)
+  implementation(libs.wear.compose.foundation)
+  implementation(libs.wear.compose.navigation)
+  implementation(libs.wear.compose.navigation3)
+  implementation(libs.androidx.navigation3.runtime)
+  implementation(libs.androidx.navigation3.ui)
 
-    // Remote Compose (for widget, same libraries as phone widget)
-    implementation(libs.androidx.remote.core)
-    implementation(libs.androidx.remote.creation)
-    implementation(libs.androidx.remote.creation.compose)
-    implementation(libs.androidx.remote.tooling.preview)
-    // Wear Remote Compose Material 3 components
-    implementation(libs.wear.compose.remote.material3)
+  // Remote Compose (for widget, same libraries as phone widget)
+  implementation(libs.androidx.remote.core)
+  implementation(libs.androidx.remote.creation)
+  implementation(libs.androidx.remote.creation.compose)
+  implementation(libs.androidx.remote.tooling.preview)
+  // Wear Remote Compose Material 3 components
+  implementation(libs.wear.compose.remote.material3)
 
-    // Standard Compose + lifecycle
-    implementation(libs.compose.runtime)
-    implementation(libs.compose.ui)
-    implementation(libs.compose.uiToolingPreview)
-    implementation(libs.compose.material.icons.extended)
-    implementation(libs.compose.ui.text.google.fonts)
-    implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.lifecycle.runtimeCompose)
-    implementation(libs.androidx.lifecycle.viewmodelCompose)
-    implementation(libs.aboutlibraries.compose.wear.m3)
-    implementation(libs.kotlinx.coroutines.android)
+  // Standard Compose + lifecycle
+  implementation(libs.compose.runtime)
+  implementation(libs.compose.ui)
+  implementation(libs.compose.uiToolingPreview)
+  implementation(libs.compose.material.icons.extended)
+  implementation(libs.compose.ui.text.google.fonts)
+  implementation(libs.androidx.activity.compose)
+  implementation(libs.androidx.lifecycle.runtimeCompose)
+  implementation(libs.androidx.lifecycle.viewmodelCompose)
+  implementation(libs.aboutlibraries.compose.wear.m3)
+  implementation(libs.kotlinx.coroutines.android)
 
-    implementation("androidx.wear.compose:compose-ui-tooling:1.6.0")
-    debugImplementation(libs.compose.uiTooling)
+  implementation("androidx.wear.compose:compose-ui-tooling:1.6.0")
+  debugImplementation(libs.compose.uiTooling)
 
-    testImplementation(libs.robolectric)
-    testImplementation(libs.androidx.core)
-    testImplementation(libs.androidx.testExt.junit)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.androidx.core)
+  testImplementation(libs.androidx.testExt.junit)
 }


### PR DESCRIPTION
## Summary

- Mechanical output of `./gradlew ktfmtFormat` (ktfmt-gradle 0.26.0, `googleStyle()`) across all 13 subprojects — 66 files, ~3.9k lines reflowed to 2-space indent / 100-char width / completed trailing commas.
- Two KDoc strings in `meshcore-core` were rephrased to dodge a ktfmt KDoc-parser bug:
  - `meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/transport/Transport.kt` — class doc + `send()` doc
  - `meshcore-core/src/commonMain/kotlin/ee/schimke/meshcore/core/protocol/Parsers.kt` — class doc

  Each contained `` `[code][body...]` `` inside backticks; the parser treated `[body...]` as a KDoc link reference and failed with "Closing bracket expected". They now read "(one `code` byte followed by body bytes)" — same meaning, no `[…]` sequence.
- Lands the baseline so the `ktfmtCheck` workflow added in #8 is green going forward.

## Test plan

- [x] `./gradlew ktfmtFormat` — BUILD SUCCESSFUL, 26 actionable tasks.
- [x] `./gradlew ktfmtCheck` — BUILD SUCCESSFUL, 26 actionable tasks (verified after the format).
- [ ] Confirm the `ktfmt` workflow passes on this PR.
- [ ] Skim a couple of files to make sure the reflow hasn't done anything visually objectionable; if so it can be re-tuned via the ktfmt DSL in a follow-up.

Recommend merging this with "Squash and merge" so the diff stays as one mechanical commit; consider adding the SHA to `.git-blame-ignore-revs` to keep `git blame` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4qJTuiEBsYn5r6wtnXdzo)_