### PR TITLE
fix(design-parity): label the DeviceBody reference icons

### DIFF
--- a/design/DeviceScreen.dark.html
+++ b/design/DeviceScreen.dark.html
@@ -233,7 +233,7 @@
         <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="empty empty-center">
-        <svg role="img" aria-label="Contact" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg>
+        <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg>
         <span>No contacts yet</span>
       </div>
 

--- a/design/DeviceScreen.dark.html
+++ b/design/DeviceScreen.dark.html
@@ -192,20 +192,20 @@
       <div class="summary">
         <div class="node-name">node-peak</div>
         <div class="line mono">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 11a2 2 0 0 0-2 2c0 2 .5 3 .5 5"/><path d="M7 13a5 5 0 0 1 10 0c0 1 0 2-.3 3"/><path d="M4 13a8 8 0 0 1 16 0"/></svg>
+          <svg role="img" aria-label="Public key" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 11a2 2 0 0 0-2 2c0 2 .5 3 .5 5"/><path d="M7 13a5 5 0 0 1 10 0c0 1 0 2-.3 3"/><path d="M4 13a8 8 0 0 1 16 0"/></svg>
           abababababababab
         </div>
         <div class="line">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M5 12.5a10 10 0 0 1 14 0"/><path d="M8.5 16a5 5 0 0 1 7 0"/><circle cx="12" cy="19" r="1.2" fill="currentColor" stroke="none"/></svg>
+          <svg role="img" aria-label="Radio" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M5 12.5a10 10 0 0 1 14 0"/><path d="M8.5 16a5 5 0 0 1 7 0"/><circle cx="12" cy="19" r="1.2" fill="currentColor" stroke="none"/></svg>
           869.525 MHz · BW 125 kHz · SF 10 · CR 5
         </div>
         <div class="line battery-row">
-          <svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="3" width="8" height="18" rx="1.5"/><rect x="10" y="1.5" width="4" height="2" rx="0.5"/></svg>
+          <svg role="img" aria-label="Battery" viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="3" width="8" height="18" rx="1.5"/><rect x="10" y="1.5" width="4" height="2" rx="0.5"/></svg>
           81% · 3980 mV
         </div>
         <div class="progress"><span></span></div>
         <div class="line storage">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+          <svg role="img" aria-label="Storage" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
           512 / 4096 kB
         </div>
       </div>
@@ -222,7 +222,7 @@
       <!-- Channels (none configured) -->
       <div class="section-h">
         <span class="label">Channels (0)</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="empty">No channels configured</div>
 
@@ -230,10 +230,10 @@
       <div class="section-h">
         <span class="label">Contacts (0)</span>
         <span class="chip">Favourited</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="empty empty-center">
-        <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg>
+        <svg role="img" aria-label="Contact" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg>
         <span>No contacts yet</span>
       </div>
 
@@ -241,7 +241,7 @@
       <div class="section-h">
         <span class="label">Rooms (0)</span>
         <span class="chip">Joined</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="empty">No rooms joined yet</div>
 
@@ -249,7 +249,7 @@
       <div class="section-h">
         <span class="label">Repeaters (0)</span>
         <span class="chip">Joined</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="empty">No repeaters joined yet</div>
 

--- a/design/DeviceScreen.light.html
+++ b/design/DeviceScreen.light.html
@@ -190,27 +190,27 @@
       <div class="summary">
         <div class="node-name">node-peak</div>
         <div class="line mono">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 11a2 2 0 0 0-2 2c0 2 .5 3 .5 5"/><path d="M7 13a5 5 0 0 1 10 0c0 1 0 2-.3 3"/><path d="M4 13a8 8 0 0 1 16 0"/></svg>
+          <svg role="img" aria-label="Public key" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 11a2 2 0 0 0-2 2c0 2 .5 3 .5 5"/><path d="M7 13a5 5 0 0 1 10 0c0 1 0 2-.3 3"/><path d="M4 13a8 8 0 0 1 16 0"/></svg>
           abababababababab
         </div>
         <div class="line">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M5 12.5a10 10 0 0 1 14 0"/><path d="M8.5 16a5 5 0 0 1 7 0"/><circle cx="12" cy="19" r="1.2" fill="currentColor" stroke="none"/></svg>
+          <svg role="img" aria-label="Radio" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M5 12.5a10 10 0 0 1 14 0"/><path d="M8.5 16a5 5 0 0 1 7 0"/><circle cx="12" cy="19" r="1.2" fill="currentColor" stroke="none"/></svg>
           869.525 MHz · BW 125 kHz · SF 10 · CR 5
         </div>
         <div class="line battery-row">
