### PR TITLE
build: wire release signing and apply Play Publisher

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,25 @@ android {
     versionCode = 1
     versionName = "0.1"
   }
-  buildTypes { getByName("release") { isMinifyEnabled = false } }
+  val releaseKeystorePath = System.getenv("MESHCORE_KEYSTORE_PATH")
+  signingConfigs {
+    if (releaseKeystorePath != null) {
+      create("release") {
+        storeFile = file(releaseKeystorePath)
+        storePassword = System.getenv("MESHCORE_KEYSTORE_PASSWORD")
+        keyAlias = System.getenv("MESHCORE_KEY_ALIAS")
+        keyPassword = System.getenv("MESHCORE_KEY_PASSWORD")
+      }
+    }
+  }
+  buildTypes {
+    getByName("release") {
+      isMinifyEnabled = false
+      if (releaseKeystorePath != null) {
+        signingConfig = signingConfigs.getByName("release")
+      }
+    }
+  }
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.triplet.gradle.androidpublisher.ReleaseStatus
+
 plugins {
   // AGP 9 has built-in Kotlin support, so `com.android.application`
   // alone covers both Android and Kotlin compilation — don't add
@@ -9,6 +11,15 @@ plugins {
   alias(libs.plugins.ksp)
   alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.composePreview)
+  alias(libs.plugins.playPublisher)
+}
+
+play {
+  track.set("internal")
+  defaultToAppBundles.set(true)
+  releaseStatus.set(ReleaseStatus.DRAFT)
+  // Skip API calls in CI runs that build but don't publish (e.g. PRs).
+  enabled.set(System.getenv("ANDROID_PUBLISHER_CREDENTIALS") != null)
 }
 
 kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "9.2.0"
+playPublisher = "4.0.0"
 android-compileSdk = "37"
 android-minSdk = "35"
 android-targetSdk = "37"
@@ -133,3 +134,4 @@ protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreview" }
+playPublisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }


### PR DESCRIPTION
## Summary
- Adds env-var-driven `signingConfigs.release` keyed off `MESHCORE_KEYSTORE_PATH` / `_PASSWORD` / `_ALIAS` / `MESHCORE_KEY_PASSWORD`. The existing release-build.yml workflow already passes these through; previously the build would land an unsigned APK/AAB.
- Applies the `com.github.triplet.play` plugin (4.0.0) and configures `play{}` to upload App Bundles to the internal track as DRAFT, gated on `ANDROID_PUBLISHER_CREDENTIALS`.

## Test plan
- [ ] First AAB uploaded manually to Play Console internal track (`ee.schimke.meshcore`)
- [ ] Repo secrets populated: `SIGNING_KEYSTORE`, `MESHCORE_KEYSTORE_PASSWORD`, `MESHCORE_KEY_ALIAS`, `MESHCORE_KEY_PASSWORD`, `PLAY_SERVICE_ACCOUNT_JSON`
- [ ] Tag a release and watch CI sign the AAB and publish to internal track as DRAFT
- [ ] Promote DRAFT to internal in Play Console