### PR TITLE
Move compose-preview plugin to version catalog and bump to 0.8.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   alias(libs.plugins.metro)
   alias(libs.plugins.ksp)
   alias(libs.plugins.kotlinSerialization)
-  id("ee.schimke.composeai.preview") version "0.7.5"
+  alias(libs.plugins.composePreview)
 }
 
 kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ wear-compose-remote = "1.0.0-alpha01"
 playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.0"
 ktfmt = "0.26.0"
+composePreview = "0.8.1"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }
@@ -149,3 +150,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
+composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreview" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   alias(libs.plugins.composeCompiler)
   alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.aboutlibraries)
-  id("ee.schimke.composeai.preview") version "0.7.5"
+  alias(libs.plugins.composePreview)
 }
 
 kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }


### PR DESCRIPTION
## Summary

- Add `composePreview = "0.8.1"` and a `composePreview` plugin entry to `gradle/libs.versions.toml`.
- Replace the inline `id("ee.schimke.composeai.preview") version "0.7.5"` in `:app` and `:wear` with `alias(libs.plugins.composePreview)`.

## Notes

- Local sandbox check: with 0.8.1 applied, only `composePreviewApplied` got registered for `:app`/`:wear` — the render tasks (`discoverPreviews`, `renderPreviews`, `renderAllPreviews`, `verifyAccessibility`, …) didn't show up under `gradlew :app:tasks --group="compose preview"`. Adding an explicit `composePreview { enabled.set(true) }` block didn't change that. With 0.7.5, the same setup registered all of them and `:app:renderAllPreviews` produced 38 PNGs successfully.
- Posting anyway per request — please confirm whether 0.8.1 needs different config in this project, or whether this is a plugin-side regression worth filing upstream.

## Test plan

- [ ] `./gradlew :app:tasks --group="compose preview"` lists `discoverPreviews` / `renderAllPreviews` / `verifyAccessibility`.
- [ ] `./gradlew :app:renderAllPreviews` succeeds and writes PNGs under `app/build/compose-previews/renders/`.
- [ ] Same for `:wear:renderAllPreviews`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FSxQ47V6E8HTSTsDEr4PFa)_