### PR TITLE
test: cover MeshCoreManager lifecycle and MeshcoreRepository merge

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,8 +35,12 @@ the reasoning behind many of these items.
 - [x] Core: unit tests for `MeshCoreClient` state machine (fake transport)
   - `FakeTransport`, `MeshCoreClientTest` (start, timeout, parse, seedFromCache)
 - [ ] Core: integration test for client handshake + event parsing
-- [ ] Core: test `MeshCoreManager` lifecycle (connect, disconnect, reconnect)
-- [ ] Data: test `MeshcoreRepository` device merging and deduplication
+- [x] Core: test `MeshCoreManager` lifecycle (connect, disconnect, reconnect)
+  - `MeshCoreManagerTest` (connect/disconnect, superseding connect, reconnect,
+    transport-error/disconnect state transitions, connect failure)
+- [x] Data: test `MeshcoreRepository` device merging and deduplication
+  - `MeshcoreRepositoryTest` (in-memory Room: public-key lookup, merge moves
+    transport + preserves canonical data, cascade delete, message dedup)
 - [x] Transport: test `StreamFrameCodec` edge cases (partial frames, junk recovery, oversized, reset)
 - [ ] App: unit tests for `AppConnectionController`
 - [ ] App: Compose screenshot tests for key UI states (empty, loaded, error)

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/manager/MeshCoreManagerTest.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/manager/MeshCoreManagerTest.kt
@@ -1,0 +1,152 @@
+package ee.schimke.meshcore.core.manager
+
+import ee.schimke.meshcore.core.protocol.CommandCode
+import ee.schimke.meshcore.core.test.FakeTransport
+import ee.schimke.meshcore.core.test.TestFrames
+import ee.schimke.meshcore.core.transport.TransportState
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Lifecycle tests for [MeshCoreManager] using the in-memory [FakeTransport] — no BLE/USB hardware.
+ * Documents the intended pattern for third-party consumers: drive the manager with any [Transport]
+ * implementation and assert on its [MeshCoreManager.state] flow.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MeshCoreManagerTest {
+
+  /**
+   * A transport that completes the handshake by replying to the `AppStart` frame with a `SelfInfo`
+   * response, the way a real device does. Without this reply [MeshCoreManager.connect] would block
+   * until the client's handshake timeout.
+   */
+  private fun handshakingTransport(name: String = "node"): FakeTransport {
+    val transport = FakeTransport()
+    transport.onSend = { frame ->
+      if (frame[0] == CommandCode.AppStart.raw) {
+        transport.receive(TestFrames.selfInfoFrame(name))
+      }
+    }
+    return transport
+  }
+
+  @Test
+  fun connect_transitionsToConnectedAndSendsAppStart() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+      val transport = handshakingTransport()
+
+      manager.connect(transport)
+
+      val state = manager.state.value
+      assertTrue(state is ManagerState.Connected, "expected Connected, got $state")
+      assertNotNull(manager.client, "client should be available after connect")
+      assertTrue(transport.sentFrames.isNotEmpty(), "expected handshake frames to be sent")
+      assertTrue(
+        transport.sentFrames[0][0] == CommandCode.AppStart.raw,
+        "first sent frame should be AppStart",
+      )
+    }
+
+  @Test
+  fun disconnect_transitionsToIdleAndClosesTransport() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+      val transport = handshakingTransport()
+
+      manager.connect(transport)
+      manager.disconnect()
+
+      assertTrue(manager.state.value is ManagerState.Idle, "expected Idle after disconnect")
+      assertNull(manager.client, "client should be cleared after disconnect")
+      assertTrue(transport.closed, "transport should be closed on disconnect")
+    }
+
+  @Test
+  fun connect_supersedesPreviousConnection() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+      val first = handshakingTransport("first")
+      val second = handshakingTransport("second")
+
+      manager.connect(first)
+      val firstClient = manager.client
+      manager.connect(second)
+
+      val state = manager.state.value
+      assertTrue(state is ManagerState.Connected, "expected Connected after second connect")
+      assertTrue(first.closed, "the superseded transport should be closed")
+      assertTrue(manager.client !== firstClient, "a new client should back the second connection")
+      assertSame(manager.client, state.client, "state should expose the live client")
+    }
+
+  @Test
+  fun reconnect_afterDisconnectSucceeds() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+      manager.connect(handshakingTransport())
+      manager.disconnect()
+      assertTrue(manager.state.value is ManagerState.Idle)
+
+      manager.connect(handshakingTransport())
+      assertTrue(manager.state.value is ManagerState.Connected, "should reconnect cleanly")
+    }
+
+  @Test
+  fun connect_failsWhenTransportConnectThrows() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+      val boom = IllegalStateException("GATT failed")
+      val transport = FakeTransport().apply { connectError = boom }
+
+      val thrown = assertFailsWith<IllegalStateException> { manager.connect(transport) }
+      assertSame(boom, thrown, "connect should rethrow the transport failure")
+
+      val state = manager.state.value
+      assertTrue(state is ManagerState.Failed, "expected Failed, got $state")
+      assertSame(boom, state.cause, "failure should carry the transport cause")
+    }
+
+  @Test
+  fun transportError_whileConnected_transitionsToFailed() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+      val transport = handshakingTransport()
+
+      manager.connect(transport)
+      assertTrue(manager.state.value is ManagerState.Connected)
+
+      val cause = RuntimeException("link lost")
+      transport.emitState(TransportState.Error(cause))
+
+      val state = manager.state.value
+      assertTrue(state is ManagerState.Failed, "expected Failed after transport error, got $state")
+      assertSame(cause, state.cause)
+    }
+
+  @Test
+  fun transportDisconnect_whileConnected_transitionsToIdle() =
+    runTest(UnconfinedTestDispatcher()) {
+      val manager = MeshCoreManager(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+      val transport = handshakingTransport()
+
+      manager.connect(transport)
+      assertTrue(manager.state.value is ManagerState.Connected)
+
+      transport.emitState(TransportState.Disconnected)
+
+      assertTrue(
+        manager.state.value is ManagerState.Idle,
+        "a dropped transport should return the manager to Idle",
+      )
+    }
+}

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/test/FakeTransport.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/test/FakeTransport.kt
@@ -23,20 +23,44 @@ class FakeTransport : Transport {
 
   val sentFrames = mutableListOf<ByteString>()
 
+  /**
+   * When non-null, [connect] throws this instead of transitioning to [TransportState.Connected].
+   */
+  var connectError: Throwable? = null
+
+  /** Set true once [close] has been invoked, so tests can assert teardown happened. */
+  var closed: Boolean = false
+    private set
+
+  /**
+   * Optional hook invoked for every frame passed to [send] (after it is recorded in [sentFrames]).
+   * Lets a test auto-respond to a request frame, e.g. replying to `AppStart` with a `SelfInfo`
+   * frame so [ee.schimke.meshcore.core.manager.MeshCoreManager.connect] can reach `Connected`.
+   */
+  var onSend: (suspend (ByteString) -> Unit)? = null
+
   override suspend fun connect() {
+    connectError?.let { throw it }
     _state.value = TransportState.Connected
   }
 
   override suspend fun send(frame: ByteString) {
     sentFrames += frame
+    onSend?.invoke(frame)
   }
 
   override suspend fun close() {
+    closed = true
     _state.value = TransportState.Disconnected
   }
 
   /** Simulate a frame arriving from the device side. */
   suspend fun receive(frame: ByteString) {
     _incoming.emit(frame)
+  }
+
+  /** Push an arbitrary transport state (e.g. [TransportState.Error]) for state-machine tests. */
+  fun emitState(state: TransportState) {
+    _state.value = state
   }
 }

