### PR TITLE
ci(design-parity): bump pinned CLI to 0.1.14

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.13 run \
+          npx -y design-parity@0.1.14 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the pinned `design-parity` CLI from **0.1.13 → 0.1.14**. 0.1.14 brings two
bundle-path fixes:

- **Candidate typography parsed** (design-parity#137): the report's candidate
  Typography overlay now shows the font **size** (read from the bundle's
  `layoutFontSize`).
- **Reference text measured at its glyph box** (design-parity#138): a `Range`
  over the text content gives the rendered text extent instead of the wide
  flex/grid cell, so the structural layout diff's text **width deltas collapse
  toward the real drift** (fixes the "candidates look like zero" symptom).

```diff
-          npx -y design-parity@0.1.13 run \
+          npx -y design-parity@0.1.14 run \
```

## Follow-up (separate PR)

Full typography (family / weight / line-height) also needs the **bundle** to
carry the v6 `typography` object, which **compose-preview 0.16.0** emits (this
repo pins 0.15.9). That compose-preview minor bump (schema v6 / render path) is
a fast-follow so it can be verified on its own.

## Test plan

- Merge to `main` triggers the `Design parity artifacts` workflow.
- Confirm it installs `design-parity@0.1.14`, publishes to `design-parity/main`,
  and a published `report.html` shows: a candidate Typography overlay with the
  font size, and text-row `Δsize` width values much closer to 0 than before.