### PR TITLE
fix(design-parity): match DeviceBody reference typography to the candidate

### DIFF
--- a/design/DeviceScreen.dark.html
+++ b/design/DeviceScreen.dark.html
@@ -70,8 +70,9 @@
       .topbar .title {
         flex: 1;
         font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
-        font-size: 22px;
-        font-weight: 700;
+        font-size: 20px;
+        font-weight: 500;
+        line-height: 28px;
         letter-spacing: 0.2px;
         color: var(--on-surface);
       }
@@ -101,12 +102,13 @@
       }
       .summary .node-name {
         font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
-        font-size: 22px;
-        font-weight: 700;
+        font-size: 20px;
+        font-weight: 500;
+        line-height: 28px;
         color: var(--on-surface);
         margin-bottom: 0px;
       }
-      .line { display: flex; align-items: center; gap: 10px; color: var(--on-surface-variant); font-size: 15px; }
+      .line { display: flex; align-items: center; gap: 10px; color: var(--on-surface-variant); font-size: 14px; line-height: 20px; }
       .line svg { width: 18px; height: 18px; flex: none; }
       .line.mono { font-family: "JetBrains Mono", ui-monospace, monospace; letter-spacing: 0.5px; }
       .battery-row { color: var(--on-surface-variant); }
@@ -115,7 +117,7 @@
         margin: 1px 0 2px; overflow: hidden;
       }
       .progress > span { display: block; height: 100%; width: 81%; background: var(--primary); border-radius: 2px; }
-      .storage { font-size: 13px; }
+      .storage { font-size: 12px; line-height: 16px; }
 
       /* ---- Last-message banner (outlined card) ---- */
       .banner {
@@ -127,8 +129,8 @@
         gap: 8px;
       }
       .banner svg { width: 22px; height: 22px; color: var(--primary); flex: none; }
-      .banner .who { font-size: 12px; font-weight: 600; color: var(--primary); }
-      .banner .text { font-size: 15px; color: var(--on-surface); }
+      .banner .who { font-size: 12px; font-weight: 700; line-height: 16px; color: var(--primary); }
+      .banner .text { font-size: 14px; line-height: 20px; color: var(--on-surface); }
 
       /* ---- Section headers ---- */
       .section-h {
@@ -136,11 +138,11 @@
         padding: 12px 0;
         color: var(--on-surface-variant);
       }
-      .section-h .label { flex: 1; font-size: 15px; font-weight: 600; }
+      .section-h .label { flex: 1; font-size: 14px; font-weight: 500; line-height: 20px; }
       .chip {
         background: var(--secondary-container);
         color: var(--on-secondary-container);
-        font-size: 13px; font-weight: 600;
+        font-size: 14px; font-weight: 700; line-height: 20px;
         padding: 6px 14px; border-radius: 8px;
       }
       .section-h .caret { width: 20px; height: 20px; color: var(--on-surface-variant); }
@@ -159,9 +161,9 @@
       }
       .avatar.amber { background: var(--tertiary-container); color: var(--on-tertiary-container); }
       .avatar svg { width: 20px; height: 20px; }
-      .row .name { font-size: 16px; font-weight: 600; color: var(--on-surface); }
-      .row .sub { font-size: 13px; color: var(--on-surface-variant); }
-      .empty { font-size: 13px; color: var(--on-surface-variant); padding: 8px 0; }
+      .row .name { font-size: 16px; font-weight: 600; line-height: 24px; color: var(--on-surface); }
+      .row .sub { font-size: 12px; line-height: 16px; color: var(--on-surface-variant); }
+      .empty { font-size: 12px; line-height: 16px; color: var(--on-surface-variant); padding: 8px 0; }
       .empty-center { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 0; }
       .empty-center svg { width: 20px; height: 20px; }
     

--- a/design/DeviceScreen.light.html
+++ b/design/DeviceScreen.light.html
@@ -70,8 +70,9 @@
       .topbar .title {
         flex: 1;
         font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
-        font-size: 22px;
-        font-weight: 700;
+        font-size: 20px;
+        font-weight: 500;
+        line-height: 28px;
         letter-spacing: 0.2px;
         color: var(--on-surface);
       }
@@ -101,12 +102,13 @@
       }
       .summary .node-name {
         font-family: "Orbitron", "Space Grotesk", system-ui, sans-serif;
-        font-size: 22px;
-        font-weight: 700;
+        font-size: 20px;
+        font-weight: 500;
+        line-height: 28px;
         color: var(--on-surface);
         margin-bottom: 0px;
       }
