### PR TITLE
feat(design-parity): label control accessibles on the references

### DIFF
--- a/design/CachedDevice.dark.html
+++ b/design/CachedDevice.dark.html
@@ -195,9 +195,9 @@
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">
-        <span class="icon-btn" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
-        <span class="icon-btn" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
-        <span class="icon-btn" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Tools" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Theme" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Disconnect" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
       </div>
     </div>
 

--- a/design/CachedDevice.light.html
+++ b/design/CachedDevice.light.html
@@ -193,9 +193,9 @@
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">
-        <span class="icon-btn" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
-        <span class="icon-btn" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
-        <span class="icon-btn" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Tools" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Theme" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Disconnect" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
       </div>
     </div>
 

--- a/design/ChannelChat.dark.html
+++ b/design/ChannelChat.dark.html
@@ -97,7 +97,7 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">General</div><div class="subtitle">Channel 0</div></div>
       
     </div>
@@ -109,7 +109,7 @@
     </div>
     <div class="input">
       <div class="field">Message</div>
-      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+      <span class="send" role="button" aria-label="Send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
     </div>
     <script type="application/design-parity+json">
 {

--- a/design/ChannelChat.light.html
+++ b/design/ChannelChat.light.html
@@ -97,7 +97,7 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">General</div><div class="subtitle">Channel 0</div></div>
       
     </div>
@@ -109,7 +109,7 @@
     </div>
     <div class="input">
       <div class="field">Message</div>
-      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+      <span class="send" role="button" aria-label="Send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
     </div>
     <script type="application/design-parity+json">
 {

--- a/design/Commands.dark.html
+++ b/design/Commands.dark.html
@@ -97,9 +97,9 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">Commands</div></div>
-      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+      <span class="icon-btn action" role="button" aria-label="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
     </div>
     <div class="messages">
       <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>
@@ -109,7 +109,7 @@
     </div>
     <div class="input">
       <div class="field">Enter command…</div>
-      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+      <span class="send" role="button" aria-label="Send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
     </div>
     <script type="application/design-parity+json">
 {

--- a/design/Commands.light.html
+++ b/design/Commands.light.html
@@ -97,9 +97,9 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">Commands</div></div>
-      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+      <span class="icon-btn action" role="button" aria-label="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
     </div>
     <div class="messages">
       <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>
@@ -109,7 +109,7 @@
     </div>
     <div class="input">
       <div class="field">Enter command…</div>
-      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+      <span class="send" role="button" aria-label="Send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
     </div>
     <script type="application/design-parity+json">
 {

--- a/design/ContactChat.dark.html
+++ b/design/ContactChat.dark.html
@@ -95,7 +95,7 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">alice</div><div class="subtitle">Direct message</div></div>
       
     </div>
@@ -107,7 +107,7 @@
     </div>
     <div class="input">
       <div class="field">Message</div>
-      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+      <span class="send" role="button" aria-label="Send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
     </div>
     <script type="application/design-parity+json">
 {

--- a/design/ContactChat.light.html
+++ b/design/ContactChat.light.html
@@ -95,7 +95,7 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">alice</div><div class="subtitle">Direct message</div></div>
       
     </div>
@@ -107,7 +107,7 @@
     </div>
     <div class="input">
       <div class="field">Message</div>
-      <span class="send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
+      <span class="send" role="button" aria-label="Send"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.4 20.4 21 12 3.4 3.6 3 10l12 2-12 2z"/></svg></span>
     </div>
     <script type="application/design-parity+json">
 {

--- a/design/DeviceScreen.dark.html
+++ b/design/DeviceScreen.dark.html
@@ -181,9 +181,9 @@
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">
-        <span class="icon-btn" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
-        <span class="icon-btn" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
-        <span class="icon-btn" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Tools" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Theme" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Disconnect" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
       </div>
     </div>
 

--- a/design/DeviceScreen.light.html
+++ b/design/DeviceScreen.light.html
@@ -179,9 +179,9 @@
     <div class="topbar">
       <div class="title">node-peak</div>
       <div class="actions">
-        <span class="icon-btn" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
-        <span class="icon-btn" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
-        <span class="icon-btn" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Tools" title="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Theme" title="Theme"><svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 100 20V2z"/><circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></span>
+        <span class="icon-btn" role="button" aria-label="Disconnect" title="Disconnect"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5"/><polyline points="9 16 13 12 9 8"/><line x1="13" y1="12" x2="3" y2="12"/></svg></span>
       </div>
     </div>
 

--- a/design/DeviceSettings.dark.html
+++ b/design/DeviceSettings.dark.html
@@ -69,9 +69,9 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="title">Device Settings</div>
-      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg></span>
+      <span class="icon-btn action" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg></span>
     </div>
     <div class="content">
       <div class="row">
@@ -79,7 +79,7 @@
           <div class="label">Buzzer</div>
           <div class="sub">On (rtttl)</div>
         </div>
-        <div class="switch"><span class="thumb"></span></div>
+        <div class="switch" role="switch" aria-label="Buzzer"><span class="thumb"></span></div>
       </div>
       <div class="divider"></div>
     </div>

--- a/design/DeviceSettings.light.html
+++ b/design/DeviceSettings.light.html
@@ -69,9 +69,9 @@
     <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/><rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/><path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>
     <div class="sysbar sysbar-bottom"><span class="pill"></span></div>
     <div class="topbar">
-      <span class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
+      <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="title">Device Settings</div>
-      <span class="icon-btn action"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg></span>
+      <span class="icon-btn action" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3.2"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 0 0-2-1.2L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg></span>
     </div>
     <div class="content">
       <div class="row">
@@ -79,7 +79,7 @@
           <div class="label">Buzzer</div>
           <div class="sub">On (rtttl)</div>
         </div>
-        <div class="switch"><span class="thumb"></span></div>
+        <div class="switch" role="switch" aria-label="Buzzer"><span class="thumb"></span></div>
       </div>
       <div class="divider"></div>
     </div>


### PR DESCRIPTION
## Summary

The other half of the **full a11y fix** for missing component boxes (paired with
design-parity #142). The references previously had bare icon buttons
(`<span class="icon-btn"><svg/></span>`) with no accessibility markup, so the
adapter — even once it captures accessible objects — has nothing to key on. This
adds `role` + `aria-label` to every interactive control across the 12 references,
matched to the Compose `contentDescription` so the reference box **matches** the
candidate's control:

| control | role | aria-label (= Compose contentDescription) |
|---|---|---|
| back arrow | `button` | `Back` |
| send | `button` | `Send` |
| terminal | `button` | `Tools` |
| theme toggle | `button` | `Theme` |
| disconnect | `button` | `Disconnect` |
| Buzzer toggle | `switch` | `Buzzer` |
| Settings gear | — | **`aria-hidden`** (decorative: `contentDescription = null` in `DeviceSettingsBody`) |

Totals: 28 `role="button"`, 2 `role="switch"`, 2 `aria-hidden`. It's also a real
accessibility improvement to the references in their own right.

**Deliberate follow-up:** avatars, status glyphs (wifi/battery), and section
carets — their candidate `contentDescription`s vary or are decorative, so I left
them for a focused second pass rather than guess.

## Test plan

- Pure markup; no behavior change. Renders identically (attributes are invisible).
- **Visible effect is gated** on design-parity #142 (the accessible-objects
  extractor) releasing **and** meshcore bumping the pinned `design-parity` CLI.
  Once both land, the reference panel boxes these controls and they match the
  candidate's — verified on the republish. Until then this is a harmless a11y
  upgrade.

Companion: design-parity#142.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_