### PR TITLE
ci(design-parity): install branded fonts before rendering references

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -75,6 +75,20 @@ jobs:
       # the 411x914 design, so render them ourselves at the right size/scale (the
       # Pixel 7 the @Preview targets: 411x914 dp @ 2.625). google-chrome-stable
       # is preinstalled on ubuntu-latest.
+      # The references name the branded faces (Space Grotesk / Orbitron /
+      # JetBrains Mono) but can't @font-face them portably, so install the same
+      # bundled .ttf the desktop candidate loads. Without this, headless Chrome
+      # falls back to a system sans and every glyph drifts vs the candidate —
+      # the dominant residual in the visual diff. fontconfig resolves them by
+      # the families the HTML already declares; no reference edits needed.
+      - name: Install branded fonts for reference rendering
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/share/fonts"
+          cp meshcore-components/src/desktopMain/resources/fonts/*.ttf \
+            "$HOME/.local/share/fonts/"
+          fc-cache -f >/dev/null
+
       - name: Render reference images from HTML
         run: |
           set -euo pipefail

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -70,7 +70,13 @@ compose-preview bundle pack --module meshcore-components \
   -o build/design-parity/bundle.png
 
 # 2. Render the reference PNGs from the HTML (required — they're not committed),
-#    at the candidate's pixel size (411x914 dp @ 2.625 -> 1078x2399 px):
+#    at the candidate's pixel size (411x914 dp @ 2.625 -> 1078x2399 px). Install
+#    the bundled branded faces first so Chrome resolves the families the HTML
+#    names (else it falls back to a system sans and the type drifts vs the
+#    candidate, which loads the same .ttf):
+mkdir -p "$HOME/.local/share/fonts"
+cp meshcore-components/src/desktopMain/resources/fonts/*.ttf "$HOME/.local/share/fonts/"
+fc-cache -f
 for ref in $(jq -r '.components[].ref' design-map.json); do
   chrome --headless=new --no-sandbox --hide-scrollbars \
     --force-device-scale-factor=2.625 --window-size=411,914 \
@@ -99,9 +105,15 @@ system bars for `showSystemUi = true`
 porting the Android renderer's `SystemBarsFrame`), the candidate will carry a
 status bar of its own and these references can restore the realistic phone framing.
 
+The references render the **branded faces** (Space Grotesk / Orbitron / JetBrains
+Mono): the workflow installs the bundled `.ttf` — the same ones the desktop
+candidate loads — into fontconfig before the Chrome render, so both sides draw the
+real type by family name. Without it Chrome falls back to a system sans, which was
+the dominant residual after the status bar.
+
 Earlier run (before dropping the status bar): visual diff **~11%** (light) /
 **~6%** (dark) of pixels over the overlap — the bulk of it that systemic vertical
-offset, with typography the main residual once it's removed.
+offset, then typography until the fonts were installed.
 
 ## Continuous artifacts (`design-parity/main` branch)
 


### PR DESCRIPTION
## Problem

The design references name the branded faces (`font-family: "Space Grotesk" / "Orbitron" / "JetBrains Mono"`) but never `@font-face`-load them. CI's headless Chrome doesn't have those fonts installed, so it falls back to a system sans — while the desktop **candidate** renders the real faces from its bundled `.ttf`. That font mismatch was the dominant residual in the visual diff (the candidate's type is correct; the reference's wasn't).

## Fix

Install the **same bundled `.ttf`** the desktop candidate uses (`meshcore-components/src/desktopMain/resources/fonts/*.ttf`) into fontconfig before the Chrome render step, so it resolves the families the HTML already declares — by name, no reference edits.

Chosen over the alternatives: `@font-face` with `file://` URLs is unreliable in headless Chrome, and base64-inlining ~360KB of fonts across 12 reference HTMLs would bloat the repo by several MB. fontconfig name-resolution is the standard path Chrome uses on Linux and adds nothing to the committed fixtures.

## Changes

- `.github/workflows/design-parity.yml` — a step that copies the bundled `.ttf` into `~/.local/share/fonts` and runs `fc-cache -f` before "Render reference images from HTML".
- `docs/design-parity.md` — the reproduce guide installs the fonts first; the residual note updated.

## Test plan

- CI-config + docs only; no app code.
- Couldn't render locally (the sandbox chromium is a non-functional snap stub). Visual proof lands on merge: `design-parity.yml` regenerates the `design-parity/main` triptychs on push to `main` — the reference type should now match the candidate's branded faces, collapsing the typography residual.