### PR TITLE
Bump compose-ai-tools to 0.8.4

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@main
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.4

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@main
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ wear-compose-remote = "1.0.0-alpha02"
 playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.1"
 ktfmt = "0.26.0"
-composePreview = "0.8.3"
+composePreview = "0.8.4"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }


### PR DESCRIPTION
- ee.schimke.composeai.preview 0.8.3 -> 0.8.4 in version catalog
- Pin preview-baselines and preview-comment workflow actions to v0.8.4
  instead of @main so CI tracks a specific release