--- a/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/test/TestFrames.kt
+++ b/meshcore-core/src/commonTest/kotlin/ee/schimke/meshcore/core/test/TestFrames.kt
@@ -1,0 +1,40 @@
+package ee.schimke.meshcore.core.test
+
+import ee.schimke.meshcore.core.protocol.ResponseCode
+import kotlinx.io.Buffer
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.readByteString
+import kotlinx.io.writeIntLe
+
+/** Frame builders shared across core tests. */
+object TestFrames {
+  /**
+   * Build a minimal `SelfInfo` response frame, the reply the device sends in response to `AppStart`
+   * during the handshake. [publicKey] defaults to a fixed 32-byte filler.
+   */
+  fun selfInfoFrame(
+    name: String = "test-node",
+    publicKey: ByteArray = ByteArray(32) { 0xAB.toByte() },
+  ): ByteString {
+    require(publicKey.size == 32) { "public key must be 32 bytes" }
+    val buf = Buffer()
+    buf.writeByte(ResponseCode.SelfInfo.raw) // code
+    buf.writeByte(1) // advType
+    buf.writeByte(14) // txPower
+    buf.writeByte(22) // maxPower
+    buf.write(publicKey) // public key
+    buf.writeIntLe(53_000_000) // lat * 1_000_000
+    buf.writeIntLe(-1_500_000) // lon * 1_000_000
+    buf.writeByte(0) // multiAcks
+    buf.writeByte(0) // advertLocationPolicy
+    buf.writeByte(0) // telemetryFlags
+    buf.writeByte(0) // manualAddContacts
+    buf.writeIntLe(869_525_000) // freq Hz
+    buf.writeIntLe(125_000) // bandwidth Hz
+    buf.writeByte(10) // spreading factor
+    buf.writeByte(5) // coding rate
+    buf.write(name.encodeToByteArray())
+    buf.writeByte(0) // null terminator
+    return buf.readByteString()
+  }
+}

