### PR TITLE
build(deps): bump design-parity to 0.1.4

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.3 run \
+          npx -y design-parity@0.1.4 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the design-parity CLI pin `0.1.3 → 0.1.4`. compose-ai-tools stays at **0.15.8** (already current across the action/CLI/plugin pins — no change).

0.1.4 brings:
- **design-parity#95** — shorten the landing-page component labels (file basename + member, full handle kept as a tooltip) so the `design-parity/main` report table fits on mobile.
- **#87** — Material colour/type role heuristics on top of 0.1.3's token reader (more reference tokens resolve without an explicit alias).

## Test plan

- YAML validated (`yaml.safe_load`); no `0.1.3` pin remains.
- `design-parity@0.1.4` is already `latest` on npm, so the post-merge `design-parity/main` run resolves it with no propagation race.
- One-line CLI version bump; no workflow behaviour change. On merge, the refreshed report should show the shorter component column.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_