### PR TITLE
ci(design-parity): bump pinned CLI to 0.1.9

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.8 run \
+          npx -y design-parity@0.1.9 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the pinned `design-parity` CLI in the artifact workflow from **0.1.8 → 0.1.9**.

0.1.9 wires the **structural layout diff** end to end: per-element position/size
drift is captured from the reference geometry, density-normalised against the
candidate render, and surfaced as a new **Layout** section in the report. This
repo's `design-parity.yml` was pinned to 0.1.8, so without this bump the
republished artifacts on `design-parity/main` would keep using the old engine
and never show layout findings.

```diff
-          npx -y design-parity@0.1.8 run \
+          npx -y design-parity@0.1.9 run \
```

No other change — same inputs, same outputs path, just the newer engine.

## Test plan

- Merging to `main` triggers the `Design parity artifacts` workflow (or run it
  via `workflow_dispatch`), which regenerates the candidate bundle + report and
  force-pushes to `design-parity/main`.
- Confirm the run installs `design-parity@0.1.9` and that the published
  `report.html` / verdict now includes a **Layout** section when any element's
  position/size drifts beyond tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_