### PR TITLE
fix(design-parity): resync reference generators + correct two controls

### DIFF
--- a/design/ChannelChat.dark.html
+++ b/design/ChannelChat.dark.html
@@ -80,11 +80,11 @@
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }
       .send svg { width: 24px; height: 24px; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays. Content is inset to match the candidate's
-         status-bar inset; the value is the residual layout-diff offset (Δpos dy)
-         this screen showed once the bars were added (body ~-2; centres the body). */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
       body { position: relative; padding-top: 2px; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }

--- a/design/ChannelChat.light.html
+++ b/design/ChannelChat.light.html
@@ -80,11 +80,11 @@
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }
       .send svg { width: 24px; height: 24px; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays. Content is inset to match the candidate's
-         status-bar inset; the value is the residual layout-diff offset (Δpos dy)
-         this screen showed once the bars were added (body ~-2; centres the body). */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
       body { position: relative; padding-top: 2px; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }

--- a/design/Commands.dark.html
+++ b/design/Commands.dark.html
@@ -80,11 +80,11 @@
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }
       .send svg { width: 24px; height: 24px; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays. Content is inset to match the candidate's
-         status-bar inset; the value is the residual layout-diff offset (Δpos dy)
-         this screen showed once the bars were added (uniform -2 here). */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
       body { position: relative; padding-top: 2px; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }
@@ -99,7 +99,7 @@
     <div class="topbar">
       <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">Commands</div></div>
-      <span class="icon-btn action" role="button" aria-label="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+      <span class="icon-btn action" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
     </div>
     <div class="messages">
       <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>

--- a/design/Commands.light.html
+++ b/design/Commands.light.html
@@ -80,11 +80,11 @@
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }
       .send svg { width: 24px; height: 24px; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays. Content is inset to match the candidate's
-         status-bar inset; the value is the residual layout-diff offset (Δpos dy)
-         this screen showed once the bars were added (uniform -2 here). */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
       body { position: relative; padding-top: 2px; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }
@@ -99,7 +99,7 @@
     <div class="topbar">
       <span class="icon-btn" role="button" aria-label="Back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="20" y1="12" x2="5" y2="12"/><polyline points="11 18 5 12 11 6"/></svg></span>
       <div class="titles"><div class="title">Commands</div></div>
-      <span class="icon-btn action" role="button" aria-label="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
+      <span class="icon-btn action" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/><line x1="12" y1="16" x2="18" y2="16"/></svg></span>
     </div>
     <div class="messages">
       <div class="row mine"><div class="bubble"><div class="text">get bat</div><div class="foot"><span>14/11 22:10</span><span class="dot">·</span><span>Sent</span></div></div></div>

--- a/design/ContactChat.dark.html
+++ b/design/ContactChat.dark.html
@@ -80,9 +80,11 @@
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }
       .send svg { width: 24px; height: 24px; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays so the app content keeps its measured place. */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
       body { position: relative; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }

--- a/design/ContactChat.light.html
+++ b/design/ContactChat.light.html
@@ -80,9 +80,11 @@
       .send { width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }
       .send svg { width: 24px; height: 24px; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays so the app content keeps its measured place. */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
       body { position: relative; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }

--- a/design/DeviceSettings.dark.html
+++ b/design/DeviceSettings.dark.html
@@ -51,12 +51,11 @@
       .switch { width: 52px; height: 32px; border-radius: 16px; position: relative; flex: none; background: var(--primary); }
       .switch .thumb { position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border-radius: 50%; background: var(--on-primary); }
       .divider { height: 1px; background: var(--outline-variant); margin: 8px 0; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays. Unlike the other references this screen's
-         content is flush to the top, so inset it by the status-bar height to match
-         the candidate, which insets its content ~14dp below the status bar
-         (measured layout-diff Δpos dy = -14). */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top insets the content to the candidate's
+         status-bar inset (the residual layout-diff offset this screen showed once
+         the bars were added). */
       body { position: relative; padding-top: 14px; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }
@@ -79,7 +78,7 @@
           <div class="label">Buzzer</div>
           <div class="sub">On (rtttl)</div>
         </div>
-        <div class="switch" role="switch" aria-label="Buzzer"><span class="thumb"></span></div>
+        <div class="switch" role="switch" aria-label="Buzzer" aria-checked="true"><span class="thumb"></span></div>
       </div>
       <div class="divider"></div>
     </div>

--- a/design/DeviceSettings.light.html
+++ b/design/DeviceSettings.light.html
@@ -51,12 +51,11 @@
       .switch { width: 52px; height: 32px; border-radius: 16px; position: relative; flex: none; background: var(--primary); }
       .switch .thumb { position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border-radius: 50%; background: var(--on-primary); }
       .divider { height: 1px; background: var(--outline-variant); margin: 8px 0; }
-    
-      /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
-         as non-reflowing overlays. Unlike the other references this screen's
-         content is flush to the top, so inset it by the status-bar height to match
-         the candidate, which insets its content ~14dp below the status bar
-         (measured layout-diff Δpos dy = -14). */
+
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top insets the content to the candidate's
+         status-bar inset (the residual layout-diff offset this screen showed once
+         the bars were added). */
       body { position: relative; padding-top: 14px; }
       .sysbar { position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }
       .sysbar-top { top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }
@@ -79,7 +78,7 @@
           <div class="label">Buzzer</div>
           <div class="sub">On (rtttl)</div>
         </div>
-        <div class="switch" role="switch" aria-label="Buzzer"><span class="thumb"></span></div>
+        <div class="switch" role="switch" aria-label="Buzzer" aria-checked="true"><span class="thumb"></span></div>
       </div>
       <div class="divider"></div>
     </div>

--- a/design/gen_chat_refs.py
+++ b/design/gen_chat_refs.py
@@ -29,6 +29,38 @@ TERMINAL = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-w
             'stroke-linecap="round" stroke-linejoin="round"><polyline points="5 7 9 11 5 15"/>'
             '<line x1="12" y1="16" x2="18" y2="16"/></svg>')
 
+# System bars (showSystemUi = true): a status bar (9:30 + battery) and a gesture
+# nav pill, drawn as absolutely-positioned, non-reflowing overlays so the app
+# content keeps its measured place. Markup goes first in <body>; CSS goes last in
+# <style>. Shared verbatim with gen_settings_refs.py — keep the two in sync.
+SYSBAR_MARKUP = (
+    '    <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" '
+    'stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/>'
+    '<rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/>'
+    '<path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>\n'
+    '    <div class="sysbar sysbar-bottom"><span class="pill"></span></div>'
+)
+
+
+def sysbar_style(inset):
+    """The system-bar CSS plus the `body` overlay/inset rule. `inset` is the px the
+    content is pushed down to match the candidate's status-bar inset — the residual
+    layout-diff Δpos dy this screen showed once the bars were added; 0 means the
+    content already lines up and only the overlays are added."""
+    pad = f" padding-top: {inset}px;" if inset else ""
+    return f"""
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top, when set, insets the content to the
+         candidate's status-bar inset (the residual layout-diff offset this screen
+         showed once the bars were added). */
+      body {{ position: relative;{pad} }}
+      .sysbar {{ position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }}
+      .sysbar-top {{ top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }}
+      .sysbar-top svg {{ width: 22px; height: 12px; }}
+      .sysbar-bottom {{ bottom: 7px; display: flex; justify-content: center; }}
+      .sysbar-bottom .pill {{ width: 108px; height: 4px; border-radius: 2px; background: currentColor; }}"""
+
+
 # Messages mirror ChatBodyPreviews (sender, text, snr, mine, status, displayed time).
 contact = [
     ("in", None, None, "hey — are you on tonight?", "14/11 21:58", None),
@@ -67,9 +99,11 @@ def bubble(side, sender, snr, text, time, status):
             f'<div class="foot">{foot}</div></div></div>')
 
 
-def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, component_id, png):
+def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, inset, component_id, png):
     sub = f'<div class="subtitle">{html.escape(subtitle)}</div>' if subtitle else ""
