### PR TITLE
fix(design-parity): drop the OS status bar from design references

### DIFF
--- a/design/CachedDevice.dark.html
+++ b/design/CachedDevice.dark.html
@@ -58,29 +58,6 @@
       }
 
       /* ---- System status bar (showSystemUi = true) ---- */
-      .statusbar {
-        height: 28px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 16px;
-        font-size: 13px;
-        font-weight: 600;
-        color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px;
-        border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery::after {
-        content: ""; position: absolute; right: -3px; top: 3px;
-        width: 2px; height: 5px; background: var(--on-surface); border-radius: 0 1px 1px 0;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
 
       /* ---- Top app bar ---- */
       .topbar {
@@ -202,11 +179,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar">
-      <span>9:30</span>
-      <span class="battery"><span></span></span>
-    </div>
-
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">

--- a/design/CachedDevice.light.html
+++ b/design/CachedDevice.light.html
@@ -58,29 +58,6 @@
       }
 
       /* ---- System status bar (showSystemUi = true) ---- */
-      .statusbar {
-        height: 28px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 16px;
-        font-size: 13px;
-        font-weight: 600;
-        color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px;
-        border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery::after {
-        content: ""; position: absolute; right: -3px; top: 3px;
-        width: 2px; height: 5px; background: var(--on-surface); border-radius: 0 1px 1px 0;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
 
       /* ---- Top app bar ---- */
       .topbar {
@@ -200,11 +177,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar">
-      <span>9:30</span>
-      <span class="battery"><span></span></span>
-    </div>
-
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">

--- a/design/ChannelChat.dark.html
+++ b/design/ChannelChat.dark.html
@@ -34,19 +34,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -95,7 +82,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">General</div><div class="subtitle">Channel 0</div></div>

--- a/design/ChannelChat.light.html
+++ b/design/ChannelChat.light.html
@@ -34,19 +34,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -95,7 +82,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">General</div><div class="subtitle">Channel 0</div></div>

--- a/design/Commands.dark.html
+++ b/design/Commands.dark.html
@@ -34,19 +34,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -95,7 +82,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">Commands</div></div>

--- a/design/Commands.light.html
+++ b/design/Commands.light.html
@@ -34,19 +34,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -95,7 +82,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">Commands</div></div>

--- a/design/ContactChat.dark.html
+++ b/design/ContactChat.dark.html
@@ -34,19 +34,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -95,7 +82,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">alice</div><div class="subtitle">Direct message</div></div>

--- a/design/ContactChat.light.html
+++ b/design/ContactChat.light.html
@@ -34,19 +34,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -95,7 +82,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">alice</div><div class="subtitle">Direct message</div></div>

--- a/design/DeviceScreen.dark.html
+++ b/design/DeviceScreen.dark.html
@@ -58,29 +58,6 @@
       }
 
       /* ---- System status bar (showSystemUi = true) ---- */
-      .statusbar {
-        height: 28px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 16px;
-        font-size: 13px;
-        font-weight: 600;
-        color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px;
-        border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery::after {
-        content: ""; position: absolute; right: -3px; top: 3px;
-        width: 2px; height: 5px; background: var(--on-surface); border-radius: 0 1px 1px 0;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
 
       /* ---- Top app bar ---- */
       .topbar {
@@ -190,11 +167,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar">
-      <span>9:30</span>
-      <span class="battery"><span></span></span>
-    </div>
-
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">

--- a/design/DeviceScreen.light.html
+++ b/design/DeviceScreen.light.html
@@ -58,29 +58,6 @@
       }
 
       /* ---- System status bar (showSystemUi = true) ---- */
-      .statusbar {
-        height: 28px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 16px;
-        font-size: 13px;
-        font-weight: 600;
-        color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px;
-        border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery::after {
-        content: ""; position: absolute; right: -3px; top: 3px;
-        width: 2px; height: 5px; background: var(--on-surface); border-radius: 0 1px 1px 0;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
 
       /* ---- Top app bar ---- */
       .topbar {
@@ -188,11 +165,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar">
-      <span>9:30</span>
-      <span class="battery"><span></span></span>
-    </div>
-
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">

--- a/design/DeviceSettings.dark.html
+++ b/design/DeviceSettings.dark.html
@@ -32,19 +32,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -67,7 +54,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="title">Device Settings</div>

--- a/design/DeviceSettings.light.html
+++ b/design/DeviceSettings.light.html
@@ -32,19 +32,6 @@
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }
-      .statusbar {
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }
-      .statusbar .battery {
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }
-      .statusbar .battery > span {
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }
       .topbar {
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -67,7 +54,6 @@
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="title">Device Settings</div>

--- a/design/gen_chat_refs.py
+++ b/design/gen_chat_refs.py
@@ -126,19 +126,6 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }}
-      .statusbar {{
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }}
-      .statusbar .battery {{
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }}
-      .statusbar .battery > span {{
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }}
       .topbar {{
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -187,7 +174,6 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn">{BACK}</span>
       <div class="titles"><div class="title">{html.escape(title)}</div>{sub}</div>

--- a/design/gen_settings_refs.py
+++ b/design/gen_settings_refs.py
@@ -78,19 +78,6 @@ def render(theme, t, fn, png):
         -webkit-font-smoothing: antialiased;
         display: flex; flex-direction: column;
       }}
-      .statusbar {{
-        height: 28px; flex: none; display: flex; align-items: center;
-        justify-content: space-between; padding: 0 16px;
-        font-size: 13px; font-weight: 600; color: var(--on-surface);
-      }}
-      .statusbar .battery {{
-        width: 22px; height: 11px; border: 1.5px solid var(--on-surface);
-        border-radius: 3px; position: relative;
-      }}
-      .statusbar .battery > span {{
-        position: absolute; left: 1px; top: 1px; bottom: 1px; right: 1px;
-        background: var(--on-surface); border-radius: 1px;
-      }}
       .topbar {{
         height: 56px; flex: none; display: flex; align-items: center;
         gap: 4px; padding: 0 8px; background: var(--surface);
@@ -113,7 +100,6 @@ def render(theme, t, fn, png):
     </style>
   </head>
   <body>
-    <div class="statusbar"><span>9:30</span><span class="battery"><span></span></span></div>
     <div class="topbar">
       <span class="icon-btn">{BACK}</span>
       <div class="title">Device Settings</div>

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -86,8 +86,22 @@ design-parity run --repo . \
 #    .design-parity/out/<component>/report.html  (reference | candidate | diff)
 ```
 
-Latest run (desktop backend): visual diff **~11%** (light) / **~6%** (dark) of
-pixels over the overlap — mostly typography and minor vertical drift.
+References intentionally omit the OS **status bar**: the candidate renders on the
+CMP desktop backend with no system chrome (`showSystemUi` is an Android-tooling
+hint the Skiko render path ignores), so a status bar in the reference offset every
+row by its height and dominated the diff. The references draw the screen's own top
+app bar as the first element (y=0), matching the candidate; the system status bar
+is OS chrome, not part of the component under test.
+
+This is an **interim** measure: once the desktop renderer learns to draw synthetic
+system bars for `showSystemUi = true`
+([compose-ai-tools#1930](https://github.com/yschimke/compose-ai-tools/issues/1930),
+porting the Android renderer's `SystemBarsFrame`), the candidate will carry a
+status bar of its own and these references can restore the realistic phone framing.
+
+Earlier run (before dropping the status bar): visual diff **~11%** (light) /
+**~6%** (dark) of pixels over the overlap — the bulk of it that systemic vertical
+offset, with typography the main residual once it's removed.
 
 ## Continuous artifacts (`design-parity/main` branch)
 


### PR DESCRIPTION
## What

Strip the OS status bar from all 12 design-parity references so they top-align with the candidate.

## Why

The candidate renders on the **CMP desktop (Skiko)** backend, which has no Android system chrome — `showSystemUi = true` is ignored there, so the candidate's top app bar sits at y=0. The hand-authored references drew a ~28px "9:30" status bar above the top app bar, offsetting **every row** by its height. That systemic vertical shift dominated the visual diff (the "~11% drift" was almost entirely the offset, not real UI divergence).

The references now draw the screen's own top app bar as the first body element (y=0), matching the candidate. The system status bar is OS chrome, not part of the component under test.

## Changes

- `design/gen_chat_refs.py`, `design/gen_settings_refs.py` — removed the `.statusbar` CSS + div; re-ran them (8 HTMLs regenerated).
- `design/{DeviceScreen,CachedDevice}.{light,dark}.html` — stripped the `.statusbar` rules (incl. the `::after` battery nub) + the multi-line div.
- `docs/design-parity.md` — documented the convention and the follow-up.

## Interim, not permanent

This is a stopgap. Once the desktop renderer can draw synthetic system bars for `showSystemUi = true` (**compose-ai-tools#1930**, porting the Android renderer's `SystemBarsFrame`), the candidate will carry its own status bar and these references can restore the realistic phone framing — matched on both sides.

## Test plan

- References-only + docs; no app code, no version bump.
- Verified locally: zero `statusbar`/`9:30` left, the top app bar is the first body child in every reference.
- Visual proof lands automatically on merge: `design-parity.yml` regenerates the `design-parity/main` triptychs on push to `main`; the per-row offset should collapse. (A local render wasn't possible — the sandbox's chromium is a non-functional snap stub.)