### PR TITLE
Refactor release workflows to support release-please automation

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,13 +8,18 @@ on:
       tag:
         description: 'Tag to build (e.g. v0.1.1)'
         required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.1.1)'
+        required: true
+        type: string
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 # Required secrets (workflow no-ops them when absent so re-running an
@@ -30,6 +35,9 @@ jobs:
     name: Build & publish release
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: write
+      packages: write
     env:
       TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
       HAS_SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE != '' }}
@@ -89,7 +97,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Attach assets to GitHub release
-        if: github.event_name == 'push' && env.HAS_SIGNING_KEYSTORE == 'true'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_call') && env.HAS_SIGNING_KEYSTORE == 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
@@ -99,7 +107,7 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Upload workflow artifact
-        if: github.event_name != 'push' || env.HAS_SIGNING_KEYSTORE != 'true'
+        if: github.event_name == 'workflow_dispatch' || env.HAS_SIGNING_KEYSTORE != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: release-${{ steps.stage.outputs.version }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,18 @@
 name: Release Please
 
+# Maintains a release PR from conventional-commit history. When merged,
+# release-please cuts the tag + GitHub Release, then this workflow calls
+# release-build.yml via workflow_call to build and publish artifacts.
+# This bypasses the GITHUB_TOKEN recursion guard that otherwise prevents
+# tag-push events from triggering downstream workflows.
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-please
@@ -17,6 +22,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -24,3 +35,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+  release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release-build.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write


### PR DESCRIPTION
## Summary
Restructured the release workflow to enable release-please to automatically create releases and trigger downstream build/publish workflows. This eliminates manual release processes and bypasses GitHub's GITHUB_TOKEN recursion guard by using `workflow_call`.

## Key Changes

- **release-please.yml**: 
  - Added explanatory comment documenting the workflow's purpose and the recursion guard bypass strategy
  - Reduced top-level permissions to `contents: read` (least privilege)
  - Moved `contents: write` and `pull-requests: write` permissions to the `release-please` job only
  - Added job outputs (`release_created`, `tag_name`) to expose release-please action results
  - Added new `release` job that conditionally calls `release-build.yml` workflow when a release is created
  - The `release` job passes the tag name and inherits secrets for downstream authentication

- **release-build.yml**:
  - Added `workflow_call` trigger to support being called from `release-please.yml`
  - Added `tag` input parameter for `workflow_call` trigger (required, string type)
  - Reduced top-level permissions to `contents: read` (least privilege)
  - Moved `contents: write` and `packages: write` permissions to the `build` job only
  - Updated concurrency group to use `inputs.tag` when available (for workflow_call invocations)
  - Updated "Attach assets to GitHub release" condition to include `workflow_call` event type
  - Updated "Upload workflow artifact" condition to be more explicit: only for `workflow_dispatch` or when signing keystore is unavailable

## Implementation Details

The refactoring implements a two-stage release process:
1. **Stage 1** (release-please.yml): Maintains release PR from conventional commits; when merged, creates the GitHub Release
2. **Stage 2** (release-build.yml): Called via `workflow_call` to build and publish artifacts using elevated permissions

This approach avoids the GitHub Actions recursion guard that prevents tag-push events from triggering workflows using the default GITHUB_TOKEN, by explicitly invoking the build workflow from the release workflow with inherited secrets.

https://claude.ai/code/session_0169fThgf2RyXysfTt44RLpa