### PR TITLE
feat(design-parity): adopt 0.1.18 and sync MeshCore design tokens

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.17 run \
+          npx -y design-parity@0.1.18 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \

--- a/design-map.json
+++ b/design-map.json
@@ -5,73 +5,85 @@
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#DeviceBodyPreview",
       "source": "claude-design",
       "ref": "design/DeviceScreen.light.html",
-      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.DeviceBodyPreview_Device — populated"
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.DeviceBodyPreview_Device — populated",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#DeviceBodyDarkPreview",
       "source": "claude-design",
       "ref": "design/DeviceScreen.dark.html",
-      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.DeviceBodyDarkPreview_Device — dark"
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.DeviceBodyDarkPreview_Device — dark",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatPreview",
       "source": "claude-design",
       "ref": "design/ContactChat.light.html",
-      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Contact chat"
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Contact chat",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatDarkPreview",
       "source": "claude-design",
       "ref": "design/ContactChat.dark.html",
-      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatDarkPreview_Contact chat — dark"
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatDarkPreview_Contact chat — dark",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatPreview",
       "source": "claude-design",
       "ref": "design/ChannelChat.light.html",
-      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatPreview_Channel chat"
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatPreview_Channel chat",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatDarkPreview",
       "source": "claude-design",
       "ref": "design/ChannelChat.dark.html",
-      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatDarkPreview_Channel chat — dark"
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatDarkPreview_Channel chat — dark",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsPreview",
       "source": "claude-design",
       "ref": "design/Commands.light.html",
-      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsPreview_Commands"
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsPreview_Commands",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsDarkPreview",
       "source": "claude-design",
       "ref": "design/Commands.dark.html",
-      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsDarkPreview_Commands — dark"
+      "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsDarkPreview_Commands — dark",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyPreview",
       "source": "claude-design",
       "ref": "design/CachedDevice.light.html",
-      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyPreview_Cached device"
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyPreview_Cached device",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyDarkPreview",
       "source": "claude-design",
       "ref": "design/CachedDevice.dark.html",
-      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyDarkPreview_Cached device — dark"
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyDarkPreview_Cached device — dark",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsPreview",
       "source": "claude-design",
       "ref": "design/DeviceSettings.light.html",
-      "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsPreview_Device settings"
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsPreview_Device settings",
+      "tokensFile": "design/meshcore.tokens.json"
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsDarkPreview",
       "source": "claude-design",
       "ref": "design/DeviceSettings.dark.html",
-      "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsDarkPreview_Device settings — dark"
+      "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsDarkPreview_Device settings — dark",
+      "tokensFile": "design/meshcore.tokens.json"
     }
   ]
 }

