### PR TITLE
Refactor preview functions to use @PreviewWrapper annotation

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/widget/WidgetPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/widget/WidgetPreviews.kt
@@ -3,13 +3,15 @@
 package ee.schimke.meshcore.app.widget
 
 import android.annotation.SuppressLint
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemotePreviewWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 
 @Preview(name = "DeviceInfo — populated", widthDp = 290, heightDp = 160)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun DeviceInfoWidgetPopulatedPreview() = RemotePreview {
+fun DeviceInfoWidgetPopulatedPreview() {
     DeviceInfoWidgetContent(
         deviceName = "node-peak",
         pubkeyPrefix = "ab1234567890cdef",
@@ -21,8 +23,9 @@ fun DeviceInfoWidgetPopulatedPreview() = RemotePreview {
 }
 
 @Preview(name = "DeviceInfo — no data", widthDp = 290, heightDp = 160)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun DeviceInfoWidgetEmptyPreview() = RemotePreview {
+fun DeviceInfoWidgetEmptyPreview() {
     DeviceInfoWidgetContent(
         deviceName = "No device",
         pubkeyPrefix = null,
@@ -34,8 +37,9 @@ fun DeviceInfoWidgetEmptyPreview() = RemotePreview {
 }
 
 @Preview(name = "DeviceInfo — stale", widthDp = 290, heightDp = 160)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun DeviceInfoWidgetStalePreview() = RemotePreview {
+fun DeviceInfoWidgetStalePreview() {
     DeviceInfoWidgetContent(
         deviceName = "node-peak",
         pubkeyPrefix = "ab1234567890cdef",

--- a/wear/src/main/kotlin/ee/schimke/meshcore/wear/widget/WidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/meshcore/wear/widget/WidgetPreviews.kt
@@ -25,10 +25,11 @@ import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemotePreviewWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.wear.compose.remote.material3.RemoteAppCard
 import androidx.wear.compose.remote.material3.RemoteButton
 import androidx.wear.compose.remote.material3.RemoteButtonGroup
@@ -42,8 +43,9 @@ import androidx.wear.compose.remote.material3.RemoteTextButtonDefaults
 import androidx.wear.compose.remote.material3.RemoteTitleCard
 
 @Preview(name = "Status — connected", widthDp = 192, heightDp = 192)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun StatusWidgetConnectedPreview() = RemotePreview {
+fun StatusWidgetConnectedPreview() {
     StatusWidgetContent(
         deviceName = "node-ridge",
         connected = true,
@@ -53,8 +55,9 @@ fun StatusWidgetConnectedPreview() = RemotePreview {
 }
 
 @Preview(name = "Status — disconnected", widthDp = 192, heightDp = 192)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun StatusWidgetDisconnectedPreview() = RemotePreview {
+fun StatusWidgetDisconnectedPreview() {
     StatusWidgetContent(
         deviceName = "node-peak",
         connected = false,
@@ -64,8 +67,9 @@ fun StatusWidgetDisconnectedPreview() = RemotePreview {
 }
 
 @Preview(name = "Status — low battery", widthDp = 192, heightDp = 192)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun StatusWidgetLowBatteryPreview() = RemotePreview {
+fun StatusWidgetLowBatteryPreview() {
     StatusWidgetContent(
         deviceName = "node-peak",
         connected = true,
@@ -75,8 +79,9 @@ fun StatusWidgetLowBatteryPreview() = RemotePreview {
 }
 
 @Preview(name = "Component Catalog", widthDp = 192, heightDp = 192)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun WearComponentCatalogPreview() = RemotePreview {
+fun WearComponentCatalogPreview() {
     val surfaceContainer = Color(0xFF1A211F).rc
     val onSurface = Color(0xFFDDE4E1).rc
     val onSurfaceVariant = Color(0xFFBEC9C5).rc
@@ -167,8 +172,9 @@ private fun CatalogComponentPreview(
 }
 
 @Preview(name = "Component Grid", widthDp = 500, heightDp = 500)
+@PreviewWrapper(RemotePreviewWrapper::class)
 @Composable
-fun WearComponentGridPreview() = RemotePreview {
+fun WearComponentGridPreview() {
     val action = Action.Empty
 
     RemoteColumn(


### PR DESCRIPTION
## Summary
Refactored preview composable functions to use the `@PreviewWrapper` annotation pattern instead of wrapping content in `RemotePreview` lambda blocks. This modernizes the preview setup to align with newer Compose preview tooling conventions.

## Changes
- **Import updates**: Replaced `RemotePreview` import with `RemotePreviewWrapper` and added `PreviewWrapper` import from `androidx.compose.ui.tooling.preview`
- **Annotation pattern**: Added `@PreviewWrapper(RemotePreviewWrapper::class)` annotation to all preview functions
- **Function signatures**: Converted preview functions from lambda-returning style (`= RemotePreview { ... }`) to direct composable functions with normal block bodies
- **Affected files**:
  - `wear/src/main/kotlin/ee/schimke/meshcore/wear/widget/WidgetPreviews.kt`: 5 preview functions updated
  - `app/src/main/kotlin/ee/schimke/meshcore/app/widget/WidgetPreviews.kt`: 3 preview functions updated

## Implementation Details
The refactoring maintains functional equivalence while adopting a cleaner annotation-based approach. The `@PreviewWrapper` annotation delegates the remote preview wrapping logic to `RemotePreviewWrapper`, eliminating the need for explicit lambda wrapping at the function level. This results in more readable preview code and better separation of concerns between preview configuration (annotations) and preview content (function body).

https://claude.ai/code/session_019FsadKZaF46s3v1L1qs4xB