### PR TITLE
feat(design-parity): adopt the Device Settings screen

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceSettingsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceSettingsScreen.kt
@@ -1,28 +1,6 @@
 package ee.schimke.meshcore.app.ui
 
 import android.util.Log
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material.icons.rounded.Settings
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -31,11 +9,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import ee.schimke.meshcore.app.di.LocalAppGraph
 import ee.schimke.meshcore.app.connection.ConnectionUiState
+import ee.schimke.meshcore.components.ui.DeviceSettingsBody
+import ee.schimke.meshcore.components.ui.DeviceSettingsUiState
 import ee.schimke.meshcore.core.client.MeshCoreClient
 import ee.schimke.meshcore.data.entity.MessageDirection
 import ee.schimke.meshcore.data.entity.MessageStatus
@@ -48,11 +25,11 @@ import kotlin.time.Clock
 
 private const val TAG = "DeviceSettings"
 
-/** Discovery state for the device settings screen. */
-private sealed class SettingsState {
-    data object Discovering : SettingsState()
-    data class Ready(val hasBuzzer: Boolean) : SettingsState()
-    data class Error(val message: String) : SettingsState()
+/** Internal discovery phase; mapped to [DeviceSettingsUiState] for the body. */
+private sealed class SettingsPhase {
+    data object Discovering : SettingsPhase()
+    data class Ready(val hasBuzzer: Boolean) : SettingsPhase()
+    data class Error(val message: String) : SettingsPhase()
 }
 
 /**
@@ -106,7 +83,6 @@ private suspend fun sendCommandAndAwaitResponse(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DeviceSettingsScreen(
     channelIndex: Int,
@@ -121,7 +97,7 @@ fun DeviceSettingsScreen(
     val selfName = client?.selfInfo?.collectAsState()?.value?.name
 
     val scope = rememberCoroutineScope()
-    var state by remember { mutableStateOf<SettingsState>(SettingsState.Discovering) }
+    var phase by remember { mutableStateOf<SettingsPhase>(SettingsPhase.Discovering) }
     var buzzerMode by remember { mutableStateOf<String?>(null) }
     var buzzerLoading by remember { mutableStateOf(false) }
 
@@ -129,18 +105,18 @@ fun DeviceSettingsScreen(
     LaunchedEffect(client, deviceId) {
         val c = client ?: return@LaunchedEffect
         val did = deviceId ?: return@LaunchedEffect
-        state = SettingsState.Discovering
+        phase = SettingsPhase.Discovering
         Log.d(TAG, "Discovering device capabilities via /help")
         val helpResponse = sendCommandAndAwaitResponse(
             c, repository, did, channelIndex, "/help", selfName,
         )
         if (helpResponse == null) {
-            state = SettingsState.Error("No response from device")
+            phase = SettingsPhase.Error("No response from device")
             return@LaunchedEffect
         }
         Log.d(TAG, "Help response: $helpResponse")
         val hasBuzzer = helpResponse.contains("/buz", ignoreCase = true)
-        state = SettingsState.Ready(hasBuzzer = hasBuzzer)
+        phase = SettingsPhase.Ready(hasBuzzer = hasBuzzer)
 
         // Probe current buzzer state
         if (hasBuzzer) {
@@ -154,133 +130,36 @@ fun DeviceSettingsScreen(
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Device Settings", style = MaterialTheme.typography.titleMedium) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, "Back")
-                    }
-                },
-                actions = {
-                    Icon(
-                        Icons.Rounded.Settings,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(end = 12.dp),
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
+    val state: DeviceSettingsUiState = when (val p = phase) {
+        SettingsPhase.Discovering -> DeviceSettingsUiState.Discovering
+        is SettingsPhase.Error -> DeviceSettingsUiState.Error(p.message)
+        is SettingsPhase.Ready ->
+            DeviceSettingsUiState.Ready(
+                hasBuzzer = p.hasBuzzer,
+                buzzerMode = buzzerMode,
+                buzzerLoading = buzzerLoading,
             )
-        },
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 16.dp),
-        ) {
-            when (val s = state) {
-                is SettingsState.Discovering -> {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                        Spacer(Modifier.size(12.dp))
-                        Text(
-                            "Discovering device capabilities\u2026",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-                is SettingsState.Error -> {
-                    Text(
-                        text = s.message,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.padding(vertical = 24.dp),
+    }
+
+    DeviceSettingsBody(
+        state = state,
+        onToggleBuzzer = { wantOn ->
+            val c = client
+            val did = deviceId
+            if (c != null && did != null) {
+                scope.launch {
+                    buzzerLoading = true
+                    val cmd = if (wantOn) "/buz rtttl" else "/buz off"
+                    val response = sendCommandAndAwaitResponse(
+                        c, repository, did, channelIndex, cmd, selfName,
                     )
-                }
-                is SettingsState.Ready -> {
-                    if (!s.hasBuzzer) {
-                        Text(
-                            text = "No configurable settings detected",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(vertical = 24.dp),
-                        )
-                    } else {
-                        Spacer(Modifier.size(8.dp))
-                        BuzzerRow(
-                            mode = buzzerMode,
-                            loading = buzzerLoading,
-                            onToggle = { wantOn ->
-                                val c = client ?: return@BuzzerRow
-                                val did = deviceId ?: return@BuzzerRow
-                                scope.launch {
-                                    buzzerLoading = true
-                                    val cmd = if (wantOn) "/buz rtttl" else "/buz off"
-                                    val response = sendCommandAndAwaitResponse(
-                                        c, repository, did, channelIndex, cmd, selfName,
-                                    )
-                                    buzzerMode = parseBuzzerMode(response) ?: buzzerMode
-                                    buzzerLoading = false
-                                }
-                            },
-                        )
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                    }
+                    buzzerMode = parseBuzzerMode(response) ?: buzzerMode
+                    buzzerLoading = false
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun BuzzerRow(
-    mode: String?,
-    loading: Boolean,
-    onToggle: (wantOn: Boolean) -> Unit,
-) {
-    val isOn = mode != null && mode != "off"
-
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Buzzer",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = when {
-                    loading -> "Updating\u2026"
-                    mode == null -> "Unknown"
-                    mode == "off" -> "Off"
-                    else -> "On ($mode)"
-                },
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        if (loading) {
-            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-            Spacer(Modifier.size(12.dp))
-        }
-        Switch(
-            checked = isOn,
-            onCheckedChange = { onToggle(it) },
-            enabled = !loading && mode != null,
-        )
-    }
+        },
+        onBack = onBack,
+    )
 }
 
 /**

--- a/design-map.json
+++ b/design-map.json
@@ -60,6 +60,18 @@
       "source": "claude-design",
       "ref": "design/CachedDevice.dark.html",
       "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyDarkPreview_Cached device — dark"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsPreview",
+      "source": "claude-design",
+      "ref": "design/DeviceSettings.light.html",
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsPreview_Device settings"
+    },
+    {
+      "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsDarkPreview",
+      "source": "claude-design",
+      "ref": "design/DeviceSettings.dark.html",
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsDarkPreview_Device settings — dark"
     }
   ]
 }

--- a/design/DeviceSettings.dark.html
+++ b/design/DeviceSettings.dark.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — Device Settings (dark).
+
+  Hand-authored design intent for the Device Settings screen's discovered "Ready"
+  state (buzzer toggle), mirroring the CMP-desktop render of DeviceSettingsBody.
+  Colours below are the MeshCore Material 3 dark scheme from MeshcoreTokens.kt.
+  The application/design-parity+json manifest at the end is the machine-readable
+  hand-off; the reference PNG is generated from this document (not committed).
+  See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Device Settings · MeshCore (dark)</title>
+    <style>
+      :root {
+        --primary: #53dbc9;
+        --on-primary: #003731;
+        --surface: #0e1513;
+        --on-surface: #dde4e1;
+        --on-surface-variant: #bec9c5;
+        --outline-variant: #3f4946;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; margin-right: 8px; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .title { flex: 1; font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .content { padding: 8px 16px 0; }
+      .row { display: flex; align-items: center; padding: 4px 0; }
+      .row .labels { flex: 1; }
+      .row .label { font-size: 16px; color: var(--on-surface); }
+      .row .sub { font-size: 13px; color: var(--on-surface-variant); }
+      .switch { width: 52px; height: 32px; border-radius: 16px; position: relative; flex: none; background: var(--primary); }
+      .switch .thumb { position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border-radius: 50%; background: var(--on-primary); }
+      .divider { height: 1px; background: var(--outline-variant); margin: 8px 0; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="title">Device Settings</div>
+      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg></span>
+    </div>
+    <div class="content">
+      <div class="row">
+        <div class="labels">
+          <div class="label">Buzzer</div>
+          <div class="sub">On (rtttl)</div>
+        </div>
+        <div class="switch"><span class="thumb"></span></div>
+      </div>
+      <div class="divider"></div>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsDarkPreview",
+  "tokens": {
+    "spacing": {
+      "screenPadding": 16,
+      "rowGap": 8
+    },
+    "radius": {
+      "switch": 16
+    },
+    "colors": {
+      "primary": "#53DBC9",
+      "onPrimary": "#003731",
+      "surface": "#0E1513",
+      "onSurface": "#DDE4E1",
+      "onSurfaceVariant": "#BEC9C5",
+      "outlineVariant": "#3F4946"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "DeviceSettings.dark.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/DeviceSettings.light.html
+++ b/design/DeviceSettings.light.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<!--
+  Claude Design HTML export — Device Settings (light).
+
+  Hand-authored design intent for the Device Settings screen's discovered "Ready"
+  state (buzzer toggle), mirroring the CMP-desktop render of DeviceSettingsBody.
+  Colours below are the MeshCore Material 3 light scheme from MeshcoreTokens.kt.
+  The application/design-parity+json manifest at the end is the machine-readable
+  hand-off; the reference PNG is generated from this document (not committed).
+  See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Device Settings · MeshCore (light)</title>
+    <style>
+      :root {
+        --primary: #006a60;
+        --on-primary: #ffffff;
+        --surface: #f4fbf8;
+        --on-surface: #161d1b;
+        --on-surface-variant: #3f4946;
+        --outline-variant: #bec9c5;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }
+      .statusbar {
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }
+      .statusbar .battery {
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }
+      .statusbar .battery > span {
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }
+      .topbar {
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }
+      .icon-btn {
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }
+      .icon-btn.action { color: var(--on-surface-variant); margin-left: auto; margin-right: 8px; }
+      .icon-btn svg { width: 24px; height: 24px; }
+      .title { flex: 1; font-size: 16px; font-weight: 600; color: var(--on-surface); }
+      .content { padding: 8px 16px 0; }
+      .row { display: flex; align-items: center; padding: 4px 0; }
+      .row .labels { flex: 1; }
+      .row .label { font-size: 16px; color: var(--on-surface); }
+      .row .sub { font-size: 13px; color: var(--on-surface-variant); }
+      .switch { width: 52px; height: 32px; border-radius: 16px; position: relative; flex: none; background: var(--primary); }
+      .switch .thumb { position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border-radius: 50%; background: var(--on-primary); }
+      .divider { height: 1px; background: var(--outline-variant); margin: 8px 0; }
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <div class="title">Device Settings</div>
+      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg></span>
+    </div>
+    <div class="content">
+      <div class="row">
+        <div class="labels">
+          <div class="label">Buzzer</div>
+          <div class="sub">On (rtttl)</div>
+        </div>
+        <div class="switch"><span class="thumb"></span></div>
+      </div>
+      <div class="divider"></div>
+    </div>
+    <script type="application/design-parity+json">
+{
+  "componentId": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsPreview",
+  "tokens": {
+    "spacing": {
+      "screenPadding": 16,
+      "rowGap": 8
+    },
+    "radius": {
+      "switch": 16
+    },
+    "colors": {
+      "primary": "#006A60",
+      "onPrimary": "#FFFFFF",
+      "surface": "#F4FBF8",
+      "onSurface": "#161D1B",
+      "onSurfaceVariant": "#3F4946",
+      "outlineVariant": "#BEC9C5"
+    }
+  },
+  "images": [
+    {
+      "state": "default",
+      "size": "compact",
+      "src": "DeviceSettings.light.png"
+    }
+  ]
+}
+    </script>
+  </body>
+</html>

--- a/design/gen_settings_refs.py
+++ b/design/gen_settings_refs.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Author the Device Settings design-parity references (design/DeviceSettings.*.html).
+
+Hand-authored design intent for the Device Settings screen's discovered "Ready"
+state (the buzzer toggle), mirroring the CMP-desktop render of
+DeviceSettingsPreview. Tokens are the MeshCore M3 scheme from MeshcoreTokens.kt.
+Run from repo root: python3 design/gen_settings_refs.py
+"""
+import json
+import os
+
+LIGHT = dict(
+    primary="#006a60", onPrimary="#ffffff", surface="#f4fbf8", onSurface="#161d1b",
+    onSurfaceVariant="#3f4946", outlineVariant="#bec9c5",
+)
+DARK = dict(
+    primary="#53dbc9", onPrimary="#003731", surface="#0e1513", onSurface="#dde4e1",
+    onSurfaceVariant="#bec9c5", outlineVariant="#3f4946",
+)
+
+BACK = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/>'
+        '<polyline points="11 18 5 12 11 6"/></svg>')
+GEAR = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle '
+        'cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2'
+        'L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 '
+        '2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg>')
+
+
+def render(theme, t, fn, png):
+    manifest = json.dumps({
+        "componentId": f"meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#{fn}",
+        "tokens": {
+            "spacing": {"screenPadding": 16, "rowGap": 8},
+            "radius": {"switch": 16},
+            "colors": {
+                "primary": t["primary"].upper(),
+                "onPrimary": t["onPrimary"].upper(),
+                "surface": t["surface"].upper(),
+                "onSurface": t["onSurface"].upper(),
+                "onSurfaceVariant": t["onSurfaceVariant"].upper(),
+                "outlineVariant": t["outlineVariant"].upper(),
+            },
+        },
+        "images": [{"state": "default", "size": "compact", "src": png}],
+    }, indent=2)
+    return f"""<!doctype html>
+<!--
+  Claude Design HTML export — Device Settings ({theme}).
+
+  Hand-authored design intent for the Device Settings screen's discovered "Ready"
+  state (buzzer toggle), mirroring the CMP-desktop render of DeviceSettingsBody.
+  Colours below are the MeshCore Material 3 {theme} scheme from MeshcoreTokens.kt.
+  The application/design-parity+json manifest at the end is the machine-readable
+  hand-off; the reference PNG is generated from this document (not committed).
+  See docs/design-parity.md.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=411, initial-scale=1" />
+    <title>Device Settings · MeshCore ({theme})</title>
+    <style>
+      :root {{
+        --primary: {t['primary']};
+        --on-primary: {t['onPrimary']};
+        --surface: {t['surface']};
+        --on-surface: {t['onSurface']};
+        --on-surface-variant: {t['onSurfaceVariant']};
+        --outline-variant: {t['outlineVariant']};
+      }}
+      * {{ box-sizing: border-box; }}
+      html, body {{ margin: 0; padding: 0; }}
+      body {{
+        width: 411px; height: 914px; overflow: hidden;
+        background: var(--surface); color: var(--on-surface);
+        font-family: "Space Grotesk", "Roboto", "Segoe UI", system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        display: flex; flex-direction: column;
+      }}
+      .statusbar {{
+        height: 28px; flex: none; display: flex; align-items: center;
+        justify-content: space-between; padding: 0 16px;
+        font-size: 13px; font-weight: 600; color: var(--on-surface);
+      }}
+      .statusbar .battery {{
+        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
+        border-radius: 3px; position: relative;
+      }}
+      .statusbar .battery > span {{
+        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
+        background: var(--on-surface); border-radius: 1px;
+      }}
+      .topbar {{
+        height: 56px; flex: none; display: flex; align-items: center;
+        gap: 4px; padding: 0 8px; background: var(--surface);
+      }}
+      .icon-btn {{
+        width: 40px; height: 40px; flex: none; display: flex;
+        align-items: center; justify-content: center; color: var(--on-surface);
+      }}
+      .icon-btn.action {{ color: var(--on-surface-variant); margin-left: auto; margin-right: 8px; }}
+      .icon-btn svg {{ width: 24px; height: 24px; }}
+      .title {{ flex: 1; font-size: 16px; font-weight: 600; color: var(--on-surface); }}
+      .content {{ padding: 8px 16px 0; }}
+      .row {{ display: flex; align-items: center; padding: 4px 0; }}
+      .row .labels {{ flex: 1; }}
+      .row .label {{ font-size: 16px; color: var(--on-surface); }}
+      .row .sub {{ font-size: 13px; color: var(--on-surface-variant); }}
+      .switch {{ width: 52px; height: 32px; border-radius: 16px; position: relative; flex: none; background: var(--primary); }}
+      .switch .thumb {{ position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border-radius: 50%; background: var(--on-primary); }}
+      .divider {{ height: 1px; background: var(--outline-variant); margin: 8px 0; }}
+    </style>
+  </head>
+  <body>
+    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
+    <div class="topbar">
+      <span class="icon-btn">{BACK}</span>
+      <div class="title">Device Settings</div>
+      <span class="icon-btn action">{GEAR}</span>
+    </div>
+    <div class="content">
+      <div class="row">
+        <div class="labels">
+          <div class="label">Buzzer</div>
+          <div class="sub">On (rtttl)</div>
+        </div>
+        <div class="switch"><span class="thumb"></span></div>
+      </div>
+      <div class="divider"></div>
+    </div>
+    <script type="application/design-parity+json">
+{manifest}
+    </script>
+  </body>
+</html>
+"""
+
+
+out = os.path.dirname(__file__)
+for theme, t, fn in (("light", LIGHT, "DeviceSettingsPreview"),
+                     ("dark", DARK, "DeviceSettingsDarkPreview")):
+    path = os.path.join(out, f"DeviceSettings.{theme}.html")
+    open(path, "w").write(render(theme, t, fn, f"DeviceSettings.{theme}.png"))
+    print("wrote", path)

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -8,9 +8,10 @@ verdict + a self-contained HTML comparison page (reference | candidate | diff).
 This repo adopts it for the **Device screen** (`DeviceScreen.kt#DeviceBody`), its
 **cached (offline)** state (`CachedDeviceScreen` — `DeviceBody` with the
 "Cached data" warning banner), and the **chat screens** — contact (1:1), channel
-(group), and device commands, all sharing the stateless `ChatBody` — each in both
-**light** and **dark** themes. All render on the CMP desktop backend from
-`:meshcore-components` `commonMain`.
+(group), and device commands, all sharing the stateless `ChatBody` — and the
+**Device Settings** screen (`DeviceSettingsScreen` → stateless `DeviceSettingsBody`,
+its discovered buzzer-toggle state) — each in both **light** and **dark** themes.
+All render on the CMP desktop backend from `:meshcore-components` `commonMain`.
 
 ## What's committed
 
@@ -19,6 +20,7 @@ This repo adopts it for the **Device screen** (`DeviceScreen.kt#DeviceBody`), it
 | `design/DeviceScreen.{light,dark}.html` | Claude Design HTML export — the Device screen references (`DeviceBodyPreview` / `DeviceBodyDarkPreview`), the single source of truth for each variant. Each carries an `application/design-parity+json` handoff manifest (M3 tokens + the `src` of its reference PNG). |
 | `design/CachedDevice.{light,dark}.html` | The cached (offline) Device references (`CachedDeviceBodyPreview` etc.) — the Device reference plus the `tertiaryContainer` "Cached data" warning banner. |
 | `design/ContactChat.{light,dark}.html`, `design/ChannelChat.{light,dark}.html`, `design/Commands.{light,dark}.html` | The chat screen references (`ContactChatPreview` etc.), authored from the MeshCore M3 scheme; `design/gen_chat_refs.py` is the re-runnable generator that emits them. |
+| `design/DeviceSettings.{light,dark}.html` | The Device Settings references (`DeviceSettingsPreview` etc.) — the discovered buzzer-toggle state; `design/gen_settings_refs.py` is the generator. |
 | `design-map.json` | Correspondence: each preview-function code handle ↔ its reference, plus the `previewId` that reconciles the compose-preview render id with the handle. |
 | `.design-parity.json` | Parity direction. **`code-led`** (advisory) for now — flip to `design-led` once thresholds are calibrated. |
 

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBody.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBody.kt
@@ -1,0 +1,160 @@
+package ee.schimke.meshcore.components.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.meshcore.components.ui.icons.MeshIcons
+
+/**
+ * Render state for the device settings screen. The stateful `DeviceSettingsScreen` wrapper in
+ * `:app` drives the `/help` + `/buz` discovery and maps it to this; the stateless
+ * [DeviceSettingsBody] renders it (the design-parity subject).
+ */
+sealed interface DeviceSettingsUiState {
+  /** Probing the device's capabilities (`/help`). */
+  data object Discovering : DeviceSettingsUiState
+
+  /** Discovery failed (e.g. no response). */
+  data class Error(val message: String) : DeviceSettingsUiState
+
+  /**
+   * Discovery done. [buzzerMode] is `null` (unknown), `"off"`, or a mode like `"rtttl"`;
+   * [buzzerLoading] is true while a toggle is in flight.
+   */
+  data class Ready(
+    val hasBuzzer: Boolean,
+    val buzzerMode: String? = null,
+    val buzzerLoading: Boolean = false,
+  ) : DeviceSettingsUiState
+}
+
+/**
+ * Stateless device-settings screen body: a top bar plus the discovery state's content (a spinner
+ * while discovering, an error message, or the settings rows — currently the buzzer toggle). The
+ * `:app` wrapper owns the command transport.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeviceSettingsBody(
+  state: DeviceSettingsUiState,
+  onToggleBuzzer: (wantOn: Boolean) -> Unit,
+  onBack: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Scaffold(
+    modifier = modifier,
+    topBar = {
+      TopAppBar(
+        title = { Text("Device Settings", style = MaterialTheme.typography.titleMedium) },
+        navigationIcon = { IconButton(onClick = onBack) { Icon(MeshIcons.ArrowBack, "Back") } },
+        actions = {
+          Icon(
+            MeshIcons.Settings,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(end = 12.dp),
+          )
+        },
+        colors =
+          TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
+      )
+    },
+  ) { padding ->
+    Column(modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp)) {
+      when (state) {
+        is DeviceSettingsUiState.Discovering ->
+          Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            Spacer(Modifier.size(12.dp))
+            Text(
+              "Discovering device capabilities…",
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        is DeviceSettingsUiState.Error ->
+          Text(
+            text = state.message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.padding(vertical = 24.dp),
+          )
+        is DeviceSettingsUiState.Ready ->
+          if (!state.hasBuzzer) {
+            Text(
+              text = "No configurable settings detected",
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              modifier = Modifier.padding(vertical = 24.dp),
+            )
+          } else {
+            Spacer(Modifier.size(8.dp))
+            BuzzerRow(
+              mode = state.buzzerMode,
+              loading = state.buzzerLoading,
+              onToggle = onToggleBuzzer,
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+          }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BuzzerRow(mode: String?, loading: Boolean, onToggle: (wantOn: Boolean) -> Unit) {
+  val isOn = mode != null && mode != "off"
+
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        text = "Buzzer",
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+      )
+      Text(
+        text =
+          when {
+            loading -> "Updating…"
+            mode == null -> "Unknown"
+            mode == "off" -> "Off"
+            else -> "On ($mode)"
+          },
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    if (loading) {
+      CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+      Spacer(Modifier.size(12.dp))
+    }
+    Switch(checked = isOn, onCheckedChange = { onToggle(it) }, enabled = !loading && mode != null)
+  }
+}

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt
@@ -1,0 +1,44 @@
+package ee.schimke.meshcore.components.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.meshcore.components.ui.theme.MeshcoreTheme
+
+// Design-parity preview subjects for the Device Settings screen (the discovered
+// "Ready" state with the buzzer toggle), on the CMP desktop render path. See
+// docs/design-parity.md.
+
+private val readyState =
+  DeviceSettingsUiState.Ready(hasBuzzer = true, buzzerMode = "rtttl", buzzerLoading = false)
+
+@Composable
+private fun settingsPreview(dark: Boolean) {
+  MeshcoreTheme(darkTheme = dark) {
+    DeviceSettingsBody(state = readyState, onToggleBuzzer = {}, onBack = {})
+  }
+}
+
+/**
+ * Design-parity subject: Device Settings, discovered (light). Reference
+ * `design/DeviceSettings.light.html`.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  name = "Device settings",
+)
+@Composable
+fun DeviceSettingsPreview() = settingsPreview(dark = false)
+
+/** Device Settings, discovered (dark). Reference `design/DeviceSettings.dark.html`. */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  uiMode = 0x20,
+  name = "Device settings — dark",
+)
+@Composable
+fun DeviceSettingsDarkPreview() = settingsPreview(dark = true)


