### PR TITLE
Exclude kotlinx legacy-API compat artifacts from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       "automerge": false
     },
     {
+      "description": "Ignore the legacy-API -compat artifacts (e.g. kotlinx-datetime 0.8.0-0.6.x-compat)",
+      "matchPackageNames": ["/^org\\.jetbrains\\.kotlinx($|[.:])/"],
+      "allowedVersions": "!/-compat$/"
+    },
+    {
       "groupName": "Kotlin",
       "matchPackageNames": [
         "/^org\\.jetbrains\\.kotlin($|[.:])/",


### PR DESCRIPTION
## Summary
Updated Renovate configuration to ignore legacy-API compatibility artifacts for kotlinx packages, which use a `-compat` suffix that doesn't follow semantic versioning conventions.

## Changes
- Added a new Renovate rule that filters out versions matching the `/-compat$/` pattern for all `org.jetbrains.kotlinx` packages
- This prevents Renovate from creating unnecessary update PRs for compatibility shim versions (e.g., `kotlinx-datetime 0.8.0-0.6.x-compat`)

## Details
The `-compat` suffix is used by JetBrains for legacy API compatibility artifacts that are not intended for direct consumption. By excluding these versions, we reduce noise in dependency updates while still receiving updates for actual releases.

https://claude.ai/code/session_013aJG1UUYXbBqscDHCHQCgt