### PR TITLE
fix(design-parity): populate the dark DeviceBody reference to match its candidate

### DIFF
--- a/design/DeviceScreen.dark.html
+++ b/design/DeviceScreen.dark.html
@@ -212,31 +212,39 @@
         </div>
       </div>
 
-      <!-- Last message banner -->
+      <!-- Cached-data banner (offline; dismissable) -->
       <div class="banner">
-        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 4h18v13H7l-4 4z"/></svg>
-        <div>
-          <div class="who">alice</div>
-          <div class="text">hey — are you on tonight?</div>
-        </div>
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 18a4 4 0 0 1-.5-7.97A6 6 0 0 1 18 8.5 3.5 3.5 0 0 1 17.5 18z"/></svg>
+        <div class="text" style="flex:1">Cached data — connect to refresh</div>
+        <svg role="img" aria-label="Dismiss" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="width:20px;height:20px;color:var(--on-surface-variant)"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
       </div>
 
-      <!-- Channels (none configured) -->
+      <!-- Channels -->
       <div class="section-h">
-        <span class="label">Channels (0)</span>
-        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
-      </div>
-      <div class="empty">No channels configured</div>
-
-      <!-- Contacts (none favourited) -->
-      <div class="section-h">
-        <span class="label">Contacts (0)</span>
+        <span class="label">Channels (1)</span>
         <span class="chip">Favourited</span>
         <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
       </div>
-      <div class="empty empty-center">
-        <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg>
-        <span>No contacts yet</span>
+      <div class="row">
+        <div class="avatar amber"><svg role="img" aria-label="Channel" viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="9" r="3"/><circle cx="16" cy="10" r="2.4"/><path d="M3 19c0-3 3-5 6-5s6 2 6 5z"/><path d="M14 19c0-2 1-3.5 3-4 2.2 0 4 1.6 4 4z"/></svg></div>
+        <div>
+          <div class="name">General</div>
+          <div class="sub">Channel 0</div>
+        </div>
+      </div>
+
+      <!-- Contacts -->
+      <div class="section-h">
+        <span class="label">Contacts (1)</span>
+        <span class="chip">Favourited</span>
+        <svg class="caret" role="img" aria-label="Collapse" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="6 15 12 9 18 15"/></svg>
+      </div>
+      <div class="row">
+        <div class="avatar"><svg role="img" aria-label="Contact" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-6 8-6s8 2 8 6z"/></svg></div>
+        <div>
+          <div class="name">alice</div>
+          <div class="sub">Contact · flood</div>
+        </div>
       </div>
 
       <!-- Rooms (none joined) -->


### PR DESCRIPTION
## Summary

The dark DeviceBody reference (`DeviceScreen.dark.html`) was authored as a
mostly-**empty** state, but `DeviceBodyDarkPreview` renders a **populated**
fixture. So the reference and candidate were in *different states* and the
design-parity diff reported content deltas that weren't design intent (an
unmatched populated avatar vs. a decorative empty-state icon, missing rows, the
wrong banner). This surfaced while landing the icon-label (#138) and typography
(#139) PRs.

This brings the dark reference to the candidate's **actual** state, read from its
`semantics.json` in the published bundle:

| section | was (empty ref) | now (matches candidate) |
|---|---|---|
| banner | last-message `alice / hey…` | **Cached data — connect to refresh** + `Dismiss` ✕ |
| Channels | `(0)` "No channels configured" | `(1)` Favourited → **General** / Channel 0 |
| Contacts | `(0)` "No contacts yet" | `(1)` Favourited → **alice** / Contact · flood |
| Rooms | `(0)` "No rooms joined yet" | unchanged — already matched |
| Repeaters | `(0)` "No repeaters joined yet" | unchanged — already matched |

The labelled-node sequence now lines up 1:1 with the candidate (summary icons →
Dismiss → 4 sections with `Collapse` carets → 2 populated rows with
`Channel`/`Contact` avatars), and the decorative empty-contact icon that Codex
flagged on #138 is gone (it's a real populated row now).

## The dark fixture ≠ the light fixture
Worth calling out: I did **not** copy the light reference. The dark fixture is
genuinely different — light has a last-message banner, `Rooms (1)`, and a
`Sensors` section; dark has the cached-data banner, empty Rooms, and **no
Sensors**. This mirrors the dark candidate specifically.

## Test plan
- HTML validated as well-formed (balanced tags); structure check: 4 sections, 2
  populated rows, 2 empty states, 4 chips — matching the candidate.
- Merge triggers the republish; on it the dark panel's content deltas should
  clear (state now matches), alongside the box/label and typography work already
  on `main`. No render is available in this environment, so the republish diff is
  the verification.