--- a/design/meshcore.tokens.json
+++ b/design/meshcore.tokens.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://github.com/yschimke/design-parity/schema/dtcg-tokens.schema.json",
+  "$description": "MeshCore design-system tokens (Material 3, seed teal #00695C), the committed artifact a Claude Code /design-sync run materialises from the Claude Design system. Single source of truth shared with meshcore-components/.../theme/MeshcoreTokens.kt; consumed by design-parity as each claude-design component's spec tokens via design-map.json `tokensFile`. Colours are the light scheme (the canonical design-system values).",
+  "color": {
+    "$type": "color",
+    "primary": { "$value": "#006A60" },
+    "on-primary": { "$value": "#FFFFFF" },
+    "primary-container": { "$value": "#74F8E5" },
+    "on-primary-container": { "$value": "#00201C" },
+    "secondary": { "$value": "#4A635F" },
+    "on-secondary": { "$value": "#FFFFFF" },
+    "secondary-container": { "$value": "#CCE8E2" },
+    "on-secondary-container": { "$value": "#05201C" },
+    "tertiary": { "$value": "#715B2E" },
+    "on-tertiary": { "$value": "#FFFFFF" },
+    "tertiary-container": { "$value": "#FDDFA6" },
+    "on-tertiary-container": { "$value": "#261A00" },
+    "error": { "$value": "#BA1A1A" },
+    "on-error": { "$value": "#FFFFFF" },
+    "error-container": { "$value": "#FFDAD6" },
+    "on-error-container": { "$value": "#410002" },
+    "surface": { "$value": "#F4FBF8" },
+    "on-surface": { "$value": "#161D1B" },
+    "surface-variant": { "$value": "#DAE5E1" },
+    "on-surface-variant": { "$value": "#3F4946" },
+    "outline": { "$value": "#6F7976" },
+    "outline-variant": { "$value": "#BEC9C5" },
+    "surface-container-lowest": { "$value": "#FFFFFF" },
+    "surface-container-low": { "$value": "#EEF5F2" },
+    "surface-container": { "$value": "#E8EFEC" },
+    "surface-container-high": { "$value": "#E2E9E6" },
+    "surface-container-highest": { "$value": "#DCE3E0" }
+  },
+  "shape": {
+    "$type": "dimension",
+    "corner-extra-small": { "$value": "4px" },
+    "corner-small": { "$value": "8px" },
+    "corner-medium": { "$value": "12px" },
+    "corner-large": { "$value": "16px" },
+    "corner-extra-large": { "$value": "28px" }
+  },
+  "space": {
+    "$type": "dimension",
+    "inset": { "$value": "16px" },
+    "gutter": { "$value": "8px" }
+  }
+}

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -21,7 +21,8 @@ All render on the CMP desktop backend from `:meshcore-components` `commonMain`.
 | `design/CachedDevice.{light,dark}.html` | The cached (offline) Device references (`CachedDeviceBodyPreview` etc.) — the Device reference plus the `tertiaryContainer` "Cached data" warning banner. |
 | `design/ContactChat.{light,dark}.html`, `design/ChannelChat.{light,dark}.html`, `design/Commands.{light,dark}.html` | The chat screen references (`ContactChatPreview` etc.), authored from the MeshCore M3 scheme; `design/gen_chat_refs.py` is the re-runnable generator that emits them. |
 | `design/DeviceSettings.{light,dark}.html` | The Device Settings references (`DeviceSettingsPreview` etc.) — the discovered buzzer-toggle state; `design/gen_settings_refs.py` is the generator. |
