### PR TITLE
fix(design-parity): align chat reference message layout to the candidate

### DIFF
--- a/design/ChannelChat.dark.html
+++ b/design/ChannelChat.dark.html
@@ -48,7 +48,7 @@
       .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
       .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
       .messages {
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }
       .row { display: flex; }
@@ -59,6 +59,7 @@
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }
+      .row.them .bubble.wide { width: 100%; }
       .row.mine .bubble {
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;
@@ -88,8 +89,8 @@
       
     </div>
     <div class="messages">
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">alice</span><span class="snr">SNR 7</span></div><div class="text">anyone near the north ridge?</div><div class="foot"><span>14/11 21:53</span></div></div></div>
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">bob-repeater</span><span class="snr">SNR 3</span></div><div class="text">I&#x27;ve got line of sight, relaying</div><div class="foot"><span>14/11 21:55</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">alice</span><span class="snr">SNR 7</span></div><div class="text">anyone near the north ridge?</div><div class="foot"><span>14/11 21:53</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">bob-repeater</span><span class="snr">SNR 3</span></div><div class="text">I&#x27;ve got line of sight, relaying</div><div class="foot"><span>14/11 21:55</span></div></div></div>
       <div class="row mine"><div class="bubble"><div class="text">copy — net looks healthy</div><div class="foot"><span>14/11 22:08</span><span class="dot">·</span><span>Delivered</span></div></div></div>
       <div class="row mine"><div class="bubble"><div class="text">broadcasting weather update</div><div class="foot"><span>14/11 22:13</span><span class="dot">·</span><span>Sending…</span></div></div></div>
     </div>

--- a/design/ChannelChat.light.html
+++ b/design/ChannelChat.light.html
@@ -48,7 +48,7 @@
       .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
       .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
       .messages {
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }
       .row { display: flex; }
@@ -59,6 +59,7 @@
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }
+      .row.them .bubble.wide { width: 100%; }
       .row.mine .bubble {
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;
@@ -88,8 +89,8 @@
       
     </div>
     <div class="messages">
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">alice</span><span class="snr">SNR 7</span></div><div class="text">anyone near the north ridge?</div><div class="foot"><span>14/11 21:53</span></div></div></div>
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">bob-repeater</span><span class="snr">SNR 3</span></div><div class="text">I&#x27;ve got line of sight, relaying</div><div class="foot"><span>14/11 21:55</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">alice</span><span class="snr">SNR 7</span></div><div class="text">anyone near the north ridge?</div><div class="foot"><span>14/11 21:53</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">bob-repeater</span><span class="snr">SNR 3</span></div><div class="text">I&#x27;ve got line of sight, relaying</div><div class="foot"><span>14/11 21:55</span></div></div></div>
       <div class="row mine"><div class="bubble"><div class="text">copy — net looks healthy</div><div class="foot"><span>14/11 22:08</span><span class="dot">·</span><span>Delivered</span></div></div></div>
       <div class="row mine"><div class="bubble"><div class="text">broadcasting weather update</div><div class="foot"><span>14/11 22:13</span><span class="dot">·</span><span>Sending…</span></div></div></div>
     </div>

--- a/design/Commands.dark.html
+++ b/design/Commands.dark.html
@@ -48,7 +48,7 @@
       .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
       .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
       .messages {
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }
       .row { display: flex; }
@@ -59,6 +59,7 @@
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }
+      .row.them .bubble.wide { width: 100%; }
       .row.mine .bubble {
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;
@@ -89,9 +90,9 @@
     </div>
     <div class="messages">
       <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">battery: 3980 mV (97%)</div><div class="foot"><span>14/11 22:10</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">battery: 3980 mV (97%)</div><div class="foot"><span>14/11 22:10</span></div></div></div>
       <div class="row mine"><div class="bubble"><div class="text">get freq</div><div class="foot"><span>14/11 22:12</span><span class="dot">·</span><span>Delivered</span></div></div></div>
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5</div><div class="foot"><span>14/11 22:12</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5</div><div class="foot"><span>14/11 22:12</span></div></div></div>
     </div>
     <div class="input">
       <div class="field">Enter command…</div>

--- a/design/Commands.light.html
+++ b/design/Commands.light.html
@@ -48,7 +48,7 @@
       .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
       .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
       .messages {
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }
       .row { display: flex; }
@@ -59,6 +59,7 @@
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }
+      .row.them .bubble.wide { width: 100%; }
       .row.mine .bubble {
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;
@@ -89,9 +90,9 @@
     </div>
     <div class="messages">
       <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">battery: 3980 mV (97%)</div><div class="foot"><span>14/11 22:10</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">battery: 3980 mV (97%)</div><div class="foot"><span>14/11 22:10</span></div></div></div>
       <div class="row mine"><div class="bubble"><div class="text">get freq</div><div class="foot"><span>14/11 22:12</span><span class="dot">·</span><span>Delivered</span></div></div></div>
-      <div class="row them"><div class="bubble"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5</div><div class="foot"><span>14/11 22:12</span></div></div></div>
+      <div class="row them"><div class="bubble wide"><div class="who-row"><span class="who">device</span><span class="snr">SNR 9</span></div><div class="text">freq: 869.525 MHz · BW 125 kHz · SF 10 · CR 5</div><div class="foot"><span>14/11 22:12</span></div></div></div>
     </div>
     <div class="input">
       <div class="field">Enter command…</div>

--- a/design/ContactChat.dark.html
+++ b/design/ContactChat.dark.html
@@ -48,7 +48,7 @@
       .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
       .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
       .messages {
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }
       .row { display: flex; }
@@ -59,6 +59,7 @@
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }
+      .row.them .bubble.wide { width: 100%; }
       .row.mine .bubble {
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;

--- a/design/ContactChat.light.html
+++ b/design/ContactChat.light.html
@@ -48,7 +48,7 @@
       .titles .title { font-size: 16px; font-weight: 600; color: var(--on-surface); }
       .titles .subtitle { font-size: 13px; color: var(--on-surface-variant); }
       .messages {
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }
       .row { display: flex; }
@@ -59,6 +59,7 @@
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }
+      .row.them .bubble.wide { width: 100%; }
       .row.mine .bubble {
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;

--- a/design/gen_chat_refs.py
+++ b/design/gen_chat_refs.py
@@ -62,7 +62,7 @@ def bubble(side, sender, snr, text, time, status):
     if mine and status:
         foot += f'<span class="dot">·</span><span>{html.escape(status)}</span>'
     return (f'<div class="row {"mine" if mine else "them"}">'
-            f'<div class="bubble">{header}'
+            f'<div class="bubble{" wide" if header else ""}">{header}'
             f'<div class="text">{html.escape(text)}</div>'
             f'<div class="foot">{foot}</div></div></div>')
 
@@ -140,7 +140,7 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
       .titles .title {{ font-size: 16px; font-weight: 600; color: var(--on-surface); }}
       .titles .subtitle {{ font-size: 13px; color: var(--on-surface-variant); }}
       .messages {{
-        flex: 1; overflow: hidden; padding: 8px 12px;
+        flex: 1; overflow: hidden; padding: 14px 12px 8px;
         display: flex; flex-direction: column; gap: 4px;
       }}
       .row {{ display: flex; }}
@@ -151,6 +151,7 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
         background: var(--surface-container-high); color: var(--on-surface);
         border-bottom-left-radius: 4px;
       }}
