### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 
-val appVersionName = "0.1.0" // x-release-please-version
+val appVersionName = "0.1.1" // x-release-please-version
 
 // Pack MAJOR.MINOR.PATCH into a monotonic int. Caps at major < 22.
 val appVersionCode: Int =


### PR DESCRIPTION
Trivial bump so the Release workflow can publish a fresh build past the versionCode consumed by the bootstrap manual upload.