### PR TITLE
ci(design-parity): pack candidate bundle with --with-semantics

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -57,7 +57,14 @@ jobs:
           mapfile -t IDS < <(jq -r '.components[].previewId' design-map.json)
           args=()
           for id in "${IDS[@]}"; do args+=(--id "$id"); done
+          # --with-semantics injects each preview's previews/<id>.semantics.json
+          # (resolved fg/bg colours + a11y tree) so design-parity's token /
+          # contrast / a11y checks evaluate instead of reporting "missing from
+          # candidate" (compose-ai-tools#1843/#1845). It spins up the daemon and
+          # re-renders, and degrades gracefully (bundle stays valid, warning to
+          # stderr) if the desktop backend doesn't emit semantics.
           compose-preview bundle pack --module meshcore-components "${args[@]}" \
+            --with-semantics \
             -o build/design-parity/candidates.bundle.png --timeout 600
 
       # Reference images are generated from the design/*.html source of truth


### PR DESCRIPTION
## Summary

The design-parity verdict on `main` is `Fail` purely because every reference token reports *"missing from candidate"* — the candidate bundle carries no per-preview semantics, so the token / contrast / a11y checks (the high-value findings) can't evaluate and the run degrades to **visual-only**.

[compose-ai-tools#1845](https://github.com/yschimke/compose-ai-tools/pull/1845) (in the pinned 0.15.5) added an opt-in `bundle pack --with-semantics` that injects `previews/<id>.semantics.json` (resolved foreground/background colours + a11y tree) in the shape design-parity reads. This passes that flag in `design-parity.yml` so those checks actually run.

## Behaviour

- `--with-semantics` spins up the daemon and re-renders the selected previews to capture each one's `compose/semantics`, then injects it beside the cover PNG.
- **Graceful degradation:** if the desktop (Skiko) backend doesn't emit the blob, the flag warns to stderr and leaves the bundle valid — worst case is no change from today's visual-only verdict.

## Validation

`design-parity.yml` runs only on push to `main`, so this is exercised on the **next post-merge run**: check the published report on `design-parity/main` — if the desktop daemon emits semantics, the token / contrast / a11y findings flip from *"missing from candidate"* to real pass/fail; if not, the "Render candidate bundle" step log shows the graceful-degradation warning and the verdict stays visual-only (~11% light / ~6% dark, unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_