+      .row.them .bubble.wide {{ width: 100%; }}
       .row.mine .bubble {{
         background: var(--primary-container); color: var(--on-primary-container);
         border-bottom-right-radius: 4px;


### PR DESCRIPTION
## What

Aligns the chat references (contact / channel / commands, light + dark) to the candidate's message layout. Two fixes in `gen_chat_refs.py`, so all six references benefit.

## Fixes

1. **Message column started ~6dp too high** vs the candidate. Bumped the message list's top padding (8 → 14px) so the first bubble seats at the candidate's y. The offset was identical across all three screens.
2. **"Them" bubble width.** The candidate's group/commands "them" bubbles — the ones with a **sender header** (`alice SNR 7`, `device SNR 9`) — fill the available width up to the 48dp gutter, but the reference grew them only to content width (a solid-red right-edge block in the diff). Added a `.wide` modifier on sender-header bubbles to match. 1:1 contact bubbles (no header) stay content-width, exactly as the candidate renders them (confirmed by measurement — making *all* them-bubbles wide regressed ContactChat).

## Result (measured locally vs the published candidate bundle)

| Screen | Before | After |
| --- | --- | --- |
| ChannelChat | 7.3% | **1.9%** |
| Commands | 5.6% | **2.4%** |
| ContactChat | 3.0% | 3.0% |

All three are now at/near the cross-renderer text floor.

## Test plan

References-only (generator + its regenerated HTML); no app code. `python3 design/gen_chat_refs.py` reproduces the HTML. CI regenerates the `design-parity/main` triptychs on merge.