### PR TITLE
ci(design-parity): bump pinned CLI to 0.1.13

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.12 run \
+          npx -y design-parity@0.1.13 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the pinned `design-parity` CLI from **0.1.12 → 0.1.13**.

0.1.13 (design-parity#136) parses the compose/semantics `boundsInRoot`
`"left,top,right,bottom"` string on the **bundle** path, so candidate nodes from
the preview bundle finally carry geometry (they came through with none before).

With this plus the 0.1.12 Chrome-path fix, the republished report should now have:
- annotation overlays on **both** the reference *and* candidate panels (Box model / Typography), and
- a **populated Layout-deltas layer** — the structural layout diff now has candidate geometry to compare against `reference.layout`.

```diff
-          npx -y design-parity@0.1.12 run \
+          npx -y design-parity@0.1.13 run \
```

## Test plan

- Merge to `main` triggers the `Design parity artifacts` workflow.
- Confirm it installs `design-parity@0.1.13`, publishes to `design-parity/main`,
  and a published `report.html` now carries a candidate-panel overlay (not just
  reference) — i.e. candidate semantics have bounds this time.