### PR TITLE
ci(design-parity): bump CLI to 0.1.17

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.16 run \
+          npx -y design-parity@0.1.17 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

Bump the design-parity CLI pin `0.1.16 → 0.1.17` (published on npm). This picks
up the **bundle-path font-family normalization** (design-parity#145): the
candidate typography callout now reads `Space Grotesk`, not
`fonts/SpaceGrotesk.ttf` — closing the one feature that 0.1.16 didn't deliver on
the `--candidate-bundles` path meshcore uses.

The accessible-object boxes and the diff-panel element highlights already landed
with the 0.1.16 bump (#136). `compose-preview`'s renderer pin (`0.16.0`) is
unchanged.

## Test plan

- Merge triggers the `Design parity artifacts` republish (`npx design-parity@0.1.17`).
- On the republish, confirm the candidate typography callout reads
  `Space Grotesk · 16sp · …` (was `fonts/SpaceGrotesk.ttf · …`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_