### PR TITLE
chore: rename applicationId to ee.schimke.meshed

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,7 +41,7 @@ android {
   namespace = "ee.schimke.meshcore.app"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
   defaultConfig {
-    applicationId = "ee.schimke.meshcore"
+    applicationId = "ee.schimke.meshed"
     minSdk = libs.versions.android.minSdk.get().toInt()
     targetSdk = libs.versions.android.targetSdk.get().toInt()
     versionCode = appVersionCode

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -21,8 +21,8 @@ Defaults are conservative — broaden locally, don't commit broadening.
 
 ```sh
 # Launch + connect (no UI interaction)
-adb shell am start -n ee.schimke.meshcore/ee.schimke.meshcore.app.MainActivity
-adb shell am broadcast -p ee.schimke.meshcore \
+adb shell am start -n ee.schimke.meshed/ee.schimke.meshcore.app.MainActivity
+adb shell am broadcast -p ee.schimke.meshed \
     -a ee.schimke.meshcore.DEBUG_CONNECT \
     --es ble C7:8D:8C:45:5F:78 --es label Kodu
 
@@ -33,7 +33,7 @@ adb shell "dumpsys -t 15 activity service MeshcoreConnectionService --help"
 
 Throughout this doc the service component is referenced by its short
 name `MeshcoreConnectionService`; the full component is
-`ee.schimke.meshcore/ee.schimke.meshcore.app.service.MeshcoreConnectionService`.
+`ee.schimke.meshed/ee.schimke.meshcore.app.service.MeshcoreConnectionService`.
 
 Use `dumpsys -t <seconds>` to lift the default 10 s dumpsys watchdog
 when running mesh operations. Internal per-verb timeouts stay under
@@ -100,12 +100,12 @@ Gated by `DebugAllowlists.bleIdentifiers` or `DebugAllowlists.tcpTargets`
 
 ```sh
 # BLE
-adb shell am broadcast -p ee.schimke.meshcore \
+adb shell am broadcast -p ee.schimke.meshed \
     -a ee.schimke.meshcore.DEBUG_CONNECT \
     --es ble C7:8D:8C:45:5F:78 --es label "Kodu"
 
 # TCP
-adb shell am broadcast -p ee.schimke.meshcore \
+adb shell am broadcast -p ee.schimke.meshed \
     -a ee.schimke.meshcore.DEBUG_CONNECT \
     --es tcp 192.168.1.42 --ei port 5000
 ```
@@ -115,7 +115,7 @@ Progress shows up under logcat tags `DebugConnect` and `MeshConnect`.
 ### `DEBUG_DISCONNECT` — cancel the active connection
 
 ```sh
-adb shell am broadcast -p ee.schimke.meshcore \
+adb shell am broadcast -p ee.schimke.meshed \
     -a ee.schimke.meshcore.DEBUG_DISCONNECT
 ```
 
@@ -124,7 +124,7 @@ Equivalent to tapping the notification's Disconnect action.
 ### `DEBUG_FORGET` — remove a saved device
 
 ```sh
-adb shell am broadcast -p ee.schimke.meshcore \
+adb shell am broadcast -p ee.schimke.meshed \
     -a ee.schimke.meshcore.DEBUG_FORGET \
     --es id "ble:C7:8D:8C:45:5F:78"
 ```

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,9 +5,9 @@ permalink: /privacy/
 
 # MeshCore — Privacy Policy
 
-_Last updated: 2026-04-27_
+_Last updated: 2026-04-28_
 
-MeshCore for Android (`ee.schimke.meshcore`) is built and maintained by
+MeshCore for Android (`ee.schimke.meshed`) is built and maintained by
 Yuri Schimke (`yuri@schimke.ee`). Source code:
 <https://github.com/yschimke/meshcore-mobile>.
 


### PR DESCRIPTION
## Summary
- Renames the phone app's `applicationId` from `ee.schimke.meshcore` → `ee.schimke.meshed` to work around Play Console's automated package-name moderation (the `core` substring in `meshcore` matches `hardcore` and gets auto-rejected).
- Internal Kotlin packages, broadcast action strings, source paths, and the wear app's `applicationId` (`ee.schimke.meshcore.wear`) are intentionally **unchanged** — they're internal identifiers, not the Play Store package.
- Updates `docs/privacy.md` (prose mention) and `docs/DEBUG.md` (the `adb -p`/`-n` process targets — `-a` action strings stay because their constants in `DebugConnectReceiver` and the debug `AndroidManifest` are hardcoded `ee.schimke.meshcore.DEBUG_*`).

## Test plan
- [ ] Merge
- [ ] Bump appVersionName + tag (separate PR if needed) → CI builds at `ee.schimke.meshed` and uploads to the Play Console listing you just registered as Draft on internal track
- [ ] Promote in Play Console