### PR TITLE
build(deps): bump design-parity to 0.1.3

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.2 run \
+          npx -y design-parity@0.1.3 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the design-parity CLI pin `0.1.2 → 0.1.3`.

0.1.3 is the **reader** half of the token-compliance chain: it reads the resolved design tokens compose-ai-tools 0.15.8 emits on `compose/semantics` nodes (design-parity#79, compose-ai-tools#1897) and adds a token alias map (design names → code names, design-parity#78). With the candidate already packed `--with-semantics` on 0.15.8 (#105), the bundle carries per-node `tokens` (background colour / corner radius / padding), so the **token / contrast checks can now populate `actual`** instead of reporting every reference token "missing from candidate".

This is the last link — producer (0.15.8) → candidate bundle (#105) → reader (0.1.3) — so the next `design-parity/main` run should show real token/contrast findings.

## Test plan

- YAML validated (`yaml.safe_load`).
- One-line CLI version bump; no behavioural change to the workflow itself.
- design-parity runs on merge to `main` (and is `workflow_dispatch`-able). Once 0.1.3 is on npm (publishing in progress at PR time), the run will exercise the new reader; I'll confirm the token findings actually move from "missing from candidate" to evaluated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_