### PR TITLE
chore(design-parity): bump CLI pin to 0.1.6

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.4 run \
+          npx -y design-parity@0.1.6 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -100,7 +100,7 @@ reference | candidate | diff without re-rendering locally.
 
 The workflow drives the render from `design-map.json` (so it can't drift from
 it): it installs the released `compose-preview` CLI, packs the candidate bundle,
-runs the published `design-parity` CLI (`npx design-parity@0.1.1`), and publishes
+runs the published `design-parity` CLI (`npx design-parity@0.1.6`), and publishes
 the output. The permanent-branch push is still the interim, hand-rolled version
 of a pattern design-parity's Action should own —
 [design-parity#56](https://github.com/yschimke/design-parity/issues/56) (modeled


### PR DESCRIPTION
Bumps the `design-parity` CLI pin from 0.1.4 → 0.1.6 in the parity workflow, and refreshes the stale `@0.1.1` reference in the docs.

## What 0.1.5/0.1.6 bring to this repo

- **#102 — advisory unmappable tokens.** Unmappable colour/typography tokens no longer report as false `missing from candidate` errors (they become non-blocking advisories), cutting the token-compliance noise this repo was hitting.
- **#89 — DTCG `tokensFile`.** A component can declare its spec tokens via a W3C DTCG token file from `design-map.json`.
- **0.1.6 — light/dark theme-matrix `report.html`.** Variants lay out as a light/dark matrix — directly relevant since every adopted screen here is a light/dark pair.

## Changes

- `.github/workflows/design-parity.yml` — `npx design-parity@0.1.4` → `@0.1.6`.
- `docs/design-parity.md` — stale `@0.1.1` reference → `@0.1.6`.

Out of scope: the compose-ai-tools pins (`install`/`apply@v0.15.9`, plugin `0.15.9`) are a separate dependency and untouched.

## Test plan

- Non-functional / CI-config only; no app code changes.
- The `design-parity.yml` workflow runs on push to `main` and force-pushes artifacts to the `design-parity/main` branch — the bumped CLI exercises end-to-end on the next `main` build (render → diff → `report.html`). Verdict stays advisory (`code-led`), so no gate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_