### PR TITLE
feat(design-parity): adopt the chat screens (contact, channel, commands)

### DIFF
--- a/design-map.json
+++ b/design-map.json
@@ -12,6 +12,42 @@
       "source": "claude-design",
       "ref": "design/DeviceScreen.dark.html",
       "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.DeviceBodyDarkPreview_Device — dark"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatPreview",
+      "source": "claude-design",
+      "ref": "design/ContactChat.light.html",
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Contact chat"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatDarkPreview",
+      "source": "claude-design",
+      "ref": "design/ContactChat.dark.html",
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatDarkPreview_Contact chat — dark"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatPreview",
+      "source": "claude-design",
+      "ref": "design/ChannelChat.light.html",
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatPreview_Channel chat"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatDarkPreview",
+      "source": "claude-design",
+      "ref": "design/ChannelChat.dark.html",
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatDarkPreview_Channel chat — dark"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsPreview",
+      "source": "claude-design",
+      "ref": "design/Commands.light.html",
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsPreview_Commands"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsDarkPreview",
+      "source": "claude-design",
+      "ref": "design/Commands.dark.html",
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsDarkPreview_Commands — dark"
     }
   ]
 }

--- a/design/ChannelChat.dark.html
+++ b/design/ChannelChat.dark.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — General chat (dark).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 dark scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>General · MeshCore (dark)</title>
+    <style>
+      :root {
+        --primary: #53dbc9;
+        --primary-container: #005048;
+        --on-primary-container: #74f8e5;
+        --surface: #0e1513;
+        --on-surface: #dde4e1;
+        --on-surface-variant: #bec9c5;
+        --surface-container-high: #242b29;
+        --outline: #89938f;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .titles { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+      .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
+      .messages {
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }
+      .row { display: flex; }
+      .row.them { justify-content: flex-start; padding-right: 48px; }
+      .row.mine { justify-content: flex-end; padding-left: 48px; }
+      .bubble { padding: 8px 12px; border-radius: 12px; max-width: 100%; }
+      .row.them .bubble {
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }
+      .row.mine .bubble {
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }
+      .who-row { display: flex; align-items: center; gap: 8px; }
+      .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .snr { font-size: 11px; opacity: 0.55; }
+      .text { font-size: 15px; line-height: 1.3; }
+      .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
+      .input {
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }
+      .field {
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }
+      .send { width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }
+      .send svg { width: 24px; height: 24px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="titles"><div class="title">General</div><div class="subtitle">Channel 0</div></div>
+      
+    </div>
+    <div class="messages">
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">alice</span><span class="snr">SNR 7</span></div><div class="text">anyone near the north ridge?</div><div class="foot"><span>14/11 21:53</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">bob-repeater</span><span class="snr">SNR 3</span></div><div class="text">I&#x27;ve got line of sight, relaying</div><div class="foot"><span>14/11 21:55</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">copy — net looks healthy</div><div class="foot"><span>14/11 22:08</span><span class="dot">·</span><span>Delivered</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">broadcasting weather update</div><div class="foot"><span>14/11 22:13</span><span class="dot">·</span><span>Sending…</span></div></div></div>
+    </div>
+    <div class="input">
+      <div class="field">Message</div>
+      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatDarkPreview",
+  "tokens": {
+    "spacing": {
+      "listPadding": 12,
+      "bubblePadding": 12,
+      "inputPadding": 8,
+      "bubbleGap": 4
+    },
+    "radius": {
+      "bubble": 12,
+      "input": 24
+    },
+    "colors": {
+      "primary": "#53DBC9",
+      "primaryContainer": "#005048",
+      "onPrimaryContainer": "#74F8E5",
+      "surface": "#0E1513",
+      "onSurface": "#DDE4E1",
+      "onSurfaceVariant": "#BEC9C5",
+      "surfaceContainerHigh": "#242B29",
+      "outline": "#89938F"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "ChannelChat.dark.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/ChannelChat.light.html
+++ b/design/ChannelChat.light.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — General chat (light).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 light scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>General · MeshCore (light)</title>
+    <style>
+      :root {
+        --primary: #006a60;
+        --primary-container: #74f8e5;
+        --on-primary-container: #00201c;
+        --surface: #f4fbf8;
+        --on-surface: #161d1b;
+        --on-surface-variant: #3f4946;
+        --surface-container-high: #e2e9e6;
+        --outline: #6f7976;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .titles { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+      .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
+      .messages {
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }
+      .row { display: flex; }
+      .row.them { justify-content: flex-start; padding-right: 48px; }
+      .row.mine { justify-content: flex-end; padding-left: 48px; }
+      .bubble { padding: 8px 12px; border-radius: 12px; max-width: 100%; }
+      .row.them .bubble {
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }
+      .row.mine .bubble {
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }
+      .who-row { display: flex; align-items: center; gap: 8px; }
+      .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .snr { font-size: 11px; opacity: 0.55; }
+      .text { font-size: 15px; line-height: 1.3; }
+      .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
+      .input {
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }
+      .field {
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }
+      .send { width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }
+      .send svg { width: 24px; height: 24px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="titles"><div class="title">General</div><div class="subtitle">Channel 0</div></div>
+      
+    </div>
+    <div class="messages">
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">alice</span><span class="snr">SNR 7</span></div><div class="text">anyone near the north ridge?</div><div class="foot"><span>14/11 21:53</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">bob-repeater</span><span class="snr">SNR 3</span></div><div class="text">I&#x27;ve got line of sight, relaying</div><div class="foot"><span>14/11 21:55</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">copy — net looks healthy</div><div class="foot"><span>14/11 22:08</span><span class="dot">·</span><span>Delivered</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">broadcasting weather update</div><div class="foot"><span>14/11 22:13</span><span class="dot">·</span><span>Sending…</span></div></div></div>
+    </div>
+    <div class="input">
+      <div class="field">Message</div>
+      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatPreview",
+  "tokens": {
+    "spacing": {
+      "listPadding": 12,
+      "bubblePadding": 12,
+      "inputPadding": 8,
+      "bubbleGap": 4
+    },
+    "radius": {
+      "bubble": 12,
+      "input": 24
+    },
+    "colors": {
+      "primary": "#006A60",
+      "primaryContainer": "#74F8E5",
+      "onPrimaryContainer": "#00201C",
+      "surface": "#F4FBF8",
+      "onSurface": "#161D1B",
+      "onSurfaceVariant": "#3F4946",
+      "surfaceContainerHigh": "#E2E9E6",
+      "outline": "#6F7976"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "ChannelChat.light.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/Commands.dark.html
+++ b/design/Commands.dark.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — Commands chat (dark).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 dark scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Commands · MeshCore (dark)</title>
+    <style>
+      :root {
+        --primary: #53dbc9;
+        --primary-container: #005048;
+        --on-primary-container: #74f8e5;
+        --surface: #0e1513;
+        --on-surface: #dde4e1;
+        --on-surface-variant: #bec9c5;
+        --surface-container-high: #242b29;
+        --outline: #89938f;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .titles { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+      .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
+      .messages {
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }
+      .row { display: flex; }
+      .row.them { justify-content: flex-start; padding-right: 48px; }
+      .row.mine { justify-content: flex-end; padding-left: 48px; }
+      .bubble { padding: 8px 12px; border-radius: 12px; max-width: 100%; }
+      .row.them .bubble {
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }
+      .row.mine .bubble {
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }
+      .who-row { display: flex; align-items: center; gap: 8px; }
+      .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .snr { font-size: 11px; opacity: 0.55; }
+      .text { font-size: 15px; line-height: 1.3; }
+      .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
+      .input {
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }
+      .field {
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }
+      .send { width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }
+      .send svg { width: 24px; height: 24px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="titles"><div class="title">Commands</div></div>
+      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+    </div>
+    <div class="messages">
+      <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">battery: 3980 mV (97%)</div><div class="foot"><span>14/11 22:10</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">get freq</div><div class="foot"><span>14/11 22:12</span><span class="dot">·</span><span>Delivered</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5</div><div class="foot"><span>14/11 22:12</span></div></div></div>
+    </div>
+    <div class="input">
+      <div class="field">Enter command…</div>
+      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsDarkPreview",
+  "tokens": {
+    "spacing": {
+      "listPadding": 12,
+      "bubblePadding": 12,
+      "inputPadding": 8,
+      "bubbleGap": 4
+    },
+    "radius": {
+      "bubble": 12,
+      "input": 24
+    },
+    "colors": {
+      "primary": "#53DBC9",
+      "primaryContainer": "#005048",
+      "onPrimaryContainer": "#74F8E5",
+      "surface": "#0E1513",
+      "onSurface": "#DDE4E1",
+      "onSurfaceVariant": "#BEC9C5",
+      "surfaceContainerHigh": "#242B29",
+      "outline": "#89938F"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "Commands.dark.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/Commands.light.html
+++ b/design/Commands.light.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — Commands chat (light).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 light scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Commands · MeshCore (light)</title>
+    <style>
+      :root {
+        --primary: #006a60;
+        --primary-container: #74f8e5;
+        --on-primary-container: #00201c;
+        --surface: #f4fbf8;
+        --on-surface: #161d1b;
+        --on-surface-variant: #3f4946;
+        --surface-container-high: #e2e9e6;
+        --outline: #6f7976;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .titles { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+      .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
+      .messages {
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }
+      .row { display: flex; }
+      .row.them { justify-content: flex-start; padding-right: 48px; }
+      .row.mine { justify-content: flex-end; padding-left: 48px; }
+      .bubble { padding: 8px 12px; border-radius: 12px; max-width: 100%; }
+      .row.them .bubble {
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }
+      .row.mine .bubble {
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }
+      .who-row { display: flex; align-items: center; gap: 8px; }
+      .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .snr { font-size: 11px; opacity: 0.55; }
+      .text { font-size: 15px; line-height: 1.3; }
+      .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
+      .input {
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }
+      .field {
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }
+      .send { width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }
+      .send svg { width: 24px; height: 24px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="titles"><div class="title">Commands</div></div>
+      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+    </div>
+    <div class="messages">
+      <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">battery: 3980 mV (97%)</div><div class="foot"><span>14/11 22:10</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">get freq</div><div class="foot"><span>14/11 22:12</span><span class="dot">·</span><span>Delivered</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5</div><div class="foot"><span>14/11 22:12</span></div></div></div>
+    </div>
+    <div class="input">
+      <div class="field">Enter command…</div>
+      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsPreview",
+  "tokens": {
+    "spacing": {
+      "listPadding": 12,
+      "bubblePadding": 12,
+      "inputPadding": 8,
+      "bubbleGap": 4
+    },
+    "radius": {
+      "bubble": 12,
+      "input": 24
+    },
+    "colors": {
+      "primary": "#006A60",
+      "primaryContainer": "#74F8E5",
+      "onPrimaryContainer": "#00201C",
+      "surface": "#F4FBF8",
+      "onSurface": "#161D1B",
+      "onSurfaceVariant": "#3F4946",
+      "surfaceContainerHigh": "#E2E9E6",
+      "outline": "#6F7976"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "Commands.light.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/ContactChat.dark.html
+++ b/design/ContactChat.dark.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — alice chat (dark).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 dark scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>alice · MeshCore (dark)</title>
+    <style>
+      :root {
+        --primary: #53dbc9;
+        --primary-container: #005048;
+        --on-primary-container: #74f8e5;
+        --surface: #0e1513;
+        --on-surface: #dde4e1;
+        --on-surface-variant: #bec9c5;
+        --surface-container-high: #242b29;
+        --outline: #89938f;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .titles { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+      .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
+      .messages {
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }
+      .row { display: flex; }
+      .row.them { justify-content: flex-start; padding-right: 48px; }
+      .row.mine { justify-content: flex-end; padding-left: 48px; }
+      .bubble { padding: 8px 12px; border-radius: 12px; max-width: 100%; }
+      .row.them .bubble {
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }
+      .row.mine .bubble {
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }
+      .who-row { display: flex; align-items: center; gap: 8px; }
+      .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .snr { font-size: 11px; opacity: 0.55; }
+      .text { font-size: 15px; line-height: 1.3; }
+      .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
+      .input {
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }
+      .field {
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }
+      .send { width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }
+      .send svg { width: 24px; height: 24px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="titles"><div class="title">alice</div><div class="subtitle">Direct message</div></div>
+      
+    </div>
+    <div class="messages">
+      <div class="row them"><div class="bubble"><div class="text">hey — are you on tonight?</div><div class="foot"><span>14/11 21:58</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">yeah, firing up the node now</div><div class="foot"><span>14/11 21:59</span><span class="dot">·</span><span>Delivered</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="text">nice — I&#x27;ll relay through bob-repeater</div><div class="foot"><span>14/11 22:11</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">sounds good, sending a test ping</div><div class="foot"><span>14/11 22:12</span><span class="dot">·</span><span>Sent</span></div></div></div>
+    </div>
+    <div class="input">
+      <div class="field">Message</div>
+      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatDarkPreview",
+  "tokens": {
+    "spacing": {
+      "listPadding": 12,
+      "bubblePadding": 12,
+      "inputPadding": 8,
+      "bubbleGap": 4
+    },
+    "radius": {
+      "bubble": 12,
+      "input": 24
+    },
+    "colors": {
+      "primary": "#53DBC9",
+      "primaryContainer": "#005048",
+      "onPrimaryContainer": "#74F8E5",
+      "surface": "#0E1513",
+      "onSurface": "#DDE4E1",
+      "onSurfaceVariant": "#BEC9C5",
+      "surfaceContainerHigh": "#242B29",
+      "outline": "#89938F"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "ContactChat.dark.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/ContactChat.light.html
+++ b/design/ContactChat.light.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — alice chat (light).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 light scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>alice · MeshCore (light)</title>
+    <style>
+      :root {
+        --primary: #006a60;
+        --primary-container: #74f8e5;
+        --on-primary-container: #00201c;
+        --surface: #f4fbf8;
+        --on-surface: #161d1b;
+        --on-surface-variant: #3f4946;
+        --surface-container-high: #e2e9e6;
+        --outline: #6f7976;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .titles { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+      .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
+      .messages {
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }
+      .row { display: flex; }
+      .row.them { justify-content: flex-start; padding-right: 48px; }
+      .row.mine { justify-content: flex-end; padding-left: 48px; }
+      .bubble { padding: 8px 12px; border-radius: 12px; max-width: 100%; }
+      .row.them .bubble {
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }
+      .row.mine .bubble {
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }
+      .who-row { display: flex; align-items: center; gap: 8px; }
+      .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .snr { font-size: 11px; opacity: 0.55; }
+      .text { font-size: 15px; line-height: 1.3; }
+      .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
+      .input {
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }
+      .field {
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }
+      .send { width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }
+      .send svg { width: 24px; height: 24px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="titles"><div class="title">alice</div><div class="subtitle">Direct message</div></div>
+      
+    </div>
+    <div class="messages">
+      <div class="row them"><div class="bubble"><div class="text">hey — are you on tonight?</div><div class="foot"><span>14/11 21:58</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">yeah, firing up the node now</div><div class="foot"><span>14/11 21:59</span><span class="dot">·</span><span>Delivered</span></div></div></div>
+      <div class="row them"><div class="bubble"><div class="text">nice — I&#x27;ll relay through bob-repeater</div><div class="foot"><span>14/11 22:11</span></div></div></div>
+      <div class="row mine"><div class="bubble"><div class="text">sounds good, sending a test ping</div><div class="foot"><span>14/11 22:12</span><span class="dot">·</span><span>Sent</span></div></div></div>
+    </div>
+    <div class="input">
+      <div class="field">Message</div>
+      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatPreview",
+  "tokens": {
+    "spacing": {
+      "listPadding": 12,
+      "bubblePadding": 12,
+      "inputPadding": 8,
+      "bubbleGap": 4
+    },
+    "radius": {
+      "bubble": 12,
+      "input": 24
+    },
+    "colors": {
+      "primary": "#006A60",
+      "primaryContainer": "#74F8E5",
+      "onPrimaryContainer": "#00201C",
+      "surface": "#F4FBF8",
+      "onSurface": "#161D1B",
+      "onSurfaceVariant": "#3F4946",
+      "surfaceContainerHigh": "#E2E9E6",
+      "outline": "#6F7976"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "ContactChat.light.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/gen_chat_refs.py
+++ b/design/gen_chat_refs.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Author the chat-screen design-parity references (design/*.html).
+
+Hand-authored design intent for the chat screens, mirroring the CMP-desktop
+renders of ChatBodyPreviews. One template, three screens (contact 1:1, channel
+group, commands), two themes. Tokens are the MeshCore M3 scheme from
+MeshcoreTokens.kt; values match docs/design-parity.md + the Device reference.
+Run from repo root: python3 design/gen_chat_refs.py
+"""
+import html
+import os
+
+LIGHT = dict(
+    primary="#006a60", primaryContainer="#74f8e5", onPrimaryContainer="#00201c",
+    surface="#f4fbf8", onSurface="#161d1b", onSurfaceVariant="#3f4946",
+    surfaceContainerHigh="#e2e9e6", outline="#6f7976", error="#ba1a1a",
+)
+DARK = dict(
+    primary="#53dbc9", primaryContainer="#005048", onPrimaryContainer="#74f8e5",
+    surface="#0e1513", onSurface="#dde4e1", onSurfaceVariant="#bec9c5",
+    surfaceContainerHigh="#242b29", outline="#89938f", error="#ffb4ab",
+)
+
+BACK = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/>'
+        '<polyline points="11 18 5 12 11 6"/></svg>')
+SEND = ('<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg>')
+TERMINAL = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+            'stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/>'
+            '<line x1="12" y1="16" x2="18" y2="16"/></svg>')
+
+# Messages mirror ChatBodyPreviews (sender, text, snr, mine, status, displayed time).
+contact = [
+    ("in", None, None, "hey — are you on tonight?", "14/11 21:58", None),
+    ("out", None, None, "yeah, firing up the node now", "14/11 21:59", "Delivered"),
+    ("in", None, None, "nice — I'll relay through bob-repeater", "14/11 22:11", None),
+    ("out", None, None, "sounds good, sending a test ping", "14/11 22:12", "Sent"),
+]
+channel = [
+    ("in", "alice", 7, "anyone near the north ridge?", "14/11 21:53", None),
+    ("in", "bob-repeater", 3, "I've got line of sight, relaying", "14/11 21:55", None),
+    ("out", None, None, "copy — net looks healthy", "14/11 22:08", "Delivered"),
+    ("out", None, None, "broadcasting weather update", "14/11 22:13", "Sending…"),
+]
+commands = [
+    ("out", None, None, "get bat", "14/11 22:10", "Sent"),
+    ("in", "device", 9, "battery: 3980 mV (97%)", "14/11 22:10", None),
+    ("out", None, None, "get freq", "14/11 22:12", "Confirmed→Delivered"),
+    ("in", "device", 9, "freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5", "14/11 22:12", None),
+]
+# normalise the one "Confirmed" → its display label "Delivered"
+commands[2] = ("out", None, None, "get freq", "14/11 22:12", "Delivered")
+
+
+def bubble(side, sender, snr, text, time, status):
+    mine = side == "out"
+    header = ""
+    if not mine and sender:
+        snr_html = f'<span class="snr">SNR {snr}</span>' if snr is not None else ""
+        header = f'<div class="who-row"><span class="who">{html.escape(sender)}</span>{snr_html}</div>'
+    foot = f'<span>{time}</span>'
+    if mine and status:
+        foot += f'<span class="dot">·</span><span>{html.escape(status)}</span>'
+    return (f'<div class="row {"mine" if mine else "them"}">'
+            f'<div class="bubble">{header}'
+            f'<div class="text">{html.escape(text)}</div>'
+            f'<div class="foot">{foot}</div></div></div>')
+
+
+def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, component_id, png):
+    sub = f'<div class="subtitle">{html.escape(subtitle)}</div>' if subtitle else ""
+    action = f'<span class="icon-btn action">{TERMINAL}</span>' if terminal else ""
+    bubbles = "\n      ".join(bubble(*m) for m in msgs)
+    import json
+    manifest = json.dumps({
+        "componentId": component_id,
+        "tokens": {
+            "spacing": {"listPadding": 12, "bubblePadding": 12, "inputPadding": 8, "bubbleGap": 4},
+            "radius": {"bubble": 12, "input": 24},
+            "colors": {
+                "primary": t["primary"].upper(),
+                "primaryContainer": t["primaryContainer"].upper(),
+                "onPrimaryContainer": t["onPrimaryContainer"].upper(),
+                "surface": t["surface"].upper(),
+                "onSurface": t["onSurface"].upper(),
+                "onSurfaceVariant": t["onSurfaceVariant"].upper(),
+                "surfaceContainerHigh": t["surfaceContainerHigh"].upper(),
+                "outline": t["outline"].upper(),
+            },
+        },
+        "images": [{"state": "default", "size": "compact", "src": png}],
+    }, indent=2)
+    return f"""<!doctype html>
+<!--
+  Claude Design HTML export — {html.escape(title)} chat ({theme_name}).
+
+  Hand-authored design intent for the MeshCore chat screen as rendered by the
+  ChatBody preview, mirroring its CMP-desktop render. Colours, radii and spacing
+  below are the MeshCore Material 3 {theme_name} scheme (seed teal #006A60) from
+  MeshcoreTokens.kt. The application/design-parity+json manifest at the end is the
+  machine-readable hand-off (componentId, tokens, reference PNG src); the PNG is
+  generated from this document (not committed). See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>{html.escape(title)} · MeshCore ({theme_name})</title>
+    <style>
+      :root {{
+        --primary: {t['primary']};
+        --primary-container: {t['primaryContainer']};
+        --on-primary-container: {t['onPrimaryContainer']};
+        --surface: {t['surface']};
+        --on-surface: {t['onSurface']};
+        --on-surface-variant: {t['onSurfaceVariant']};
+        --surface-container-high: {t['surfaceContainerHigh']};
+        --outline: {t['outline']};
+      }}
+      * {{ box-sizing: border-box; }}
+      html, body {{ margin: 0; padding: 0; }}
+      body {{
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }}
+      .statusbar {{
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }}
+      .statusbar .battery {{
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }}
+      .statusbar .battery > span {{
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }}
+      .topbar {{
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }}
+      .icon-btn {{
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }}
+      .icon-btn.action {{ color: var(--on-surface-variant); margin-left: auto; }}
+      .icon-btn svg {{ width: 24px; height: 24px; }}
+      .titles {{ flex: 1; display: flex; flex-direction: column; justify-content: center; }}
+      .titles .title {{ font-size: 16px; font-weight: 600; color: var(--on-surface); }}
+      .titles .subtitle {{ font-size: 13px; color: var(--on-surface-variant); }}
+      .messages {{
+        flex: 1; overflow: hidden; padding: 8px 12px;
+        display: flex; flex-direction: column; gap: 4px;
+      }}
+      .row {{ display: flex; }}
+      .row.them {{ justify-content: flex-start; padding-right: 48px; }}
+      .row.mine {{ justify-content: flex-end; padding-left: 48px; }}
+      .bubble {{ padding: 8px 12px; border-radius: 12px; max-width: 100%; }}
+      .row.them .bubble {{
+        background: var(--surface-container-high); color: var(--on-surface);
+        border-bottom-left-radius: 4px;
+      }}
+      .row.mine .bubble {{
+        background: var(--primary-container); color: var(--on-primary-container);
+        border-bottom-right-radius: 4px;
+      }}
+      .who-row {{ display: flex; align-items: center; gap: 8px; }}
+      .who {{ font-size: 12px; font-weight: 600; color: var(--primary); }}
+      .snr {{ font-size: 11px; opacity: 0.55; }}
+      .text {{ font-size: 15px; line-height: 1.3; }}
+      .foot {{ display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }}
+      .input {{
+        flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
+      }}
+      .field {{
+        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        display: flex; align-items: center; padding: 0 18px;
+        color: var(--on-surface-variant); font-size: 15px;
+      }}
+      .send {{ width: 44px; height: 44px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface-variant); }}
+      .send svg {{ width: 24px; height: 24px; }}
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn">{BACK}</span>
+      <div class="titles"><div class="title">{html.escape(title)}</div>{sub}</div>
+      {action}
+    </div>
+    <div class="messages">
+      {bubbles}
+    </div>
+    <div class="input">
+      <div class="field">{html.escape(placeholder)}</div>
+      <span class="send">{SEND}</span>
+    </div>
+    <script type="application/design-parity+json">
+{manifest}
+    </script>
+  </body>
+</html>
+"""
+
+
+SCREENS = [
+    ("ContactChat", "alice", "Direct message", contact, "Message", False,
+     "ContactChatPreview", "ContactChatDarkPreview"),
+    ("ChannelChat", "General", "Channel 0", channel, "Message", False,
+     "ChannelChatPreview", "ChannelChatDarkPreview"),
+    ("Commands", "Commands", None, commands, "Enter command…", True,
+     "CommandsPreview", "CommandsDarkPreview"),
+]
+CID = "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#{}"
+
+out_dir = os.path.join(os.path.dirname(__file__))
+for base, title, subtitle, msgs, placeholder, terminal, light_fn, dark_fn in SCREENS:
+    for theme, t, fn in (("light", LIGHT, light_fn), ("dark", DARK, dark_fn)):
+        path = os.path.join(out_dir, f"{base}.{theme}.html")
+        png = f"{base}.{theme}.png"
+        with open(path, "w") as f:
+            f.write(render(theme, t, title, subtitle, msgs, placeholder, terminal,
+                           CID.format(fn), png))
+        print("wrote", path)

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -5,15 +5,17 @@ at parity with its intended design: it renders the Compose code (the
 *candidate*), diffs it against a committed design *reference*, and emits a
 verdict + a self-contained HTML comparison page (reference | candidate | diff).
 
-This repo adopts it for the **Device screen** (`DeviceScreen.kt#DeviceBody`) as
-the first subject, in both **light** and **dark** themes.
+This repo adopts it for the **Device screen** (`DeviceScreen.kt#DeviceBody`) and
+the **chat screens** — contact (1:1), channel (group), and device commands, all
+sharing the stateless `ChatBody` — each in both **light** and **dark** themes.
+All render on the CMP desktop backend from `:meshcore-components` `commonMain`.
 
 ## What's committed
 
 | Path | Role |
 | --- | --- |
-| `design/DeviceScreen.light.html` | Claude Design HTML export — the **light** reference (`DeviceBodyPreview`), and the single source of truth for that variant. Carries an `application/design-parity+json` handoff manifest (M3 light tokens + the `src` of its reference PNG). |
-| `design/DeviceScreen.dark.html` | The **dark** reference (`DeviceBodyDarkPreview`), M3 dark tokens. |
+| `design/DeviceScreen.{light,dark}.html` | Claude Design HTML export — the Device screen references (`DeviceBodyPreview` / `DeviceBodyDarkPreview`), the single source of truth for each variant. Each carries an `application/design-parity+json` handoff manifest (M3 tokens + the `src` of its reference PNG). |
+| `design/ContactChat.{light,dark}.html`, `design/ChannelChat.{light,dark}.html`, `design/Commands.{light,dark}.html` | The chat screen references (`ContactChatPreview` etc.), authored from the MeshCore M3 scheme; `design/gen_chat_refs.py` is the re-runnable generator that emits them. |
 | `design-map.json` | Correspondence: each preview-function code handle ↔ its reference, plus the `previewId` that reconciles the compose-preview render id with the handle. |
 | `.design-parity.json` | Parity direction. **`code-led`** (advisory) for now — flip to `design-led` once thresholds are calibrated. |
 


### PR DESCRIPTION
## Summary

Makes the three **chat screens** design-parity subjects — the fast-follow to #109 (merged), which moved the chat UI to `commonMain` behind a shared `ChatBody` and verified it renders on the CMP desktop backend.

For each of **contact (1:1)**, **channel (group)**, and **device commands**, in **light + dark**:
- A **claude-design HTML reference** authored from the MeshCore M3 scheme (`MeshcoreTokens.kt`), mirroring the verified `ChatBody` renders — outgoing `primaryContainer` bubbles, incoming `surfaceContainerHigh`, sender name + SNR on group messages, the send/back/terminal icons, the outlined input. Each carries an `application/design-parity+json` manifest (tokens + reference-PNG `src`).
- Wired into **`design-map.json`** (8 components total). The workflow already auto-derives both the bundle-pack `--id` list and the reference renders from `design-map.json`, so **no workflow change is needed**.

`design/gen_chat_refs.py` is the re-runnable generator that emits the six references from one shared layout + per-screen data + tokens (analogous to `IconExtractorTest` for `MeshIcons`).

## Test plan
- `jq` validates `design-map.json` (8 components).
- **`previewId`s cross-checked** against the `@Preview` names in `ChatBodyPreviews.kt` — all 6 match (a mismatch would fail that component's pack `--id`).
- Reference PNGs stay generated-not-committed (`design/*.png` gitignored); `google-chrome-stable` on the runner renders them (no working Chrome in this sandbox, so the local eyeball was on the candidate renders from #109's preview comment, which these references mirror).
- No code change → the PR's build/render checks are unaffected. On merge, the `design-parity/main` run renders **reference | candidate | diff** for each chat screen and publishes the verdict; I'll confirm it there.

## Scope
Chat batch of the "adopt design-parity for the rest of the app screens" work (you chose: all app screens, defer Scanner; I author references from tokens). **CachedDevice** and **DeviceSettings** batches follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_