### PR TITLE
fix(design-parity): match chat input shape + message text size to candidate

### DIFF
--- a/design/ChannelChat.dark.html
+++ b/design/ChannelChat.dark.html
@@ -67,15 +67,15 @@
       .who-row { display: flex; align-items: center; gap: 8px; }
       .who { font-size: 12px; font-weight: 600; color: var(--primary); }
       .snr { font-size: 11px; opacity: 0.55; }
-      .text { font-size: 15px; line-height: 1.3; }
+      .text { font-size: 14px; line-height: 1.3; }
       .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
       .input {
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }
       .field {
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }

--- a/design/ChannelChat.light.html
+++ b/design/ChannelChat.light.html
@@ -67,15 +67,15 @@
       .who-row { display: flex; align-items: center; gap: 8px; }
       .who { font-size: 12px; font-weight: 600; color: var(--primary); }
       .snr { font-size: 11px; opacity: 0.55; }
-      .text { font-size: 15px; line-height: 1.3; }
+      .text { font-size: 14px; line-height: 1.3; }
       .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
       .input {
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }
       .field {
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }

--- a/design/Commands.dark.html
+++ b/design/Commands.dark.html
@@ -67,15 +67,15 @@
       .who-row { display: flex; align-items: center; gap: 8px; }
       .who { font-size: 12px; font-weight: 600; color: var(--primary); }
       .snr { font-size: 11px; opacity: 0.55; }
-      .text { font-size: 15px; line-height: 1.3; }
+      .text { font-size: 14px; line-height: 1.3; }
       .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
       .input {
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }
       .field {
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }

--- a/design/Commands.light.html
+++ b/design/Commands.light.html
@@ -67,15 +67,15 @@
       .who-row { display: flex; align-items: center; gap: 8px; }
       .who { font-size: 12px; font-weight: 600; color: var(--primary); }
       .snr { font-size: 11px; opacity: 0.55; }
-      .text { font-size: 15px; line-height: 1.3; }
+      .text { font-size: 14px; line-height: 1.3; }
       .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
       .input {
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }
       .field {
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }

--- a/design/ContactChat.dark.html
+++ b/design/ContactChat.dark.html
@@ -67,15 +67,15 @@
       .who-row { display: flex; align-items: center; gap: 8px; }
       .who { font-size: 12px; font-weight: 600; color: var(--primary); }
       .snr { font-size: 11px; opacity: 0.55; }
-      .text { font-size: 15px; line-height: 1.3; }
+      .text { font-size: 14px; line-height: 1.3; }
       .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
       .input {
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }
       .field {
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }

--- a/design/ContactChat.light.html
+++ b/design/ContactChat.light.html
@@ -67,15 +67,15 @@
       .who-row { display: flex; align-items: center; gap: 8px; }
       .who { font-size: 12px; font-weight: 600; color: var(--primary); }
       .snr { font-size: 11px; opacity: 0.55; }
-      .text { font-size: 15px; line-height: 1.3; }
+      .text { font-size: 14px; line-height: 1.3; }
       .foot { display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }
       .input {
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }
       .field {
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }

--- a/design/gen_chat_refs.py
+++ b/design/gen_chat_refs.py
@@ -159,15 +159,15 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
       .who-row {{ display: flex; align-items: center; gap: 8px; }}
       .who {{ font-size: 12px; font-weight: 600; color: var(--primary); }}
       .snr {{ font-size: 11px; opacity: 0.55; }}
-      .text {{ font-size: 15px; line-height: 1.3; }}
+      .text {{ font-size: 14px; line-height: 1.3; }}
       .foot {{ display: flex; gap: 6px; font-size: 11px; opacity: 0.55; margin-top: 3px; }}
       .input {{
         flex: none; display: flex; align-items: center; gap: 8px; padding: 8px;
       }}
       .field {{
-        flex: 1; height: 48px; border: 1px solid var(--outline); border-radius: 24px;
+        flex: 1; height: 56px; border: 1px solid var(--outline); border-radius: 24px;
         display: flex; align-items: center; padding: 0 18px;
-        color: var(--on-surface-variant); font-size: 15px;
+        color: var(--on-surface-variant); font-size: 16px;
       }}
       .send {{ width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }}


### PR DESCRIPTION
Matches three chat-reference values to what the candidate actually renders (each read from the app's composables/typography, not eyeballed).

## Fixes

1. **Input field shape** — the candidate `ChatInput` is an `OutlinedTextField` with `RoundedCornerShape(24.dp)` at the M3 default **56dp** height; at 56dp the 24dp radius is < height/2, so it reads as a **rounded rectangle**. The reference was 48dp, where radius 24 = height/2 made it a **full pill**. Height 48 → 56 fixes the shape (and the height).
2. **Placeholder size** — 15 → 16px (`bodyLarge`).
3. **Message text** — 15 → 14px (`bodyMedium`, 14sp; confirmed structurally: the candidate text box is 17.9dp = 14×1.28 line-height, ~206dp wide). This also narrows the content-width bubbles to the candidate's.

## Result (local diff vs the candidate bundle)

| Screen | Before | After |
| --- | --- | --- |
| ContactChat | 3.0% | **1.6%** |
| Commands | 2.4% | **1.8%** |
| ChannelChat | 1.9% | 2.3% |

ChannelChat ticks up slightly: with the correct 14sp its larger label set renders a touch more text-edge AA. I did **not** game it back to the wrong 15px — 14sp is what the app renders.

## Notes (answering the other two observations)

- **Text weight / boldness:** the apparent difference isn't fixable by setting weights. The desktop candidate bundles only `SpaceGrotesk.ttf` (the **Light** static), registered for *all* weights without variation axes, so Skiko renders every Space Grotesk weight at ~Light regardless of the nominal `fontWeight` (`labelSmall` is Bold in code but renders light). Matching the *nominal* weight makes the reference too heavy. The real fix is app-side (bundle weighted/variable faces with `wght` axes); the weight isn't in the diff data either (compose-ai-tools#1934). Left the reference at its lighter weights to match the render.
- **Bubble width** is already matched (the #120 `.wide` rule + the 14px text narrowing); a per-element layout audit (reference DOM bounds vs candidate semantics) confirms positions align within a few dp.

## Test plan

References-only (generator + regenerated HTML); no app code. `python3 design/gen_chat_refs.py` reproduces.