### PR TITLE
chore(design-parity): bump CLI pin to 0.1.7

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.6 run \
+          npx -y design-parity@0.1.7 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -126,7 +126,7 @@ reference | candidate | diff without re-rendering locally.
 
 The workflow drives the render from `design-map.json` (so it can't drift from
 it): it installs the released `compose-preview` CLI, packs the candidate bundle,
-runs the published `design-parity` CLI (`npx design-parity@0.1.6`), and publishes
+runs the published `design-parity` CLI (`npx design-parity@0.1.7`), and publishes
 the output. The permanent-branch push is still the interim, hand-rolled version
 of a pattern design-parity's Action should own —
 [design-parity#56](https://github.com/yschimke/design-parity/issues/56) (modeled


### PR DESCRIPTION
Bumps the `design-parity` CLI pin from 0.1.6 → 0.1.7 in the parity workflow and the docs reference.

## What 0.1.7 brings

The release captures the five fixes that clear the Device screen's false findings (all verified against the real bundle semantics):

- `diff`: preserve distinct candidate token values when flattening
- `diff`: match M3 accent base roles against either ground
- `diff`: 1dp density-rounding slack on spacing/radius tokens
- `diff`: assert a11y coverage tree-wide, not on the root node
- `checks`: don't flag measurement values as locale-grouped numbers

## Effect

Paired with the status-bar removal and reference-font install already on `main`, the Device parity run should drop from **12 token errors + 2 a11y warnings + 1 i18n warning → 0**, with the typography residual collapsed.

## Changes

- `.github/workflows/design-parity.yml` — `npx design-parity@0.1.6` → `@0.1.7`.
- `docs/design-parity.md` — pin reference updated.

## Test plan

- CI-config + docs only; no app code.
- Visual + verdict proof lands on merge: `design-parity.yml` regenerates the `design-parity/main` triptychs and markdown verdict on push to `main`. (npm may need a few minutes to propagate 0.1.7; the CHANGELOG/tag on the design-parity repo already reflect it.)