### PR TITLE
feat(design-parity): adopt the cached (offline) Device screen

### DIFF
--- a/design-map.json
+++ b/design-map.json
@@ -48,6 +48,18 @@
       "source": "claude-design",
       "ref": "design/Commands.dark.html",
       "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsDarkPreview_Commands — dark"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyPreview",
+      "source": "claude-design",
+      "ref": "design/CachedDevice.light.html",
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyPreview_Cached device"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyDarkPreview",
+      "source": "claude-design",
+      "ref": "design/CachedDevice.dark.html",
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyDarkPreview_Cached device — dark"
     }
   ]
 }

--- a/design/CachedDevice.dark.html
+++ b/design/CachedDevice.dark.html
@@ -1,0 +1,323 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — Device screen ("Device — populated"), DARK theme.
+
+  Claude Design is a research preview with no read API and no Figma export, so
+  the design reference is committed as this HTML document and resolved via the
+  repo-root design-map.json (the `claude-design` entry points here). The visible
+  markup below is the design hand-off; the application/design-parity+json script
+  block at the end is the machine-readable manifest the design-parity
+  `claude-design` adapter reads (componentId, tokens, and the `src` of the
+  reference PNG). That PNG is generated from this document (not committed — it
+  would drift from the HTML); the current render lives on the `design-parity/main`
+  branch. See docs/design-parity.md.
+
+  This is the design intent for ee.schimke.meshcore.app.ui.DeviceScreen#DeviceBody
+  as rendered by DeviceBodyDarkPreview ("Device — dark"). Colours, spacing,
+  radii and type roles below are the MeshCore Material 3 dark scheme
+  (seed teal #006A60, dark) taken from app/ui/theme/MeshcoreTheme.kt + Dimens.kt.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Cached device · MeshCore (dark)</title>
+    <style>
+      :root {
+        /* MeshCore M3 dark tokens (MeshcoreTheme.kt) */
+        --primary: #53dbc9;
+        --on-primary: #003731;
+        --secondary-container: #324b47;
+        --on-secondary-container: #cce8e2;
+        --tertiary-container: #584419;
+        --on-tertiary-container: #fddfa6;
+        --surface: #0e1513;
+        --on-surface: #dde4e1;
+        --on-surface-variant: #bec9c5;
+        --outline-variant: #3f4946;
+        --surface-container-lowest: #090f0e;
+        --surface-container-low: #161d1b;
+        --surface-container: #1a211f;
+        --surface-container-high: #242b29;
+        /* Dimens.kt: ScreenPadding 16, CardGap 12, RowGap 8 */
+        --screen-pad: 16px;
+        --card-gap: 12px;
+      }
+
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+
+      body {
+        width: 411px;
+        height: 914px;
+        overflow: hidden;
+        background: var(--surface);
+        color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ---- System status bar (showSystemUi = true) ---- */
+      .statusbar {
+        height: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 16px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px;
+        border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery::after {
+        content: ""; position: absolute; right: -3px; top: 3px;
+        width: 2px; height: 5px; background: var(--on-surface); border-radius: 0 1px 1px 0;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+
+      /* ---- Top app bar ---- */
+      .topbar {
+        height: 56px;
+        display: flex;
+        align-items: center;
+        padding: 0 8px 0 var(--screen-pad);
+        background: var(--surface);
+      }
+      .topbar .title {
+        flex: 1;
+        font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: 0.2px;
+        color: var(--on-surface);
+      }
+      .topbar .actions { display: flex; gap: 4px; }
+      .icon-btn {
+        width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+        color: var(--on-surface-variant);
+      }
+      .icon-btn svg { width: 24px; height: 24px; }
+
+      /* ---- Scroll content column ---- */
+      .content {
+        padding: 8px var(--screen-pad) 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--card-gap);
+      }
+
+      /* ---- Summary hero card ---- */
+      .summary {
+        background: var(--surface-container-low);
+        border-radius: 12px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .summary .node-name {
+        font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
+        font-size: 22px;
+        font-weight: 700;
+        color: var(--on-surface);
+        margin-bottom: 2px;
+      }
+      .line { display: flex; align-items: center; gap: 10px; color: var(--on-surface-variant); font-size: 15px; }
+      .line svg { width: 18px; height: 18px; flex: none; }
+      .line.mono { font-family: "JetBrains Mono", ui-monospace, monospace; letter-spacing: 0.5px; }
+      .battery-row { color: var(--on-surface); }
+      .progress {
+        height: 4px; border-radius: 2px; background: var(--surface-container-high);
+        margin: 2px 0 4px; overflow: hidden;
+      }
+      .progress > span { display: block; height: 100%; width: 81%; background: var(--primary); border-radius: 2px; }
+      .storage { font-size: 13px; }
+
+      /* ---- Last-message banner (outlined card) ---- */
+      .banner {
+        border: 1px solid var(--outline-variant);
+        border-radius: 12px;
+        padding: 12px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .banner svg { width: 22px; height: 22px; color: var(--primary); flex: none; }
+      .banner .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .banner .text { font-size: 15px; color: var(--on-surface); }
+
+      /* ---- Section headers ---- */
+      .section-h {
+        display: flex; align-items: center; gap: 12px;
+        padding: 4px 0;
+        color: var(--on-surface-variant);
+      }
+      .section-h .label { flex: 1; font-size: 15px; font-weight: 600; }
+      .chip {
+        background: var(--secondary-container);
+        color: var(--on-secondary-container);
+        font-size: 13px; font-weight: 600;
+        padding: 6px 14px; border-radius: 8px;
+      }
+      .section-h .caret { width: 20px; height: 20px; color: var(--on-surface-variant); }
+
+      /* ---- Contact / channel rows ---- */
+      .row {
+        background: var(--surface-container-low);
+        border-radius: 12px;
+        padding: 10px 12px;
+        display: flex; align-items: center; gap: 12px;
+      }
+      .avatar {
+        width: 36px; height: 36px; border-radius: 50%;
+        display: flex; align-items: center; justify-content: center;
+        background: var(--secondary-container); color: var(--on-secondary-container); flex: none;
+      }
+      .avatar.amber { background: var(--tertiary-container); color: var(--on-tertiary-container); }
+      .avatar svg { width: 20px; height: 20px; }
+      .row .name { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .row .sub { font-size: 13px; color: var(--on-surface-variant); }
+      .empty { font-size: 13px; color: var(--on-surface-variant); padding: 8px 0; }
+      .empty-center { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 0; }
+      .empty-center svg { width: 20px; height: 20px; }
+      /* ---- Cached-data warning banner (tertiaryContainer) ---- */
+      .warning {
+        background: var(--tertiary-container);
+        color: var(--on-tertiary-container);
+        border-radius: 8px;
+        padding: 12px;
+        display: flex; align-items: center; gap: 8px;
+        font-size: 13px;
+      }
+      .warning svg { width: 18px; height: 18px; flex: none; }
+      .warning .warn-text { flex: 1; }
+      .warning .warn-close { width: 16px; height: 16px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar">
+      <span>9:30</span>
+      <span class="battery"><span></span></span>
+    </div>
+
+    <div class="topbar">
+      <div class="title">node-peak</div>
+      <div class="actions">
+        <span class="icon-btn" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+        <span class="icon-btn" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
+        <span class="icon-btn" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
+      </div>
+    </div>
+
+    <div class="content">
+      <!-- Hero summary card -->
+      <div class="summary">
+        <div class="node-name">node-peak</div>
+        <div class="line mono">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 11a2 2 0 0 0-2 2c0 2 .5 3 .5 5"/><path d="M7 13a5 5 0 0 1 10 0c0 1 0 2-.3 3"/><path d="M4 13a8 8 0 0 1 16 0"/></svg>
+          abababababababab
+        </div>
+        <div class="line">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M5 12.5a10 10 0 0 1 14 0"/><path d="M8.5 16a5 5 0 0 1 7 0"/><circle cx="12" cy="19" r="1.2" fill="currentColor" stroke="none"/></svg>
+          869.525 MHz · BW 125 kHz · SF 10 · CR 5
+        </div>
+        <div class="line battery-row">
+          <svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="3" width="8" height="18" rx="1.5"/><rect x="10" y="1.5" width="4" height="2" rx="0.5"/></svg>
+          81% · 3980 mV
+        </div>
+        <div class="progress"><span></span></div>
+        <div class="line storage">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+          512 / 4096 kB
+        </div>
+      </div>
+
+      <!-- Cached-data warning banner -->
+      <div class="warning">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <span class="warn-text">Cached data — connect to refresh</span>
+        <svg class="warn-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>
+      </div>
+
+      <!-- Last message banner -->
+      <div class="banner">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 4h18v13H7l-4 4z"/></svg>
+        <div>
+          <div class="who">alice</div>
+          <div class="text">hey — are you on tonight?</div>
+        </div>
+      </div>
+
+      <!-- Channels (none configured) -->
+      <div class="section-h">
+        <span class="label">Channels (0)</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="empty">No channels configured</div>
+
+      <!-- Contacts (none favourited) -->
+      <div class="section-h">
+        <span class="label">Contacts (0)</span>
+        <span class="chip">Favourited</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="empty empty-center">
+        <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg>
+        <span>No contacts yet</span>
+      </div>
+
+      <!-- Rooms (none joined) -->
+      <div class="section-h">
+        <span class="label">Rooms (0)</span>
+        <span class="chip">Joined</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="empty">No rooms joined yet</div>
+
+      <!-- Repeaters (none joined) -->
+      <div class="section-h">
+        <span class="label">Repeaters (0)</span>
+        <span class="chip">Joined</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="empty">No repeaters joined yet</div>
+
+    </div>
+
+    <script type="application/design-parity+json">
+      {
+        "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyDarkPreview",
+        "tokens": {
+          "spacing": { "screenPadding": 16, "cardGap": 12, "rowGap": 8, "cardPadding": 16 },
+          "radius": { "card": 12, "chip": 8, "avatar": 18 },
+          "colors": {
+            "primary": "#53DBC9",
+            "surface": "#0E1513",
+            "onSurface": "#DDE4E1",
+            "onSurfaceVariant": "#BEC9C5",
+            "surfaceContainerLow": "#161D1B",
+            "secondaryContainer": "#324B47",
+            "onSecondaryContainer": "#CCE8E2",
+            "tertiaryContainer": "#584419",
+            "outlineVariant": "#3F4946"
+          }
+        },
+        "images": [
+          {
+            "state": "default",
+            "theme": "dark",
+            "size": "compact",
+            "src": "CachedDevice.dark.png"
+          }
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/design/CachedDevice.light.html
+++ b/design/CachedDevice.light.html
@@ -1,0 +1,341 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — Device screen ("Device — populated"), LIGHT theme.
+
+  Claude Design is a research preview with no read API and no Figma export, so
+  the design reference is committed as this HTML document and resolved via the
+  repo-root design-map.json (the `claude-design` entry points here). The visible
+  markup below is the design hand-off; the application/design-parity+json script
+  block at the end is the machine-readable manifest the design-parity
+  `claude-design` adapter reads (componentId, tokens, and the `src` of the
+  reference PNG). That PNG is generated from this document (not committed — it
+  would drift from the HTML); the current render lives on the `design-parity/main`
+  branch. See docs/design-parity.md.
+
+  This is the design intent for ee.schimke.meshcore.app.ui.DeviceScreen#DeviceBody
+  as rendered by DeviceBodyPreview ("Device — populated"). Colours, spacing,
+  radii and type roles below are the MeshCore Material 3 light scheme
+  (seed teal #006A60) taken from app/ui/theme/MeshcoreTheme.kt + Dimens.kt.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Cached device · MeshCore (light)</title>
+    <style>
+      :root {
+        /* MeshCore M3 light tokens (MeshcoreTheme.kt) */
+        --primary: #006a60;
+        --on-primary: #ffffff;
+        --secondary-container: #cce8e2;
+        --on-secondary-container: #05201c;
+        --tertiary-container: #fddfa6;
+        --on-tertiary-container: #261a00;
+        --surface: #f4fbf8;
+        --on-surface: #161d1b;
+        --on-surface-variant: #3f4946;
+        --outline-variant: #bec9c5;
+        --surface-container-lowest: #ffffff;
+        --surface-container-low: #eef5f2;
+        --surface-container: #e8efec;
+        --surface-container-high: #e2e9e6;
+        /* Dimens.kt: ScreenPadding 16, CardGap 12, RowGap 8 */
+        --screen-pad: 16px;
+        --card-gap: 12px;
+      }
+
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+
+      body {
+        width: 411px;
+        height: 914px;
+        overflow: hidden;
+        background: var(--surface);
+        color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ---- System status bar (showSystemUi = true) ---- */
+      .statusbar {
+        height: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 16px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px;
+        border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery::after {
+        content: ""; position: absolute; right: -3px; top: 3px;
+        width: 2px; height: 5px; background: var(--on-surface); border-radius: 0 1px 1px 0;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+
+      /* ---- Top app bar ---- */
+      .topbar {
+        height: 56px;
+        display: flex;
+        align-items: center;
+        padding: 0 8px 0 var(--screen-pad);
+        background: var(--surface);
+      }
+      .topbar .title {
+        flex: 1;
+        font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: 0.2px;
+        color: var(--on-surface);
+      }
+      .topbar .actions { display: flex; gap: 4px; }
+      .icon-btn {
+        width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
+        color: var(--on-surface-variant);
+      }
+      .icon-btn svg { width: 24px; height: 24px; }
+
+      /* ---- Scroll content column ---- */
+      .content {
+        padding: 8px var(--screen-pad) 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--card-gap);
+      }
+
+      /* ---- Summary hero card ---- */
+      .summary {
+        background: var(--surface-container-low);
+        border-radius: 12px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .summary .node-name {
+        font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
+        font-size: 22px;
+        font-weight: 700;
+        color: var(--on-surface);
+        margin-bottom: 2px;
+      }
+      .line { display: flex; align-items: center; gap: 10px; color: var(--on-surface-variant); font-size: 15px; }
+      .line svg { width: 18px; height: 18px; flex: none; }
+      .line.mono { font-family: "JetBrains Mono", ui-monospace, monospace; letter-spacing: 0.5px; }
+      .battery-row { color: var(--on-surface); }
+      .progress {
+        height: 4px; border-radius: 2px; background: var(--surface-container-high);
+        margin: 2px 0 4px; overflow: hidden;
+      }
+      .progress > span { display: block; height: 100%; width: 81%; background: var(--primary); border-radius: 2px; }
+      .storage { font-size: 13px; }
+
+      /* ---- Last-message banner (outlined card) ---- */
+      .banner {
+        border: 1px solid var(--outline-variant);
+        border-radius: 12px;
+        padding: 12px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .banner svg { width: 22px; height: 22px; color: var(--primary); flex: none; }
+      .banner .who { font-size: 12px; font-weight: 600; color: var(--primary); }
+      .banner .text { font-size: 15px; color: var(--on-surface); }
+
+      /* ---- Section headers ---- */
+      .section-h {
+        display: flex; align-items: center; gap: 12px;
+        padding: 4px 0;
+        color: var(--on-surface-variant);
+      }
+      .section-h .label { flex: 1; font-size: 15px; font-weight: 600; }
+      .chip {
+        background: var(--secondary-container);
+        color: var(--on-secondary-container);
+        font-size: 13px; font-weight: 600;
+        padding: 6px 14px; border-radius: 8px;
+      }
+      .section-h .caret { width: 20px; height: 20px; color: var(--on-surface-variant); }
+
+      /* ---- Contact / channel rows ---- */
+      .row {
+        background: var(--surface-container-low);
+        border-radius: 12px;
+        padding: 10px 12px;
+        display: flex; align-items: center; gap: 12px;
+      }
+      .avatar {
+        width: 36px; height: 36px; border-radius: 50%;
+        display: flex; align-items: center; justify-content: center;
+        background: var(--secondary-container); color: var(--on-secondary-container); flex: none;
+      }
+      .avatar.amber { background: var(--tertiary-container); color: var(--on-tertiary-container); }
+      .avatar svg { width: 20px; height: 20px; }
+      .row .name { font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .row .sub { font-size: 13px; color: var(--on-surface-variant); }
+      .empty { font-size: 13px; color: var(--on-surface-variant); padding: 8px 0; }
+      /* ---- Cached-data warning banner (tertiaryContainer) ---- */
+      .warning {
+        background: var(--tertiary-container);
+        color: var(--on-tertiary-container);
+        border-radius: 8px;
+        padding: 12px;
+        display: flex; align-items: center; gap: 8px;
+        font-size: 13px;
+      }
+      .warning svg { width: 18px; height: 18px; flex: none; }
+      .warning .warn-text { flex: 1; }
+      .warning .warn-close { width: 16px; height: 16px; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar">
+      <span>9:30</span>
+      <span class="battery"><span></span></span>
+    </div>
+
+    <div class="topbar">
+      <div class="title">node-peak</div>
+      <div class="actions">
+        <span class="icon-btn" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+        <span class="icon-btn" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
+        <span class="icon-btn" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
+      </div>
+    </div>
+
+    <div class="content">
+      <!-- Hero summary card -->
+      <div class="summary">
+        <div class="node-name">node-peak</div>
+        <div class="line mono">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 11a2 2 0 0 0-2 2c0 2 .5 3 .5 5"/><path d="M7 13a5 5 0 0 1 10 0c0 1 0 2-.3 3"/><path d="M4 13a8 8 0 0 1 16 0"/></svg>
+          abababababababab
+        </div>
+        <div class="line">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M5 12.5a10 10 0 0 1 14 0"/><path d="M8.5 16a5 5 0 0 1 7 0"/><circle cx="12" cy="19" r="1.2" fill="currentColor" stroke="none"/></svg>
+          869.525 MHz · BW 125 kHz · SF 10 · CR 5
+        </div>
+        <div class="line battery-row">
+          <svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="3" width="8" height="18" rx="1.5"/><rect x="10" y="1.5" width="4" height="2" rx="0.5"/></svg>
+          81% · 3980 mV
+        </div>
+        <div class="progress"><span></span></div>
+        <div class="line storage">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+          512 / 4096 kB
+        </div>
+      </div>
+
+      <!-- Cached-data warning banner -->
+      <div class="warning">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <span class="warn-text">Cached data — connect to refresh</span>
+        <svg class="warn-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>
+      </div>
+
+      <!-- Last message banner -->
+      <div class="banner">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 4h18v13H7l-4 4z"/></svg>
+        <div>
+          <div class="who">alice</div>
+          <div class="text">hey — are you on tonight?</div>
+        </div>
+      </div>
+
+      <!-- Channels -->
+      <div class="section-h">
+        <span class="label">Channels (1)</span>
+        <span class="chip">Favourited</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="row">
+        <div class="avatar amber"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
+        <div>
+          <div class="name">General</div>
+          <div class="sub">Channel 0</div>
+        </div>
+      </div>
+
+      <!-- Contacts -->
+      <div class="section-h">
+        <span class="label">Contacts (1)</span>
+        <span class="chip">Favourited</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="row">
+        <div class="avatar"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg></div>
+        <div>
+          <div class="name">alice</div>
+          <div class="sub">Contact · flood</div>
+        </div>
+      </div>
+
+      <!-- Rooms -->
+      <div class="section-h">
+        <span class="label">Rooms (1)</span>
+        <span class="chip">Joined</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="row">
+        <div class="avatar"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
+        <div>
+          <div class="name">common-room</div>
+          <div class="sub">Room · 0 hops</div>
+        </div>
+      </div>
+
+      <!-- Repeaters -->
+      <div class="section-h">
+        <span class="label">Repeaters (0)</span>
+        <span class="chip">Joined</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="empty">No repeaters joined yet</div>
+
+      <!-- Sensors -->
+      <div class="section-h">
+        <span class="label">Sensors (1)</span>
+        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+    </div>
+
+    <script type="application/design-parity+json">
+      {
+        "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyPreview",
+        "tokens": {
+          "spacing": { "screenPadding": 16, "cardGap": 12, "rowGap": 8, "cardPadding": 16 },
+          "radius": { "card": 12, "chip": 8, "avatar": 18 },
+          "colors": {
+            "primary": "#006A60",
+            "surface": "#F4FBF8",
+            "onSurface": "#161D1B",
+            "onSurfaceVariant": "#3F4946",
+            "surfaceContainerLow": "#EEF5F2",
+            "secondaryContainer": "#CCE8E2",
+            "onSecondaryContainer": "#05201C",
+            "tertiaryContainer": "#FDDFA6",
+            "outlineVariant": "#BEC9C5"
+          }
+        },
+        "images": [
+          {
+            "state": "default",
+            "size": "compact",
+            "src": "CachedDevice.light.png"
+          }
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -5,16 +5,19 @@ at parity with its intended design: it renders the Compose code (the
 *candidate*), diffs it against a committed design *reference*, and emits a
 verdict + a self-contained HTML comparison page (reference | candidate | diff).
 
-This repo adopts it for the **Device screen** (`DeviceScreen.kt#DeviceBody`) and
-the **chat screens** — contact (1:1), channel (group), and device commands, all
-sharing the stateless `ChatBody` — each in both **light** and **dark** themes.
-All render on the CMP desktop backend from `:meshcore-components` `commonMain`.
+This repo adopts it for the **Device screen** (`DeviceScreen.kt#DeviceBody`), its
+**cached (offline)** state (`CachedDeviceScreen` — `DeviceBody` with the
+"Cached data" warning banner), and the **chat screens** — contact (1:1), channel
+(group), and device commands, all sharing the stateless `ChatBody` — each in both
+**light** and **dark** themes. All render on the CMP desktop backend from
+`:meshcore-components` `commonMain`.
 
 ## What's committed
 
 | Path | Role |
 | --- | --- |
 | `design/DeviceScreen.{light,dark}.html` | Claude Design HTML export — the Device screen references (`DeviceBodyPreview` / `DeviceBodyDarkPreview`), the single source of truth for each variant. Each carries an `application/design-parity+json` handoff manifest (M3 tokens + the `src` of its reference PNG). |
+| `design/CachedDevice.{light,dark}.html` | The cached (offline) Device references (`CachedDeviceBodyPreview` etc.) — the Device reference plus the `tertiaryContainer` "Cached data" warning banner. |
 | `design/ContactChat.{light,dark}.html`, `design/ChannelChat.{light,dark}.html`, `design/Commands.{light,dark}.html` | The chat screen references (`ContactChatPreview` etc.), authored from the MeshCore M3 scheme; `design/gen_chat_refs.py` is the re-runnable generator that emits them. |
 | `design-map.json` | Correspondence: each preview-function code handle ↔ its reference, plus the `previewId` that reconciles the compose-preview render id with the handle. |
 | `.design-parity.json` | Parity direction. **`code-led`** (advisory) for now — flip to `design-led` once thresholds are calibrated. |

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt
@@ -143,3 +143,53 @@ fun DeviceBodyDarkPreview() {
     )
   }
 }
+
+private const val CACHED_WARNING = "Cached data — connect to refresh"
+
+@Composable
+private fun cachedDevicePreview(dark: Boolean) {
+  val alice = previewContact("alice", -1, 0x11)
+  MeshcoreTheme(darkTheme = dark) {
+    DeviceBody(
+      self = previewSelf(),
+      battery = BatteryInfo(3980, 512, 4096),
+      radio = RadioSettings(869_525_000, 125_000, 10, 5),
+      contacts =
+        listOf(
+          alice,
+          previewContact("bob-repeater", 2, 0x22, ContactType.REPEATER),
+          previewContact("common-room", 0, 0x33, ContactType.ROOM),
+        ),
+      channels = listOf(ChannelInfo(0, "General", ByteString())),
+      contactedKeys = setOf(alice.publicKey.toHex()),
+      contactedChannelIndices = setOf(0),
+      warnings = listOf(CACHED_WARNING),
+      onDisconnect = {},
+    )
+  }
+}
+
+/**
+ * Design-parity subject for the **cached** (offline) Device screen — the `CachedDeviceScreen`
+ * state: `DeviceBody` carrying the "Cached data" warning banner. Reference
+ * `design/CachedDevice.light.html`. See `docs/design-parity.md`.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  name = "Cached device",
+)
+@Composable
+fun CachedDeviceBodyPreview() = cachedDevicePreview(dark = false)
+
+/** Cached Device screen, dark. Reference `design/CachedDevice.dark.html`. */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  uiMode = 0x20,
+  name = "Cached device — dark",
+)
+@Composable
+fun CachedDeviceBodyDarkPreview() = cachedDevicePreview(dark = true)


### PR DESCRIPTION
## Summary

Adopts the **cached (offline) Device screen** for design-parity — the next batch after the chat screens (#109/#110, merged).

`CachedDeviceScreen` is just `DeviceBody` populated from cached Room data **with the `warnings = ["Cached data — connect to refresh"]` banner** (`tertiaryContainer`/amber, after the summary card). That banner is the one state the existing Device previews don't exercise, so it's the only new visual to cover.

- **Previews**: `CachedDeviceBodyPreview` / `CachedDeviceBodyDarkPreview` in `DeviceBodyPreviews.kt` — `DeviceBody` with the cached warning, reusing the Device preview data helpers.
- **References**: `design/CachedDevice.{light,dark}.html` — derived from the Device references with the amber warning banner injected after the summary card; manifest re-pointed at the cached preview + its reference PNG.
- **Map**: `design-map.json` +2 → **10 components**.

## Test plan
- `:meshcore-components:compileKotlinDesktop` ✅; ktfmt clean.
- `design-map.json` valid; **all 10 previewIds cross-checked** against the `@Preview` names across both preview files — all match.
- No app-code change. On merge, the `design-parity/main` run renders the cached **reference | candidate | diff** (the candidate already exercises `DeviceBody`'s `warnings` path).

## Scope
Per your chosen scope (all app screens, defer Scanner). Remaining: **DeviceSettings** (needs a discovery-state extraction to make a stateless body renderable on desktop) — the last batch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_