### PR TITLE
ci(design-parity): bump pinned CLI to 0.1.12

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.11 run \
+          npx -y design-parity@0.1.12 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the pinned `design-parity` CLI from **0.1.11 → 0.1.12**.

0.1.12 fixes the reference layout capture (design-parity#133): the extractor now
resolves Chrome to an **absolute path** before launch, so on CI — where
`google-chrome-stable` is on `PATH` but not given as an absolute
`CHROME_BIN`/`CHROMIUM_BIN` — puppeteer-core no longer rejects it with
`existsSync(...) === false`.

This activates two things that were **silently dormant** in this workflow's runs
(because `reference.layout` was never captured):

- the **structural layout diff** — it'll start producing `layout` findings, and
- the report's **reference-panel** annotation overlays (Box model / Typography) and the **Layout-deltas** layer.

```diff
-          npx -y design-parity@0.1.11 run \
+          npx -y design-parity@0.1.12 run \
```

## Test plan

- Merge to `main` triggers the `Design parity artifacts` workflow.
- Confirm it installs `design-parity@0.1.12`, publishes to `design-parity/main`,
  and that a published `report.html` now carries an annotation overlay on the
  **reference** panel (not just the candidate) — i.e. `reference.layout` was
  captured this time.