-    action = f'<span class="icon-btn action">{TERMINAL}</span>' if terminal else ""
+    # The trailing terminal glyph is a decorative Icon (contentDescription = null in
+    # CommandsScreen.kt), so it is aria-hidden and stays unboxed like the candidate.
+    action = f'<span class="icon-btn action" aria-hidden="true">{TERMINAL}</span>' if terminal else ""
     bubbles = "\n      ".join(bubble(*m) for m in msgs)
     import json
     manifest = json.dumps({
@@ -172,11 +206,13 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
       .send {{ width: 44px; height: 44px; flex: none; display: flex;
         align-items: center; justify-content: center; color: var(--on-surface-variant); }}
       .send svg {{ width: 24px; height: 24px; }}
+{sysbar_style(inset)}
     </style>
   </head>
   <body>
+{SYSBAR_MARKUP}
     <div class="topbar">
-      <span class="icon-btn">{BACK}</span>
+      <span class="icon-btn" role="button" aria-label="Back">{BACK}</span>
       <div class="titles"><div class="title">{html.escape(title)}</div>{sub}</div>
       {action}
     </div>
@@ -185,7 +221,7 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
     </div>
     <div class="input">
       <div class="field">{html.escape(placeholder)}</div>
-      <span class="send">{SEND}</span>
+      <span class="send" role="button" aria-label="Send">{SEND}</span>
     </div>
     <script type="application/design-parity+json">
 {manifest}
@@ -195,22 +231,24 @@ def render(theme_name, t, title, subtitle, msgs, placeholder, terminal, componen
 """
 
 
+# inset = px the content is pushed down to match the candidate's status-bar inset
+# (the residual layout-diff Δpos dy each screen showed once the bars were added).
 SCREENS = [
-    ("ContactChat", "alice", "Direct message", contact, "Message", False,
+    ("ContactChat", "alice", "Direct message", contact, "Message", False, 0,
      "ContactChatPreview", "ContactChatDarkPreview"),
-    ("ChannelChat", "General", "Channel 0", channel, "Message", False,
+    ("ChannelChat", "General", "Channel 0", channel, "Message", False, 2,
      "ChannelChatPreview", "ChannelChatDarkPreview"),
-    ("Commands", "Commands", None, commands, "Enter command…", True,
+    ("Commands", "Commands", None, commands, "Enter command…", True, 2,
      "CommandsPreview", "CommandsDarkPreview"),
 ]
 CID = "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#{}"
 
 out_dir = os.path.join(os.path.dirname(__file__))
-for base, title, subtitle, msgs, placeholder, terminal, light_fn, dark_fn in SCREENS:
+for base, title, subtitle, msgs, placeholder, terminal, inset, light_fn, dark_fn in SCREENS:
     for theme, t, fn in (("light", LIGHT, light_fn), ("dark", DARK, dark_fn)):
         path = os.path.join(out_dir, f"{base}.{theme}.html")
         png = f"{base}.{theme}.png"
         with open(path, "w") as f:
-            f.write(render(theme, t, title, subtitle, msgs, placeholder, terminal,
+            f.write(render(theme, t, title, subtitle, msgs, placeholder, terminal, inset,
                            CID.format(fn), png))
         print("wrote", path)

--- a/design/gen_settings_refs.py
+++ b/design/gen_settings_refs.py
@@ -26,6 +26,34 @@ GEAR = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width
         'L16 2H8l-.5 2.6a7 7 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 0 0 3 12a7 7 0 0 0 .1 1.2l-2 1.6 '
         '2 3.4 2.4-1a7 7 0 0 0 2 1.2L8 22h8l.5-2.6a7 7 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6A7 7 0 0 0 19 12z"/></svg>')
 
+# System bars (showSystemUi = true): a status bar (9:30 + battery) and a gesture
+# nav pill, drawn as non-reflowing overlays. Shared verbatim with gen_chat_refs.py
+# — keep the two in sync. This screen's content is flush to the top, so it carries
+# the full status-bar inset (14px, the residual Δpos dy it showed once bars added).
+SYSBAR_INSET = 14
+SYSBAR_MARKUP = (
+    '    <div class="sysbar sysbar-top"><span>9:30</span><svg viewBox="0 0 24 12" fill="none" '
+    'stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="19" height="10" rx="2.5"/>'
+    '<rect x="3" y="3" width="11" height="6" rx="1" fill="currentColor" stroke="none"/>'
+    '<path d="M22 4.5v3" stroke-width="2" stroke-linecap="round"/></svg></div>\n'
+    '    <div class="sysbar sysbar-bottom"><span class="pill"></span></div>'
+)
+
+
+def sysbar_style(inset):
+    pad = f" padding-top: {inset}px;" if inset else ""
+    return f"""
+      /* System bars (showSystemUi = true): status bar + gesture nav pill drawn as
+         non-reflowing overlays. padding-top insets the content to the candidate's
+         status-bar inset (the residual layout-diff offset this screen showed once
+         the bars were added). */
+      body {{ position: relative;{pad} }}
+      .sysbar {{ position: absolute; left: 0; right: 0; pointer-events: none; color: var(--on-surface); }}
+      .sysbar-top {{ top: 0; height: 24px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; font-size: 13px; font-weight: 600; letter-spacing: 0.2px; }}
+      .sysbar-top svg {{ width: 22px; height: 12px; }}
+      .sysbar-bottom {{ bottom: 7px; display: flex; justify-content: center; }}
+      .sysbar-bottom .pill {{ width: 108px; height: 4px; border-radius: 2px; background: currentColor; }}"""
+
 
 def render(theme, t, fn, png):
     manifest = json.dumps({
@@ -97,13 +125,15 @@ def render(theme, t, fn, png):
       .switch {{ width: 52px; height: 32px; border-radius: 16px; position: relative; flex: none; background: var(--primary); }}
       .switch .thumb {{ position: absolute; top: 6px; right: 6px; width: 20px; height: 20px; border-radius: 50%; background: var(--on-primary); }}
       .divider {{ height: 1px; background: var(--outline-variant); margin: 8px 0; }}
+{sysbar_style(SYSBAR_INSET)}
     </style>
   </head>
   <body>
+{SYSBAR_MARKUP}
     <div class="topbar">
-      <span class="icon-btn">{BACK}</span>
+      <span class="icon-btn" role="button" aria-label="Back">{BACK}</span>
       <div class="title">Device Settings</div>
-      <span class="icon-btn action">{GEAR}</span>
+      <span class="icon-btn action" aria-hidden="true">{GEAR}</span>
     </div>
     <div class="content">
       <div class="row">
@@ -111,7 +141,7 @@ def render(theme, t, fn, png):
           <div class="label">Buzzer</div>
           <div class="sub">On (rtttl)</div>
         </div>
-        <div class="switch"><span class="thumb"></span></div>
+        <div class="switch" role="switch" aria-label="Buzzer" aria-checked="true"><span class="thumb"></span></div>
       </div>
       <div class="divider"></div>
     </div>


### PR DESCRIPTION
## Summary

Full resync of the reference generators (your call on the Codex review of #134),
plus the two control corrections Codex caught.

The chat/settings references are generated by `design/gen_chat_refs.py` /
`design/gen_settings_refs.py`, but everything added since they were last
touched — system bars (#131), per-screen insets (#132/#133), a11y markup
(#134) — was only hand-applied to the emitted HTML. Running the generators
would have **silently stripped all of it**. This brings the templates back to
source of truth and bakes in the fixes:

**Resync (templates now emit):**
- system-bar overlays (status bar + nav pill) + the per-screen `padding-top`
  inset — `ContactChat 0`, `ChannelChat`/`Commands` `2`, `DeviceSettings` `14`
- `role`/`aria-label` on back + send; `aria-hidden` on the decorative gear;
  `role="switch"` + `aria-label` on the Buzzer toggle

**Two corrections (Codex P2s):**
- 🐛 **Commands terminal glyph** is a decorative `Icon` (`contentDescription =
  null` in `CommandsScreen.kt:139`), not an `IconButton` — now `aria-hidden`
  instead of a `Tools` button, so the reference no longer exposes a control the
  candidate lacks. *(The DeviceScreen/CachedDevice "Tools" labels are correct —
  those come from `DeviceBody.kt:131`, `contentDescription = "Tools"`.)*
- **Buzzer switch** is checked in the Ready state — add `aria-checked="true"`.

## Test plan

- **Idempotent**: re-running both generators reproduces the committed HTML
  byte-for-byte (verified).
- Diff vs `main` is exactly: the two fixes + a standardized sysbar comment (the
  per-screen hand-notes collapse into one generator comment — cosmetic, no
  render change). All insets, message content, tokens, and other a11y preserved.
- DeviceBody references have **no generator** (hand-authored) and are untouched.

Addresses all three review comments on #134.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_