### PR TITLE
Pin wall-clock sources in previews to avoid false diffs

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreenPreviews.kt
@@ -208,14 +208,20 @@ fun DeviceBodyManyContactsPreview() {
 )
 @Composable
 fun DeviceStatusConnectingPreview() {
+    // Pin both the start time and the "now" clock so the rendered PNG
+    // doesn't drift between runs (the elapsed/remaining label and the
+    // progress bar both depend on wall-clock time otherwise).
+    val previewStartedAtMs = 0L
+    val previewNowMs = 7_000L
     MeshcoreTheme {
         DeviceStatusView(
             title = "Connecting",
             status = DeviceConnectStatus.Connecting(
-                startedAtMs = System.currentTimeMillis() - 7_000L,
+                startedAtMs = previewStartedAtMs,
                 timeoutMs = 20_000L,
             ),
             onCancel = {},
+            nowMs = { previewNowMs },
         )
     }
 }

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceStatusViews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceStatusViews.kt
@@ -59,6 +59,7 @@ fun DeviceStatusView(
     status: DeviceConnectStatus,
     onCancel: () -> Unit,
     onOpenThemePicker: () -> Unit = {},
+    nowMs: () -> Long = { System.currentTimeMillis() },
 ) {
     Scaffold(
         topBar = {
@@ -93,6 +94,7 @@ fun DeviceStatusView(
                     startedAtMs = status.startedAtMs,
                     timeoutMs = status.timeoutMs,
                     onCancel = onCancel,
+                    nowMs = nowMs,
                 )
                 is DeviceConnectStatus.Failed -> FailureCard(cause = status.cause, onRetry = onCancel)
             }
@@ -105,21 +107,23 @@ private fun ConnectingCard(
     startedAtMs: Long,
     timeoutMs: Long,
     onCancel: () -> Unit,
+    nowMs: () -> Long,
 ) {
     // Drive the progress bar from inside the composable itself using
     // withFrameMillis — the caller only has to provide the wall-clock
     // start time. In preview mode the produceState coroutine returns
     // immediately so the bar freezes at its initial value and the
-    // renderer can settle.
+    // renderer can settle. The caller-supplied [nowMs] also lets
+    // previews pin the clock so the rendered PNG is deterministic.
     val inPreview = androidx.compose.ui.platform.LocalInspectionMode.current
     val elapsedMs by androidx.compose.runtime.produceState(
-        initialValue = (System.currentTimeMillis() - startedAtMs).coerceAtLeast(0L),
+        initialValue = (nowMs() - startedAtMs).coerceAtLeast(0L),
         startedAtMs,
     ) {
         if (inPreview) return@produceState
         while (true) {
             androidx.compose.runtime.withFrameMillis {
-                value = (System.currentTimeMillis() - startedAtMs).coerceAtLeast(0L)
+                value = (nowMs() - startedAtMs).coerceAtLeast(0L)
             }
         }
     }

--- a/wear/src/main/kotlin/ee/schimke/meshcore/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/meshcore/wear/ui/WearPreviews.kt
@@ -2,10 +2,26 @@ package ee.schimke.meshcore.wear.ui
 
 import androidx.compose.runtime.Composable
 import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.TimeSource
+import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import ee.schimke.meshcore.grpc.ContactMsg
 import ee.schimke.meshcore.grpc.ContactType
 import ee.schimke.meshcore.wear.ui.theme.MeshcoreWearTheme
+
+// AppScaffold's default TimeText reads the wall clock, so each render
+// shows a different "HH:MM" string and every wear preview ends up with
+// a false diff. Pin the displayed time so PNGs stay byte-stable.
+private object FixedTimeSource : TimeSource {
+    @Composable override fun currentTime(): String = "10:10"
+}
+
+@Composable
+private fun PreviewAppScaffold(content: @Composable () -> Unit) {
+    AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) {
+        content()
+    }
+}
 
 // --- StatusScreen previews ---------------------------------------------------
 
@@ -13,7 +29,7 @@ import ee.schimke.meshcore.wear.ui.theme.MeshcoreWearTheme
 @Composable
 fun StatusBodyLoadingPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             StatusBody(state = WearUiState.Loading)
         }
     }
@@ -23,7 +39,7 @@ fun StatusBodyLoadingPreview() {
 @Composable
 fun StatusBodyPhoneDisconnectedPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             StatusBody(state = WearUiState.PhoneDisconnected)
         }
     }
@@ -33,7 +49,7 @@ fun StatusBodyPhoneDisconnectedPreview() {
 @Composable
 fun StatusBodyRadioDisconnectedPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             StatusBody(state = WearUiState.RadioDisconnected)
         }
     }
@@ -43,7 +59,7 @@ fun StatusBodyRadioDisconnectedPreview() {
 @Composable
 fun StatusBodyConnectedPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             StatusBody(
                 state = WearUiState.Connected(
                     deviceName = "MeshNode-A",
@@ -60,7 +76,7 @@ fun StatusBodyConnectedPreview() {
 @Composable
 fun StatusBodyConnectedLowBatteryPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             StatusBody(
                 state = WearUiState.Connected(
                     deviceName = "MeshNode-B",
@@ -77,7 +93,7 @@ fun StatusBodyConnectedLowBatteryPreview() {
 @Composable
 fun StatusBodyErrorPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             StatusBody(state = WearUiState.Error("Connection timeout"))
         }
     }
@@ -89,7 +105,7 @@ fun StatusBodyErrorPreview() {
 @Composable
 fun ContactsBodyEmptyPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             ContactsBody(contacts = emptyList())
         }
     }
@@ -99,7 +115,7 @@ fun ContactsBodyEmptyPreview() {
 @Composable
 fun ContactsBodyFewPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             ContactsBody(
                 contacts = listOf(
                     fakeContact("Alice"),
@@ -117,7 +133,7 @@ fun ContactsBodyFewPreview() {
 @Composable
 fun QuickReplyBodyPreview() {
     MeshcoreWearTheme {
-        AppScaffold {
+        PreviewAppScaffold {
             QuickReplyBody()
         }
     }


### PR DESCRIPTION
## Summary

The preview-diff bot on #17 flagged 10 previews as "changed" purely
from wall-clock noise. Two distinct sources:

- **Wear previews (9)** — `AppScaffold`'s default `TimeText` reads the
  system clock, so each PNG embedded a different `HH:MM` string. A new
  `PreviewAppScaffold` helper supplies a `FixedTimeSource` returning
  `"10:10"`, per the `compose-preview` `WEAR_UI.md` §7 recipe.
- **`DeviceStatusConnectingPreview` (app)** — the preview passed
  `startedAtMs = System.currentTimeMillis() - 7_000L` and
  `ConnectingCard` recomputed elapsed via another
  `System.currentTimeMillis()` call, so the progress bar / "Xs
  remaining" label drifted by a few ms between renders. An injectable
  `nowMs: () -> Long = { System.currentTimeMillis() }` is now threaded
  through `DeviceStatusView` → `ConnectingCard`; the preview pins both
  `startedAtMs = 0L` and `nowMs = { 7_000L }` so elapsed is exactly 7s
  every render.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin`
- [x] `./gradlew :app:ktfmtCheck :wear:ktfmtCheck`
- [ ] Preview-diff bot on this PR shows the previously-noisy 10
      functions as Unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbAYpAaW4qv1SbDqDJRCi)_