### PR TITLE
Update Compose AI Tools to 0.9.0

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -14,10 +14,13 @@ concurrency:
 
 jobs:
   update:
-    name: Update preview_main baselines
+    name: Update compose-preview/main baselines
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.10
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.9.0
+        with:
+          cli-version: catalog
+          catalog-key: composePreview

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -22,4 +22,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.10
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.9.0
+        with:
+          cli-version: catalog
+          catalog-key: composePreview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ wear-compose-remote = "1.0.0-alpha02"
 playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.1"
 ktfmt = "0.26.0"
-composePreview = "0.8.10"
+composePreview = "0.9.0"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }


### PR DESCRIPTION
## Summary
- bump the Compose AI Tools Gradle plugin to 0.9.0
- update preview review workflows to use the v0.9.0 shared actions
- rely on the 0.9.0 default preview branches (`compose-preview/main`, `compose-preview/pr`) via the shared actions

Cleanup issue for old branches: #38.

## Validation so far
- `./gradlew help`
- `git diff --check`

Additional CLI/MCP validation is being run after opening this PR.