-          <svg viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="3" width="8" height="18" rx="1.5"/><rect x="10" y="1.5" width="4" height="2" rx="0.5"/></svg>
+          <svg role="img" aria-label="Battery" viewBox="0 0 24 24" fill="currentColor"><rect x="8" y="3" width="8" height="18" rx="1.5"/><rect x="10" y="1.5" width="4" height="2" rx="0.5"/></svg>
           81% · 3980 mV
         </div>
         <div class="progress"><span></span></div>
         <div class="line storage">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+          <svg role="img" aria-label="Storage" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
           512 / 4096 kB
         </div>
       </div>
 
       <!-- Last message banner -->
       <div class="banner">
-        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 4h18v13H7l-4 4z"/></svg>
+        <svg role="img" aria-label="New message" viewBox="0 0 24 24" fill="currentColor"><path d="M3 4h18v13H7l-4 4z"/></svg>
         <div>
           <div class="who">alice</div>
           <div class="text">hey — are you on tonight?</div>
@@ -221,10 +221,10 @@
       <div class="section-h">
         <span class="label">Channels (1)</span>
         <span class="chip">Favourited</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="row">
-        <div class="avatar amber"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
+        <div class="avatar amber"><svg role="img" aria-label="Channel" viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
         <div>
           <div class="name">General</div>
           <div class="sub">Channel 0</div>
@@ -235,10 +235,10 @@
       <div class="section-h">
         <span class="label">Contacts (1)</span>
         <span class="chip">Favourited</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="row">
-        <div class="avatar"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg></div>
+        <div class="avatar"><svg role="img" aria-label="Contact" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg></div>
         <div>
           <div class="name">alice</div>
           <div class="sub">Contact · flood</div>
@@ -249,10 +249,10 @@
       <div class="section-h">
         <span class="label">Rooms (1)</span>
         <span class="chip">Joined</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="row">
-        <div class="avatar"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
+        <div class="avatar"><svg role="img" aria-label="Room" viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
         <div>
           <div class="name">common-room</div>
           <div class="sub">Room · 0 hops</div>
@@ -263,14 +263,14 @@
       <div class="section-h">
         <span class="label">Repeaters (0)</span>
         <span class="chip">Joined</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
       <div class="empty">No repeaters joined yet</div>
 
       <!-- Sensors -->
       <div class="section-h">
         <span class="label">Sensors (1)</span>
-        <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

Follow-up to the box-matching review on the DeviceBody (`node-peak`) report. With
the 0.1.16 accessible-objects extractor, the candidate boxes **50** elements vs
the reference's **24** — the gap is the candidate's icon `Image`s
(`Radio`/`Battery`/`Storage`/avatars/section carets/…) which carry content
descriptions, while the reference's matching SVGs were **decorative** (no
`role`/`aria-label`) so they weren't boxed or matched.

Per the call to label the reference icons, give each informative reference icon
`role="img"` + an `aria-label` matching the candidate's `contentDescription`, so
the relevant boxes correspond on both sides — and the references gain real a11y
labels (the extractor reads `aria-label` as the node label, so they also **match
by label** in the layout diff).

- **light (populated):** `Public key`, `Radio`, `Battery`, `Storage`,
  `New message`, `Collapse` (×5 section carets), `Channel`/`Contact`/`Room`
  avatars — 13 icons.
- **dark:** the rock-solid subset — summary icons + the 4 section carets.

## Hand-authored, no generator
`DeviceScreen.{light,dark}.html` aren't generated (unlike the chat/settings
references), so these are direct edits. Labels were derived from the candidate
`semantics.json` in the published bundle and applied with per-icon assertions.

## Test plan
- Merge triggers the republish; on it, the DeviceBody reference box count should
  rise toward the candidate's and the icons should pair up by label.

## Deliberately not labeled (genuine content differences, not decoration)
- The dark **empty-contact** icon: Codex correctly noted it is decorative in
  `ContactListEmpty()` (`contentDescription = null`), and the dark candidate is
  actually *populated* (`Contacts (1)`), so labeling the reference's empty-state
  icon would create an unmatched box — reverted it.
- The dark banner's `Dismiss` control and the dark empty-channel illustration
  exist in the candidate but not the reference — flagged for a follow-up.
- No visual render is available in this environment, so the republish diff is the
  verification.