### PR TITLE
ci(design-parity): bump CLI to 0.1.16

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.14 run \
+          npx -y design-parity@0.1.16 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the design-parity CLI pin `0.1.14 → 0.1.16` in `design-parity.yml`. This
activates three merged design-parity features in meshcore's reports at once:

- **Typography** (0.1.15) — font-family normalized to its display name, so the
  candidate callout reads `Space Grotesk`, not `fonts/SpaceGrotesk.ttf`.
- **Accessible objects** (0.1.16) — the reference adapter now captures
  buttons/switches/icons, not just text leaves, so the `role`/`aria-label`
  markup added in #134 gets boxed and matched against the candidate's controls.
- **Diff highlights** (0.1.16) — the diff panel outlines *which elements* differ,
  not only which pixels.

`compose-preview`'s renderer pin (`0.16.0`) is separate and unchanged.

## Test plan

- Merge triggers the `Design parity artifacts` republish, which runs
  `npx design-parity@0.1.16` (verified published on npm).
- On the republish, expect: candidate typography reads `Space Grotesk · …`;
  control boxes (back/send/switch) appear on the reference side; the diff column
  highlights differing elements.

**Interplay note:** the Commands "Tools" phantom-button + Buzzer `aria-checked`
fixes live in the still-open #135 (generator resync). Until #135 merges, the
0.1.16 extractor will box the Commands decorative icon as an extra reference
control — i.e. it *surfaces* the bug #135 fixes. Merging both clears it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_