### PR TITLE
ci(design-parity): bump pinned CLI to 0.1.11

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.10 run \
+          npx -y design-parity@0.1.11 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the pinned `design-parity` CLI in the artifact workflow from **0.1.10 → 0.1.11**.

0.1.11 adds the report's **toggleable annotation overlays** over both the
reference and candidate panels:

- **Box model** — element boxes, `W×H`, corner radius, padding rings
- **Typography** — `family · size · weight · line-height` + colour swatch
- **Layout deltas** — elements the structural diff flagged, highlighted with `Δpos x,y · Δsize w,h`

With this pin, the republished `report.html` on `design-parity/main` carries
them. Report-rendering only — no change to verdicts or the workflow's
inputs/outputs.

```diff
-          npx -y design-parity@0.1.10 run \
+          npx -y design-parity@0.1.11 run \
```

## Test plan

- Merge to `main` triggers the `Design parity artifacts` workflow (push
  trigger), or run via `workflow_dispatch`.
- Confirm the run installs `design-parity@0.1.11`, publishes to
  `design-parity/main`, and the report's **Annotations** toggles (Box model /
  Typography / Layout deltas) are present when opening `report.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_