### PR TITLE
ci(design-parity): bump to 0.1.8, use native landing-page links

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,11 +107,14 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.7 run \
+          npx -y design-parity@0.1.8 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \
-            --out build/design-parity/out
+            --out build/design-parity/out \
+            --repo-slug "${GITHUB_REPOSITORY}" \
+            --branch design-parity/main \
+            --source-commit "${GITHUB_SHA}"
 
       - name: Publish artifacts to design-parity/main
         env:
@@ -122,15 +125,6 @@ jobs:
           cp -a build/design-parity/out/. "$art/"
           cp build/design-parity/candidates.bundle.png "$art/" || true
           printf '%s\n' "$GITHUB_SHA" > "$art/SOURCE_COMMIT"
-          # The artifacts live on a branch, where GitHub serves .html as source
-          # rather than rendering it, so the landing page's relative report links
-          # don't open. Each report is self-contained, so rewrite the README's
-          # report links to htmlpreview, which renders a branch-hosted HTML page.
-          if [ -f "$art/README.md" ]; then
-            sed -i -E \
-              "s#\]\(\./([^)]+\.html)\)#](https://htmlpreview.github.io/?https://github.com/${GITHUB_REPOSITORY}/blob/design-parity/main/\1)#g" \
-              "$art/README.md"
-          fi
           cd "$art"
           git init -q
           git checkout -q -b design-parity/main

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -126,7 +126,7 @@ reference | candidate | diff without re-rendering locally.
 
 The workflow drives the render from `design-map.json` (so it can't drift from
 it): it installs the released `compose-preview` CLI, packs the candidate bundle,
-runs the published `design-parity` CLI (`npx design-parity@0.1.7`), and publishes
+runs the published `design-parity` CLI (`npx design-parity@0.1.8`), and publishes
 the output. The permanent-branch push is still the interim, hand-rolled version
 of a pattern design-parity's Action should own —
 [design-parity#56](https://github.com/yschimke/design-parity/issues/56) (modeled


### PR DESCRIPTION
## What

Bumps the `design-parity` pin to **0.1.8** and uses its new native landing-page link support, deleting the hand-rolled `sed` from #121.

## Why

0.1.8 adds `--repo-slug` / `--branch` / `--source-commit` to `design-parity run` (yschimke/design-parity#115). With them, the generated `README.md`'s report + board links resolve through htmlpreview natively — so the workflow no longer needs to post-process the README to make branch-hosted `.html` links open.

## Changes

- `.github/workflows/design-parity.yml`:
  - pin `design-parity@0.1.7` → `@0.1.8`;
  - pass `--repo-slug "${GITHUB_REPOSITORY}" --branch design-parity/main --source-commit "${GITHUB_SHA}"` to `run`;
  - **remove** the `sed` README-rewrite step (the CLI owns it now). Also stamps the source commit onto the landing page.
- `docs/design-parity.md`: pin reference → 0.1.8.

## Net

Same result as #121 (landing-page links open the rendered report), but the logic now lives upstream in design-parity instead of a per-consumer `sed`. The hand-rolled branch-publish itself remains the interim approach (design-parity#56) — a larger future migration onto the Action's baseline mode.

## Test plan

CI-config + docs only; no app code. Confirmed the design-parity 0.1.8 `run` flags produce htmlpreview links e2e in the upstream PR. (npm may need a few minutes to propagate 0.1.8; the tag/CHANGELOG already reflect it.) The next `design-parity.yml` run on `main` regenerates `design-parity/main` with native links.