-| `design-map.json` | Correspondence: each preview-function code handle ↔ its reference, plus the `previewId` that reconciles the compose-preview render id with the handle. |
+| `design/meshcore.tokens.json` | The MeshCore design-system tokens as a committed [W3C DTCG](https://tr.designtokens.org/) document — the artifact a Claude Code [`/design-sync`](#synced-design-system-tokens) run materialises from the Claude Design system (M3 colour roles + shape radii + spacing). Mirrors `meshcore-components/.../theme/MeshcoreTokens.kt`. |
+| `design-map.json` | Correspondence: each preview-function code handle ↔ its reference, plus the `previewId` that reconciles the compose-preview render id with the handle, plus the `tokensFile` that points every component at the synced `design/meshcore.tokens.json` spec tokens. |
 | `.design-parity.json` | Parity direction. **`code-led`** (advisory) for now — flip to `design-led` once thresholds are calibrated. |
 
 The reference PNGs the manifests' `src` point to (`design/*.png`) are **generated
@@ -30,6 +31,43 @@ rendered on demand (see below). The current renders, plus the candidate bundle
 and `report.html` triptychs, live on the
 [`design-parity/main`](https://github.com/yschimke/meshcore-mobile/tree/design-parity/main)
 branch, regenerated on every push to `main`.
+
+## Synced design-system tokens (`/design-sync`)
+
+Each `design-map.json` entry carries a **`tokensFile`** pointing at
+`design/meshcore.tokens.json` — the MeshCore design system as a committed
+[W3C DTCG](https://tr.designtokens.org/) document. This is the artifact a
+[Claude Code `/design-sync`](https://github.com/yschimke/design-parity/blob/main/docs/claude-design-sync-impact.md)
+run materialises from the Claude Design system: the M3 colour roles, shape
+radii, and spacing, on disk and deterministic. design-parity loads it as each
+component's **spec tokens** (`@design-parity/adapter-claude-design` ≥ 0.1.18
+consumes `/design-sync` token artifacts) and runs them through the
+token-compliance diff against the candidate's resolved tokens — so the
+references no longer report "missing from candidate" for tokens (the
+[first-adoption gap](#known-gaps-first-adoption) for the token half).
+
+Because Claude Design exposes **no read API**, the file is committed, not fetched
+at run time — `/design-sync` produces it, design-parity enforces it. It is the
+**single source of truth** with `MeshcoreTokens.kt`: change one, change the
+other (the colours here are the light scheme — the canonical design-system
+values). Pointing every entry at the one file keeps the design system in one
+place; the loader caches it, so the 12 entries cost one parse.
+
+### Uploading back to Claude Design (the reverse direction)
+
+design-parity is **read-only on Claude Design**: it resolves a committed
+reference and diffs it, and ships **no `claude-design` canvas writer** (see
+[design-parity's reconciliation note](https://github.com/yschimke/design-parity/blob/main/docs/claude-design-sync-impact.md#follow-ups)).
+Getting what you built *into* Claude Design is **`/design-sync`'s** job — an
+**interactive, human-run** Claude Code skill, deliberately off the unattended
+Action path. So the round trip is: `/design-sync` (human, in a terminal) seeds
+`design/meshcore.tokens.json`; this workflow (CI) then enforces it on every PR.
+
+The push-back can't run in an unattended cloud agent session: `/design-sync`
+isn't installed there (it lands in new local sessions; `/update` if absent), and
+there is no Claude Design write API or credential to call. To upload, run
+`/design-sync` yourself from a local Claude Code session with Claude Design beta
+access.
 
 ## Render path
 
@@ -126,7 +164,7 @@ reference | candidate | diff without re-rendering locally.
 
 The workflow drives the render from `design-map.json` (so it can't drift from
 it): it installs the released `compose-preview` CLI, packs the candidate bundle,
-runs the published `design-parity` CLI (`npx design-parity@0.1.8`), and publishes
+runs the published `design-parity` CLI (`npx design-parity@0.1.18`), and publishes
 the output. The permanent-branch push is still the interim, hand-rolled version
 of a pattern design-parity's Action should own —
 [design-parity#56](https://github.com/yschimke/design-parity/issues/56) (modeled


### PR DESCRIPTION
## Summary

Adopt design-parity **0.1.18** and wire MeshCore's design system into the parity check as synced spec tokens.

- Bump the pinned CLI `design-parity@0.1.17 → 0.1.18` in `design-parity.yml`. The 0.1.18 `claude-design` adapter consumes `/design-sync` token artifacts.
- Add `design/meshcore.tokens.json`: the MeshCore design system (M3 colour roles + shape radii + spacing) as a committed **W3C DTCG** document — the artifact a Claude Code `/design-sync` run materialises from Claude Design. Single source of truth with `meshcore-components/.../theme/MeshcoreTokens.kt`.
- Point every `design-map.json` entry at it via `tokensFile`, so the token-compliance diff runs against real spec tokens instead of reporting them missing from the candidate.
- Docs: add a synced-tokens section + a note on the reverse direction (uploading back to Claude Design is `/design-sync`'s interactive, human-run job; the unattended Action stays read-only). Fix a stale `@0.1.8` CLI reference.

## Test plan

- `design-parity@0.1.18` is published to npm (`latest = 0.1.18`; scoped packages too), so the pinned CLI resolves.
- `validate-dtcg design/meshcore.tokens.json` → valid, 34 tokens; `loadDtcgTokens` parses to 27 colours + spacing, no warnings.
- `validate-design-map design-map.json` → valid (12 components, all carrying `tokensFile`).
- End-to-end token-diff yield surfaces on the next push to `main`, where the workflow renders the CMP-desktop candidate and publishes the report to the `design-parity/main` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBdQMYuAhC9KDGGapBsotd)_