--- a/meshcore-data/build.gradle.kts
+++ b/meshcore-data/build.gradle.kts
@@ -22,6 +22,12 @@ kotlin {
       implementation(libs.sqlite.bundled)
       implementation(libs.kotlinx.coroutines.core)
     }
+    jvmTest.dependencies {
+      implementation(libs.kotlin.test)
+      implementation(libs.kotlinx.coroutines.test)
+      implementation(libs.room.runtime)
+      implementation(libs.sqlite.bundled)
+    }
   }
 }
 

--- a/meshcore-data/src/jvmTest/kotlin/ee/schimke/meshcore/data/repository/MeshcoreRepositoryTest.kt
+++ b/meshcore-data/src/jvmTest/kotlin/ee/schimke/meshcore/data/repository/MeshcoreRepositoryTest.kt
@@ -1,0 +1,191 @@
+package ee.schimke.meshcore.data.repository
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import ee.schimke.meshcore.core.model.Contact
+import ee.schimke.meshcore.core.model.ContactType
+import ee.schimke.meshcore.core.model.PublicKey
+import ee.schimke.meshcore.core.model.RadioSettings
+import ee.schimke.meshcore.core.model.ReceivedDirectMessage
+import ee.schimke.meshcore.core.model.SelfInfo
+import ee.schimke.meshcore.core.protocol.TextType
+import ee.schimke.meshcore.data.MeshcoreDatabase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+
+/**
+ * Repository-level tests against an in-memory Room database (JVM, no Android). These document the
+ * device-merge / public-key deduplication flow that [MeshcoreRepository] performs when the same
+ * physical node is reached over two different transports (e.g. BLE then USB).
+ */
+class MeshcoreRepositoryTest {
+
+  private lateinit var db: MeshcoreDatabase
+  private lateinit var repo: MeshcoreRepository
+
+  @BeforeTest
+  fun setUp() {
+    db =
+      Room.inMemoryDatabaseBuilder<MeshcoreDatabase>()
+        .setDriver(BundledSQLiteDriver())
+        .setQueryCoroutineContext(Dispatchers.IO)
+        .build()
+    repo = MeshcoreRepository(db)
+  }
+
+  @AfterTest
+  fun tearDown() {
+    db.close()
+  }
+
+  private fun pubKey(fill: Int): PublicKey =
+    PublicKey.fromBytes(ByteString(*ByteArray(32) { fill.toByte() }))
+
+  private fun selfInfo(name: String, key: PublicKey): SelfInfo =
+    SelfInfo(
+      advertType = 1,
+      txPowerDbm = 14,
+      maxPowerDbm = 22,
+      publicKey = key,
+      latitude = 53.0,
+      longitude = -1.5,
+      multiAcks = 0,
+      advertLocationPolicy = 0,
+      telemetryFlags = 0,
+      manualAddContacts = 0,
+      radio = RadioSettings(869_525_000, 125_000, 10, 5),
+      name = name,
+    )
+
+  private fun contact(key: PublicKey, name: String): Contact =
+    Contact(
+      publicKey = key,
+      type = ContactType.fromRaw(1),
+      flags = 0,
+      pathLength = 0,
+      path = ByteString(),
+      name = name,
+      advertTimestamp = Instant.fromEpochSeconds(0),
+      latitude = 0.0,
+      longitude = 0.0,
+      lastModified = Instant.fromEpochSeconds(0),
+    )
+
+  @Test
+  fun upsertDevice_isObservable() = runTest {
+    repo.upsertDevice("ble:aa", "Node A", SavedTransport.Ble("aa", "adv-a"))
+
+    val devices = repo.observeDevices().first()
+    assertEquals(1, devices.size)
+    assertEquals("ble:aa", devices[0].id)
+    assertTrue(devices[0].transport is SavedTransport.Ble)
+  }
+
+  @Test
+  fun updateSelfInfo_enablesPublicKeyLookupAndUpdatesLabel() = runTest {
+    val key = pubKey(0x11)
+    repo.upsertDevice("ble:aa", "placeholder", SavedTransport.Ble("aa", null))
+
+    repo.updateSelfInfo("ble:aa", selfInfo("Real Name", key), fetchedAtMs = 1_000)
+
+    assertEquals("ble:aa", repo.findDeviceIdByPublicKey(key))
+    // updateSelfInfo also rewrites the device label with the node's real name.
+    assertEquals("Real Name", repo.getDevice("ble:aa")?.label)
+  }
+
+  @Test
+  fun findDeviceIdByPublicKey_returnsNullForUnknownKey() = runTest {
+    repo.upsertDevice("ble:aa", "Node A", SavedTransport.Ble("aa", null))
+    repo.updateSelfInfo("ble:aa", selfInfo("A", pubKey(0x11)), fetchedAtMs = 0)
+
+    assertNull(repo.findDeviceIdByPublicKey(pubKey(0x22)))
+  }
+
+  @Test
+  fun mergeDevice_dedupesByPublicKeyMovingTransportAndPreservingCanonicalData() = runTest {
+    val key = pubKey(0x33)
+
+    // Canonical entry first seen over BLE, with cached state (public key) and a contact.
+    repo.upsertDevice("ble:aa", "Node", SavedTransport.Ble("aa", "adv"))
+    repo.updateSelfInfo("ble:aa", selfInfo("Node", key), fetchedAtMs = 0)
+    repo.replaceContacts("ble:aa", listOf(contact(pubKey(0x99), "friend")), fetchedAtMs = 0)
+
+    // Same physical node reached over USB lands as a separate entry...
+    repo.upsertDevice("usb:bb", "Node", SavedTransport.Usb("Cls", 1, 2))
+    // ...but the public-key lookup finds the existing canonical entry.
+    val canonical = repo.findDeviceIdByPublicKey(key)
+    assertEquals("ble:aa", canonical)
+
+    repo.mergeDevice(
+      fromId = "usb:bb",
+      intoId = "ble:aa",
+      transport = SavedTransport.Usb("Cls", 1, 2),
+    )
+
+    // Source entry is gone, canonical survives and now carries the USB transport.
+    assertNull(repo.getDevice("usb:bb"))
+    val merged = repo.getDevice("ble:aa")
+    assertTrue(merged?.transport is SavedTransport.Usb, "transport should be moved to USB")
+    // Canonical contacts (and the public-key state) are preserved across the merge.
+    assertEquals(1, repo.getContacts("ble:aa").size)
+    assertEquals("ble:aa", repo.findDeviceIdByPublicKey(key))
+  }
+
+  @Test
+  fun mergeDevice_intoSameIdIsANoOpDelete() = runTest {
+    repo.upsertDevice("ble:aa", "Node", SavedTransport.Ble("aa", "adv"))
+
+    // Merging an entry into itself must not delete it.
+    repo.mergeDevice(
+      fromId = "ble:aa",
+      intoId = "ble:aa",
+      transport = SavedTransport.Ble("aa", "adv"),
+    )
+
+    assertEquals(1, repo.observeDevices().first().size)
+  }
+
+  @Test
+  fun forgetDevice_cascadesToContacts() = runTest {
+    repo.upsertDevice("ble:aa", "Node", SavedTransport.Ble("aa", null))
+    repo.replaceContacts("ble:aa", listOf(contact(pubKey(0x99), "friend")), fetchedAtMs = 0)
+    assertEquals(1, repo.getContacts("ble:aa").size)
+
+    repo.forgetDevice("ble:aa")
+
+    assertNull(repo.getDevice("ble:aa"))
+    assertTrue(
+      repo.getContacts("ble:aa").isEmpty(),
+      "contacts should cascade-delete with the device",
+    )
+  }
+
+  @Test
+  fun insertReceivedDm_deduplicatesByTimestampAndText() = runTest {
+    repo.upsertDevice("ble:aa", "Node", SavedTransport.Ble("aa", null))
+    val contactHex = pubKey(0x99).toHex()
+    val msg =
+      ReceivedDirectMessage(
+        snr = 10,
+        senderPrefix = pubKey(0x99),
+        pathLength = 0,
+        timestamp = Instant.fromEpochSeconds(1_000),
+        textType = TextType.Plain,
+        text = "hello",
+      )
+
+    repo.insertReceivedDm("ble:aa", msg, contactHex)
+    repo.insertReceivedDm("ble:aa", msg, contactHex) // duplicate
+
+    assertEquals(1, repo.getRecentMessages("ble:aa").size, "duplicate DM should be ignored")
+  }
+}