### PR DESCRIPTION
## Summary

Adopts the **Device Settings** screen for design-parity — the **last** app screen in your chosen scope (all app screens, defer Scanner).

`DeviceSettingsScreen` did its `/help` + `/buz` discovery inline and rendered the result. This extracts the presentational part so it renders on the CMP desktop backend, like `DeviceBody`/`ChatBody`:

- **`DeviceSettingsBody`** + a public **`DeviceSettingsUiState`** (`Discovering` / `Error` / `Ready(hasBuzzer, buzzerMode, buzzerLoading)`) in `:meshcore-components` `commonMain`; `BuzzerRow` moves with it. Both icons it uses (`ArrowBack`, `Settings`) were already vendored.
- **`DeviceSettingsScreen`** keeps the discovery state machine + command transport, maps its phase to `DeviceSettingsUiState`, and delegates rendering to `DeviceSettingsBody` (−161 lines of inlined UI).
- **Previews + references**: `DeviceSettingsBodyPreviews` (the discovered buzzer-toggle state, light + dark); `design/DeviceSettings.{light,dark}.html` (+ `design/gen_settings_refs.py` generator); `design-map.json` +2 → **12 components**.

## Test plan
- `:meshcore-components:compileKotlinDesktop`, `:meshcore-components:compileAndroidMain`, `:app:compileDebugKotlin` ✅; ktfmt clean.
- `design-map.json` valid; **all 12 previewIds cross-checked** against the `@Preview` names across every preview file — all match.
- On merge, `design-parity/main` renders the Device Settings **reference | candidate | diff**.

## Scope — complete
With this, all app screens in scope are design-parity subjects: **Device, Cached Device, Contact/Channel/Commands chat, and Device Settings** (Scanner deferred per the agreed plan — it needs a BLE/USB platform-abstraction layer to render off-Android).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_