### PR TITLE
ci(design-parity): bump pinned CLI to 0.1.10

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.9 run \
+          npx -y design-parity@0.1.10 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the pinned `design-parity` CLI in the artifact workflow from **0.1.9 → 0.1.10**.

0.1.10 fixes the launcher no-op (design-parity#122): `npx design-parity run`
was *importing* the run module without executing `main()`, so it produced no
output and never wrote the `--out` directory. That made this workflow fail at
the publish step on every run, regardless of CLI version:

```
cp: cannot stat 'build/design-parity/out/.': No such file or directory
```

With 0.1.10 the run actually executes, so the artifact republish to
`design-parity/main` works end to end — and now carries the structural **layout
diff** that landed in 0.1.9.

```diff
-          npx -y design-parity@0.1.9 run \
+          npx -y design-parity@0.1.10 run \
```

## Test plan

- Merge to `main` triggers the `Design parity artifacts` workflow (push
  trigger), or run it via `workflow_dispatch`.
- Verify the `Run design-parity` step now produces output and writes
  `build/design-parity/out/`, the `Publish artifacts to design-parity/main`
  step succeeds (no more `cp: cannot stat`), and `design-parity/main` is
  refreshed for the head SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_