### PR TITLE
ci(design-parity): make landing-page report links openable from the branch

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -122,6 +122,15 @@ jobs:
           cp -a build/design-parity/out/. "$art/"
           cp build/design-parity/candidates.bundle.png "$art/" || true
           printf '%s\n' "$GITHUB_SHA" > "$art/SOURCE_COMMIT"
+          # The artifacts live on a branch, where GitHub serves .html as source
+          # rather than rendering it, so the landing page's relative report links
+          # don't open. Each report is self-contained, so rewrite the README's
+          # report links to htmlpreview, which renders a branch-hosted HTML page.
+          if [ -f "$art/README.md" ]; then
+            sed -i -E \
+              "s#\]\(\./([^)]+\.html)\)#](https://htmlpreview.github.io/?https://github.com/${GITHUB_REPOSITORY}/blob/design-parity/main/\1)#g" \
+              "$art/README.md"
+          fi
           cd "$art"
           git init -q
           git checkout -q -b design-parity/main


### PR DESCRIPTION
## Problem

On the `design-parity/main` branch, the generated `README.md` lists each report with a **relative** link — `[report](./<component>/report.html)`. GitHub serves `.html` on a branch as **source**, not a rendered page, so clicking those links shows raw HTML (or nothing useful) rather than the reference | candidate | diff comparison. The README even notes "GitHub shows a linked `.html` as source" but then points at those same non-working relative links.

## Fix

The reports are **self-contained** HTML (inline images), so in the publish step rewrite the README's report links to **htmlpreview**, which renders a branch-hosted HTML file:

```
./<component>/report.html
→ https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/design-parity/main/<component>/report.html
```

Non-`.html` links (e.g. `SOURCE_COMMIT`) are left as relative. Verified the `sed` against the live README — report rows rewrite correctly, the `SOURCE_COMMIT` link is untouched.

## Notes

- Takes effect on the next `design-parity.yml` run (next push to `main`, or a manual `workflow_dispatch`), which regenerates `design-parity/main`.
- This rewrite lives in the consumer workflow because publishing to a *branch* is the interim, hand-rolled approach (design-parity#56); the proper home is the design-parity Action once it owns the artifact branch (or GitHub Pages, where relative links + HTML rendering work natively).
- If htmlpreview proves flaky on the larger reports (~1.2 MB), `raw.githack.com/<owner>/<repo>/design-parity/main/<path>` is a drop-in, more robust alternative — easy swap.

## Test plan

CI-config only; no app code. Confirmed the link transform locally.