### PR DESCRIPTION
## Summary

Expands integration-layer test coverage (issue #89) for two previously-uncovered boundaries, hardware-free:

- **Core — `MeshCoreManagerTest`** (7 tests, `commonTest`, driven by `FakeTransport`): connect → `Connected` + AppStart sent; disconnect → `Idle` + transport closed; superseding connect; reconnect after disconnect; connect failure → `Failed` (rethrown); transport `Error` while connected → `Failed`; transport `Disconnected` while connected → `Idle`.
- **Data — `MeshcoreRepositoryTest`** (7 tests, new `jvmTest` source set, in-memory Room): device observable after upsert; `updateSelfInfo` enables public-key lookup and rewrites the label; unknown-key lookup returns null; the merge/dedup flow (public-key lookup finds the canonical entry, `mergeDevice` moves the transport and preserves canonical contacts/state); merge-into-self is a no-op delete; `forgetDevice` cascade-deletes contacts; received-DM deduplication by timestamp + text.

Supporting changes:
- `FakeTransport` gains (backward-compatibly) an `onSend` hook, `connectError`, a `closed` flag, and `emitState` so the handshake and failure paths can be simulated.
- Shared `TestFrames.selfInfoFrame` builder backs the handshake reply.
- Adds a `jvmTest` source set to `meshcore-data`.
- Ticks off the two corresponding Testing items in `docs/TODO.md`.

## Scope

Covers the **Core** (manager lifecycle) and **Data** (repository merge/dedup) bullets from #89. The `AppConnectionController` bullet is left out as it is blocked by #85 (DI) — the controller still hard-instantiates the platform transports and uses `android.util.Log`/`Context`. The transport and Compose UI bullets are the optional items and are not included here.

## Test plan

- `./gradlew :meshcore-core:jvmTest :meshcore-data:jvmTest` — all 14 new tests pass.
- `./gradlew ktfmtCheck` — passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BS67RuKiXJXiK9767amFcn)_