### PR TITLE
fix(build): defer native-image toolchain resolution to execution time

### DIFF
--- a/meshcore-cli/build.gradle.kts
+++ b/meshcore-cli/build.gradle.kts
@@ -52,21 +52,28 @@ graalvmNative {
 // provisioning ends up with empty files where links should be. Recreate
 // them before nativeCompile runs. Fix via square/okhttp#9393.
 tasks.named<BuildNativeImageTask>("nativeCompile") {
-  val toolchainDir =
-    options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
-      if (name == "bin") parentFile else this
+  // Resolve the toolchain and recreate the symlinks at execution time, not at
+  // configuration time. In the `named { }` body this ran whenever the task was
+  // merely realized — including when a tool queries the Gradle project model
+  // (`compose-preview show`) — forcing the GraalVM toolchain to be provisioned
+  // and failing on environments that can't fetch it.
+  doFirst {
+    val toolchainDir =
+      options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
+        if (name == "bin") parentFile else this
+      }
+    val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
+    val emptyFiles = toolchainFiles.filter { it.length() == 0L }
+    val links = toolchainFiles.mapNotNull { file ->
+      emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
     }
-  val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
-  val emptyFiles = toolchainFiles.filter { it.length() == 0L }
-  val links = toolchainFiles.mapNotNull { file ->
-    emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
-  }
-  links.forEach { (target, link) ->
-    logger.quiet("Fixing up '$link' to link to '$target'.")
-    if (link.delete()) {
-      Files.createSymbolicLink(link.toPath(), target.toPath())
-    } else {
-      logger.warn("Unable to delete '$link'.")
+    links.forEach { (target, link) ->
+      logger.quiet("Fixing up '$link' to link to '$target'.")
+      if (link.delete()) {
+        Files.createSymbolicLink(link.toPath(), target.toPath())
+      } else {
+        logger.warn("Unable to delete '$link'.")
+      }
     }
   }
 }

--- a/meshcore-tui/build.gradle.kts
+++ b/meshcore-tui/build.gradle.kts
@@ -46,21 +46,28 @@ graalvmNative {
 // square/okhttp#9393 — recreate symlinks broken by Gradle toolchain provisioning
 // (https://github.com/gradle/gradle/issues/28583).
 tasks.named<BuildNativeImageTask>("nativeCompile") {
-  val toolchainDir =
-    options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
-      if (name == "bin") parentFile else this
+  // Resolve the toolchain and recreate the symlinks at execution time, not at
+  // configuration time. In the `named { }` body this ran whenever the task was
+  // merely realized — including when a tool queries the Gradle project model
+  // (`compose-preview show`) — forcing the GraalVM toolchain to be provisioned
+  // and failing on environments that can't fetch it.
+  doFirst {
+    val toolchainDir =
+      options.get().javaLauncher.get().executablePath.asFile.parentFile.run {
+        if (name == "bin") parentFile else this
+      }
+    val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
+    val emptyFiles = toolchainFiles.filter { it.length() == 0L }
+    val links = toolchainFiles.mapNotNull { file ->
+      emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
     }
-  val toolchainFiles = toolchainDir.walkTopDown().filter { it.isFile }
-  val emptyFiles = toolchainFiles.filter { it.length() == 0L }
-  val links = toolchainFiles.mapNotNull { file ->
-    emptyFiles.singleOrNull { it != file && it.name == file.name }?.let { file to it }
-  }
-  links.forEach { (target, link) ->
-    logger.quiet("Fixing up '$link' to link to '$target'.")
-    if (link.delete()) {
-      Files.createSymbolicLink(link.toPath(), target.toPath())
-    } else {
-      logger.warn("Unable to delete '$link'.")
+    links.forEach { (target, link) ->
+      logger.quiet("Fixing up '$link' to link to '$target'.")
+      if (link.delete()) {
+        Files.createSymbolicLink(link.toPath(), target.toPath())
+      } else {
+        logger.warn("Unable to delete '$link'.")
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

The compose-preview "Render previews" check has been failing for a while (red on #73, #74, #75). The root cause is unrelated to compose-ai-tools itself.

`compose-preview show` discovers previews by querying the **full Gradle project model**, which realizes every task across all modules. In `meshcore-cli` and `meshcore-tui`, the GraalVM symlink-fixup sat directly in the `tasks.named<BuildNativeImageTask>("nativeCompile") { … }` body, so it ran at **configuration time** and eagerly called `options.get().javaLauncher.get()`. That forced the pinned **GraalVM 25** toolchain to be provisioned merely to *realize* the task. When the toolchain couldn't be provisioned, the model query died, `show` emitted nothing → empty `_previews.json` → the preview job failed.

This was not a 0.12.0 regression — the 0.11.16 CLI reproduces the failure identically.

## Fix

Move the symlink-fixup into `doFirst { … }` in both `meshcore-cli/build.gradle.kts` and `meshcore-tui/build.gradle.kts`, so the toolchain is resolved only when `nativeCompile` actually executes (which is what the existing comment — "recreate them before nativeCompile runs" — already intended). Configuration and Gradle model queries no longer touch the GraalVM toolchain.

## Test plan

- `compose-preview show` previously produced no output (model query failed at configuration). After the change it gets past configuration and logs `Found preview modules: app, wear`, then proceeds into rendering.
- `ktfmtCheck` passes.
- The `nativeCompile` execution path is unchanged — the fixup still runs before the native image build, just as a `doFirst` action instead of at configuration time.
- The real signal is whether the compose-preview check goes green on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAECgMoYue9s7roB24W2C9)_