### PR TITLE
build(deps): bump design-parity to 0.1.2

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.1 run \
+          npx -y design-parity@0.1.2 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the design-parity CLI pin in `design-parity.yml` from `0.1.1` → `0.1.2`.

0.1.2 generates a branch landing page (`README.md` + `index.html`) for the published `design-parity/main` artifacts, so the long-lived branch gets a readable entry point alongside the per-preview `report.html` triptychs.

## Test plan

- YAML validated (`yaml.safe_load`).
- Verified end-to-end on a `workflow_dispatch` run against `main` (e66b864): the design-parity job is green and `design-parity/main` republishes with the landing page (`README.md` + `index.html`) present.
- No behavioural change to the parity verdict — purely the published-artifacts entry point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_