### PR TITLE
build: update compose-ai-tools to 0.11.0 and drop plugin from app/wear

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.9.2
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.11.0
         with:
           cli-version: catalog
           catalog-key: composePreview

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.9.2
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.11.0
         with:
           cli-version: catalog
           catalog-key: composePreview

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,6 @@ plugins {
   alias(libs.plugins.metro)
   alias(libs.plugins.ksp)
   alias(libs.plugins.kotlinSerialization)
-  alias(libs.plugins.composePreview)
   alias(libs.plugins.playPublisher)
   alias(libs.plugins.tapmoc)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ androidx-core = "1.18.0"
 androidx-lifecycle = "2.10.0"
 androidx-testExt = "1.3.0"
 composeMultiplatform = "1.10.3"
-composePreviewAnnotations = "0.9.2"
+composePreviewAnnotations = "0.11.0"
 core = "1.7.0"
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.10.2"
@@ -45,7 +45,7 @@ wear-compose-remote = "1.0.0-alpha02"
 playservices-wearable = "20.0.1"
 aboutlibraries = "14.1.0"
 ktfmt = "0.26.0"
-composePreview = "0.9.2"
+composePreview = "0.11.0"
 tapmoc = "0.4.2"
 
 [libraries]
@@ -136,6 +136,5 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
-composePreview = { id = "ee.schimke.composeai.preview", version.ref = "composePreview" }
 playPublisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }
 tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   alias(libs.plugins.composeCompiler)
   alias(libs.plugins.kotlinSerialization)
   alias(libs.plugins.aboutlibraries)
-  alias(libs.plugins.composePreview)
   alias(libs.plugins.tapmoc)
 }
 


### PR DESCRIPTION
The 0.11.0 CLI injects the preview plugin via an init script, so
consumer modules no longer need to apply ee.schimke.composeai.preview
themselves. Drop the plugin alias from :app and :wear, remove the
unused plugin declaration from the version catalog, and bump the
preview-annotations library plus the GitHub Actions to v0.11.0.