### PR TITLE
[codex] Update compose-preview to 0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ app/project.info
 /meshcore-grpc-service/bin/
 /traces/
 */bin/*
+
+/.compose-preview-cli/

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
@@ -100,7 +100,7 @@ fun DeviceSummaryCardPopulatedPreview() {
 @Composable
 fun DeviceSummaryCardLoadingPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             DeviceSummaryCard(self = null, radio = null, battery = null)
         }
     }
@@ -108,11 +108,11 @@ fun DeviceSummaryCardLoadingPreview() {
 
 // --- ContactRow / ContactList --------------------------------------------
 
-@Preview(showBackground = true, name = "ContactRow — variants")
+@Preview(showBackground = true, name = "ContactRow — variants", widthDp = 340)
 @Composable
 fun ContactRowVariantsPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             ContactRow(contact("alice", pathLen = -1, fill = 0x11, type = ContactType.CHAT))
             ContactRow(contact("bob-repeater", pathLen = 2, fill = 0x22, type = ContactType.REPEATER))
             ContactRow(contact("common-room", pathLen = 0, fill = 0x33, type = ContactType.ROOM))
@@ -121,11 +121,11 @@ fun ContactRowVariantsPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "ContactList — empty")
+@Preview(showBackground = true, name = "ContactList — empty", widthDp = 340)
 @Composable
 fun ContactListEmptyPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             Text("Contacts (0)", style = MaterialTheme.typography.titleSmall)
             ContactList(
                 contacts = emptyList(),
@@ -135,11 +135,11 @@ fun ContactListEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "ContactList — 2 items")
+@Preview(showBackground = true, name = "ContactList — 2 items", widthDp = 340)
 @Composable
 fun ContactListFewPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             Text("Contacts (2)", style = MaterialTheme.typography.titleSmall)
             ContactList(
                 contacts = listOf(
@@ -152,11 +152,11 @@ fun ContactListFewPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "ContactList — 10 items (scrolls)")
+@Preview(showBackground = true, name = "ContactList — 10 items (scrolls)", widthDp = 340)
 @Composable
 fun ContactListManyPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             Text("Contacts (10)", style = MaterialTheme.typography.titleSmall)
             ContactList(
                 contacts = tenContacts(),
@@ -168,11 +168,11 @@ fun ContactListManyPreview() {
 
 // --- BleDeviceList --------------------------------------------------------
 
-@Preview(showBackground = true, name = "BleDeviceList — empty")
+@Preview(showBackground = true, name = "BleDeviceList — empty", widthDp = 340)
 @Composable
 fun BleDeviceListEmptyPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             Text("Scanning… 0 devices", style = MaterialTheme.typography.titleSmall)
             BleDeviceList(
                 rows = emptyList(),
@@ -184,11 +184,11 @@ fun BleDeviceListEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "BleDeviceList — 2 devices")
+@Preview(showBackground = true, name = "BleDeviceList — 2 devices", widthDp = 340)
 @Composable
 fun BleDeviceListFewPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             BleDeviceList(
                 rows = listOf(
                     bleRow("MeshCore-ABCD", "C7:8D:8C:45:5F:78", -52),
@@ -202,11 +202,11 @@ fun BleDeviceListFewPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "BleDeviceList — 10 devices (scrolls)")
+@Preview(showBackground = true, name = "BleDeviceList — 10 devices (scrolls)", widthDp = 340)
 @Composable
 fun BleDeviceListManyPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             BleDeviceList(
                 rows = (0 until 10).map { i ->
                     bleRow(
@@ -225,21 +225,21 @@ fun BleDeviceListManyPreview() {
 
 // --- TcpConnectPanel ------------------------------------------------------
 
-@Preview(showBackground = true, name = "TcpConnectPanel — idle")
+@Preview(showBackground = true, name = "TcpConnectPanel — idle", widthDp = 340)
 @Composable
 fun TcpConnectPanelIdlePreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             TcpConnectPanel(busy = false, onConnect = { _, _ -> })
         }
     }
 }
 
-@Preview(showBackground = true, name = "TcpConnectPanel — busy")
+@Preview(showBackground = true, name = "TcpConnectPanel — busy", widthDp = 340)
 @Composable
 fun TcpConnectPanelBusyPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             TcpConnectPanel(busy = true, onConnect = { _, _ -> })
         }
     }
@@ -247,21 +247,21 @@ fun TcpConnectPanelBusyPreview() {
 
 // --- BlePermissionPanel ---------------------------------------------------
 
-@Preview(showBackground = true, name = "BlePermissionPanel — first request")
+@Preview(showBackground = true, name = "BlePermissionPanel — first request", widthDp = 340)
 @Composable
 fun BlePermissionPanelFirstPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
-            BlePermissionPanel(lastResult = null, onRequest = {})
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+            BlePermissionPanel(lastResult = null, onOpenSettings = {})
         }
     }
 }
 
-@Preview(showBackground = true, name = "BlePermissionPanel — denied")
+@Preview(showBackground = true, name = "BlePermissionPanel — denied", widthDp = 340)
 @Composable
 fun BlePermissionPanelDeniedPreview() {
     MeshcoreTheme {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             BlePermissionPanel(
                 lastResult = mapOf(
                     "android.permission.BLUETOOTH_SCAN" to false,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-core = "1.18.0"
 androidx-lifecycle = "2.10.0"
 androidx-testExt = "1.3.0"
 composeMultiplatform = "1.10.3"
+composePreviewAnnotations = "0.9.1"
 core = "1.7.0"
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.10.2"
@@ -44,7 +45,7 @@ wear-compose-remote = "1.0.0-alpha02"
 playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.1"
 ktfmt = "0.26.0"
-composePreview = "0.8.10"
+composePreview = "0.9.1"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }
@@ -62,6 +63,7 @@ compose-material-icons-extended = { module = "androidx.compose.material:material
 compose-ui-text-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts", version = "1.11.0" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
+compose-preview-annotations = { module = "ee.schimke.composeai:preview-annotations", version.ref = "composePreviewAnnotations" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
   // Standard Compose + lifecycle
   implementation(libs.compose.runtime)
+  implementation(libs.compose.preview.annotations)
   implementation(libs.compose.ui)
   implementation(libs.compose.uiToolingPreview)
   implementation(libs.compose.material.icons.extended)

--- a/wear/src/main/kotlin/ee/schimke/meshcore/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/meshcore/wear/ui/WearPreviews.kt
@@ -1,10 +1,25 @@
 package ee.schimke.meshcore.wear.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.CircularProgressIndicator
+import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TimeSource
 import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import ee.schimke.composeai.preview.AnimatedPreview
 import ee.schimke.meshcore.grpc.ContactMsg
 import ee.schimke.meshcore.grpc.ContactType
 import ee.schimke.meshcore.wear.ui.theme.MeshcoreWearTheme
@@ -62,10 +77,10 @@ fun StatusBodyConnectedPreview() {
         PreviewAppScaffold {
             StatusBody(
                 state = WearUiState.Connected(
-                    deviceName = "MeshNode-A",
+                    deviceName = "MeshNode-Alpha-Ridge-Relay-East-Gate",
                     batteryPercent = 72,
                     contactCount = 5,
-                    radioInfo = "915.000 MHz · SF11 · BW250k",
+                    radioInfo = "915.000 MHz · SF11 · BW250k · CR4/8 · telemetry uplink active",
                 ),
             )
         }
@@ -135,6 +150,56 @@ fun QuickReplyBodyPreview() {
     MeshcoreWearTheme {
         PreviewAppScaffold {
             QuickReplyBody()
+        }
+    }
+}
+
+@Preview(
+    name = "Interactive Toggle Chip",
+    device = "id:wearos_large_round",
+    showSystemUi = true,
+    showBackground = true,
+)
+@Composable
+fun InteractiveToggleChipPreview() {
+    var telemetryEnabled by remember { mutableStateOf(false) }
+
+    MeshcoreWearTheme {
+        PreviewAppScaffold {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Button(
+                    onClick = { telemetryEnabled = !telemetryEnabled },
+                    colors = ButtonDefaults.filledTonalButtonColors(),
+                ) {
+                    Text(if (telemetryEnabled) "Telemetry ON" else "Telemetry OFF")
+                }
+            }
+        }
+    }
+}
+
+@Preview(
+    name = "Animated Circular Progress",
+    device = "id:wearos_large_round",
+    showSystemUi = true,
+    showBackground = true,
+)
+@AnimatedPreview(durationMs = 1200, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedCircularProgressPreview() {
+    MeshcoreWearTheme {
+        PreviewAppScaffold {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                CircularProgressIndicator()
+            }
         }
     }
 }

--- a/wear/src/main/kotlin/ee/schimke/meshcore/wear/widget/WidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/meshcore/wear/widget/WidgetPreviews.kt
@@ -45,7 +45,7 @@ import androidx.wear.compose.remote.material3.RemoteTitleCard
 @Composable
 fun StatusWidgetConnectedPreview() = RemotePreview {
     StatusWidgetContent(
-        deviceName = "node-peak",
+        deviceName = "node-ridge",
         connected = true,
         batteryPercent = 81,
         contactCount = 3,


### PR DESCRIPTION
## Goal
Update compose-preview to the 0.9.1 release and keep the preview suite working with the newer preview tooling.

## What changed
- Bumped compose-preview plugin and preview annotations to `0.9.1`.
- Added the preview annotations dependency to the Wear module.
- Adjusted component preview widths/layout wrappers for more stable render output.
- Added Wear interactive/animated preview coverage.
- Ignored local compose-preview CLI output.

## Verification
- `git diff --cached --check` before commit