### PR TITLE
Bump compose-preview to 0.8.3 and adopt CI workflow actions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,8 +11,9 @@ A `SessionStart` hook at `.claude/hooks/session-start.sh` installs JDK 21 (if
 missing) and downloads the Android SDK into `$HOME/.android-sdk` with the
 `platform-tools`, `platforms;android-36`, and `build-tools;36.0.0` packages,
 then exports `ANDROID_HOME` / `ANDROID_SDK_ROOT` / `PATH` via
-`$CLAUDE_ENV_FILE`. It's gated on `CLAUDE_CODE_REMOTE=true` so it's a no-op
-on developer machines.
+`$CLAUDE_ENV_FILE`. It also runs `scripts/install-git-hooks.sh` so the
+ktfmt pre-commit hook is in place before any agent commit. It's gated on
+`CLAUDE_CODE_REMOTE=true` so it's a no-op on developer machines.
 
 If you're running outside the hook (e.g. validating manually) and the SDK is
 missing, run the hook directly:

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -44,3 +44,10 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     echo "export PATH=\"$CMDLINE_TOOLS_DIR/bin:$ANDROID_SDK_ROOT/platform-tools:\$PATH\""
   } >> "$CLAUDE_ENV_FILE"
 fi
+
+# Install repo-managed git hooks (ktfmt pre-commit) so agent commits are
+# formatted before they land. Idempotent — overwrites .git/hooks/pre-commit.
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$repo_root" ] && [ -x "$repo_root/scripts/install-git-hooks.sh" ]; then
+  "$repo_root/scripts/install-git-hooks.sh" >/dev/null
+fi

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -1,0 +1,23 @@
+name: Preview Baselines
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: preview-baselines
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update preview_main baselines
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@main

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,25 @@
+name: Preview Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-comment-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare previews against baselines
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          cache-read-only: 'true'
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@main

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ wear-compose-remote = "1.0.0-alpha02"
 playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.1"
 ktfmt = "0.26.0"
-composePreview = "0.8.1"
+composePreview = "0.8.3"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }


### PR DESCRIPTION
## Summary

- Bump `ee.schimke.composeai.preview` from 0.8.1 to 0.8.3 in the version catalog.
- Add `.github/workflows/preview-baselines.yml` (push to `main`) using `yschimke/compose-ai-tools/.github/actions/preview-baselines@main` to maintain the `preview_main` branch with rendered PNGs and a `baselines.json` manifest.
- Add `.github/workflows/preview-comment.yml` (pull request) using `yschimke/compose-ai-tools/.github/actions/preview-comment@main` to post before/after diff comments against the baselines. Runs with `cache-read-only` to avoid Gradle cache poisoning from PR runs.
- Both workflows reuse the local `./.github/actions/setup` composite (Temurin JDK 21 + `gradle/actions/setup-gradle@v6`) for consistency with the other workflows in this repo.
- Install `scripts/git-hooks/pre-commit` (ktfmt) from the `SessionStart` hook on cloud agent sandboxes so agent commits are formatted before they land. Mirrored in `.claude/CLAUDE.md`.

## Test plan

- [ ] CI green on this PR (build / test / lint / ktfmt).
- [ ] Preview Comment workflow runs on this PR; first run will likely have no `preview_main` baselines yet — verify the action fails gracefully or prints a "no baselines" notice.
- [ ] After merge to `main`, Preview Baselines workflow creates / updates the `preview_main` branch with rendered PNGs for `:app` and `:wear` and a `baselines.json` manifest.
- [ ] Open a follow-up PR touching a `@Preview` composable and confirm the comment workflow posts a before/after diff.
- [ ] On a fresh cloud session (`CLAUDE_CODE_REMOTE=true`), confirm `.git/hooks/pre-commit` ends up installed and `git commit` triggers `ktfmtCheck`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vp9X2ZH5KPJxrnEUZUh2Pp)_