-      .line { display: flex; align-items: center; gap: 10px; color: var(--on-surface-variant); font-size: 15px; }
+      .line { display: flex; align-items: center; gap: 10px; color: var(--on-surface-variant); font-size: 14px; line-height: 20px; }
       .line svg { width: 18px; height: 18px; flex: none; }
       .line.mono { font-family: "JetBrains Mono", ui-monospace, monospace; letter-spacing: 0.5px; }
       .battery-row { color: var(--on-surface-variant); }
@@ -115,7 +117,7 @@
         margin: 1px 0 2px; overflow: hidden;
       }
       .progress > span { display: block; height: 100%; width: 81%; background: var(--primary); border-radius: 2px; }
-      .storage { font-size: 13px; }
+      .storage { font-size: 12px; line-height: 16px; }
 
       /* ---- Last-message banner (outlined card) ---- */
       .banner {
@@ -127,8 +129,8 @@
         gap: 8px;
       }
       .banner svg { width: 22px; height: 22px; color: var(--primary); flex: none; }
-      .banner .who { font-size: 12px; font-weight: 600; color: var(--primary); }
-      .banner .text { font-size: 15px; color: var(--on-surface); }
+      .banner .who { font-size: 12px; font-weight: 700; line-height: 16px; color: var(--primary); }
+      .banner .text { font-size: 14px; line-height: 20px; color: var(--on-surface); }
 
       /* ---- Section headers ---- */
       .section-h {
@@ -136,11 +138,11 @@
         padding: 12px 0;
         color: var(--on-surface-variant);
       }
-      .section-h .label { flex: 1; font-size: 15px; font-weight: 600; }
+      .section-h .label { flex: 1; font-size: 14px; font-weight: 500; line-height: 20px; }
       .chip {
         background: var(--secondary-container);
         color: var(--on-secondary-container);
-        font-size: 13px; font-weight: 600;
+        font-size: 14px; font-weight: 700; line-height: 20px;
         padding: 6px 14px; border-radius: 8px;
       }
       .section-h .caret { width: 20px; height: 20px; color: var(--on-surface-variant); }
@@ -159,9 +161,9 @@
       }
       .avatar.amber { background: var(--tertiary-container); color: var(--on-tertiary-container); }
       .avatar svg { width: 20px; height: 20px; }
-      .row .name { font-size: 16px; font-weight: 600; color: var(--on-surface); }
-      .row .sub { font-size: 13px; color: var(--on-surface-variant); }
-      .empty { font-size: 13px; color: var(--on-surface-variant); padding: 8px 0; }
+      .row .name { font-size: 16px; font-weight: 600; line-height: 24px; color: var(--on-surface); }
+      .row .sub { font-size: 12px; line-height: 16px; color: var(--on-surface-variant); }
+      .empty { font-size: 12px; line-height: 16px; color: var(--on-surface-variant); padding: 8px 0; }
     
       /* System bars (showSystemUi = true): status bar + gesture nav pill, drawn
          as non-reflowing overlays so the app content keeps its measured place. */


### PR DESCRIPTION
## Summary

"Trim the reference typography to just match the candidate" on DeviceBody — the
**exact** match you picked (sizes, weights, **and** line-heights). Values were
read from the candidate `semantics.json` in the published bundle and mapped to
the reference's CSS rules:

| element | reference (was) | candidate (now) |
|---|---|---|
| Orbitron node name / app-bar title | `22px / 700` | `20sp / 500 · lh 28` |
| summary lines (signal/battery/mono) | `15px` | `14sp · lh 20` |
| storage line | `13px` | `12sp · lh 16` |
| section labels | `15px / 600` | `14sp / 500 · lh 20` |
| chips (Favourited/Joined) | `13px / 600` | `14sp / 700 · lh 20` |
| row name | `16px / 600` | `16sp / 600 · lh 24` |
| row sub | `13px` | `12sp · lh 16` |
| empty text | `13px` | `12sp · lh 16` |
| banner who / text | `12/600`, `15px` | `12/700 · lh16`, `14sp · lh20` |

Typography is theme-invariant, so the same 11 rules are applied to both
`DeviceScreen.light.html` and `DeviceScreen.dark.html`.

## Test plan
- Merge triggers the republish; the DeviceBody **Typography** layer should read
  identically on both panels and the type deltas should clear. No render is
  available in this environment, so the republish is the verification — I'll tune
  if any value is off.

## Independent of the other DeviceBody PRs
This is CSS-only (the `<style>` block); the icon-label PR (#138) is body-only, so
they don't conflict.

---
**Separate finding (not in this PR):** the dark variant's *reference* is the
empty state while its *candidate* is populated (`Contacts (1)` / `Contact ·
flood`). That state mismatch drives real deltas independent of type/boxes — worth
reconciling the dark reference's content in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy14QBxTubKHt4VtE5irGZ)_