### PR TITLE
Run Kotlin compiler on JDK 21

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
   alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.composePreview)
   alias(libs.plugins.playPublisher)
+  alias(libs.plugins.tapmoc)
 }
 
 play {
@@ -35,7 +36,12 @@ play {
   enabled.set(System.getenv("ANDROID_PUBLISHER_CREDENTIALS") != null)
 }
 
-kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
+kotlin { jvmToolchain(21) }
+
+tapmoc {
+  java(21)
+  kotlin(libs.versions.kotlin.get())
+}
 
 android {
   namespace = "ee.schimke.meshcore.app"
@@ -65,10 +71,6 @@ android {
         signingConfig = signingConfigs.getByName("release")
       }
     }
-  }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
   }
   testOptions.unitTests { isIncludeAndroidResources = true }
 }

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
@@ -252,7 +252,7 @@ fun TcpConnectPanelBusyPreview() {
 fun BlePermissionPanelFirstPreview() {
     MeshcoreTheme {
         Column(Modifier.fillMaxWidth().padding(16.dp)) {
-            BlePermissionPanel(lastResult = null, onOpenSettings = {})
+            BlePermissionPanel(lastResult = null, onRequest = {})
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.graalvmNative) apply false
     alias(libs.plugins.protobuf) apply false
     alias(libs.plugins.ktfmt) apply false
+    alias(libs.plugins.tapmoc) apply false
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,9 @@
 #Kotlin
 kotlin.code.style=official
+# Metro RC4's compiler plugin is compiled for Java 21. Keep Kotlin compiler plugin loading inside
+# the Gradle daemon JVM selected by gradle/gradle-daemon-jvm.properties instead of a stale Java 17
+# Kotlin daemon.
+kotlin.compiler.execution.strategy=in-process
 
 #Gradle
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ playservices-wearable = "19.0.0"
 aboutlibraries = "14.0.1"
 ktfmt = "0.26.0"
 composePreview = "0.9.1"
+tapmoc = "0.4.0"
 
 [libraries]
 androidx-core = { module = "androidx.test:core", version.ref = "core" }
@@ -137,3 +138,4 @@ aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "abo
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreview" }
 playPublisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }
+tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -5,9 +5,15 @@ plugins {
   alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.aboutlibraries)
   alias(libs.plugins.composePreview)
+  alias(libs.plugins.tapmoc)
 }
 
-kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
+kotlin { jvmToolchain(21) }
+
+tapmoc {
+  java(21)
+  kotlin(libs.versions.kotlin.get())
+}
 
 android {
   namespace = "ee.schimke.meshcore.wear"
@@ -20,10 +26,6 @@ android {
     versionName = "0.1"
   }
   buildTypes { getByName("release") { isMinifyEnabled = false } }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-  }
   testOptions.unitTests { isIncludeAndroidResources = true }
 }
 


### PR DESCRIPTION
## Summary
- Apply TapMoc to the app and wear modules and configure Java/Kotlin toolchains for JDK 21.
- Keep Kotlin compiler execution in-process so Metro's Java 21 compiler plugin is loaded by the Gradle daemon JVM selected by `gradle/gradle-daemon-jvm.properties`.
- Fix a stale `BlePermissionPanel` preview parameter that blocked `:app:compileDebugKotlin` after the JDK issue was resolved.

## Validation
- `./gradlew :app:compileDebugKotlin --stacktrace`
- `./gradlew :app:ktfmtCheck :wear:ktfmtCheck`
- `git diff --check`