### PR TITLE
feat: publish MeshCore design system report

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -1,0 +1,111 @@
+name: Design Artifacts
+
+# Render the MeshCore design catalog (:app @Preview sticker sheet) and publish
+# its importable bundle (catalog.json + DTCG tokens + Figma variables + PNGs) to
+# a clean `design-artifacts/meshcore-mobile` branch. The public preview server
+# (preview.coo.ee) fetches that branch and serves it at /meshcore-mobile/.
+#
+# Pipeline mirrors compose-ai-tools' own design-artifacts job:
+#   compose-preview bundle pack  →  @design-parity/catalog-export driver
+#   (from a compose-ai-tools checkout)  →  force-push out/ to the branch.
+
+on:
+  # Weekly, so the published sticker sheet tracks the catalog as it evolves.
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      allow_incomplete:
+        description: 'Publish even if some catalog previews fail to render or lack semantics (use for the first run while tuning the spec).'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: design-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: meshcore-mobile
+    # Don't run on forks — the publish step pushes a branch into this repo.
+    if: ${{ github.repository == 'yschimke/meshcore-mobile' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
+
+      # JDK 21 + Gradle. The Android SDK is preinstalled on ubuntu-latest, which
+      # is what the :app Robolectric render needs (same as compose-preview.yml).
+      - uses: ./.github/actions/setup
+
+      # Install the compose-preview CLI, pinned to the applied plugin version
+      # (composePreviewPlugin in libs.versions.toml) so the CLI and plugin stay
+      # in lockstep — exactly as compose-preview.yml does for the apply action.
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.15.9
+        with:
+          version: catalog
+          catalog-key: composePreviewPlugin
+          github-token: ${{ github.token }}
+
+      # The export driver + its render helpers live in compose-ai-tools; check it
+      # out (public repo) so we can run scripts/design-artifacts/. Pin CAT_REF to a
+      # release tag for full reproducibility once the path-URL changes have shipped.
+      - uses: actions/checkout@v6.0.3
+        with:
+          repository: yschimke/compose-ai-tools
+          ref: main
+          path: compose-ai-tools
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+      - name: Install export engine (pinned npm packages)
+        working-directory: compose-ai-tools/scripts/design-artifacts
+        run: npm ci
+
+      # Render the catalog module into a portable bundle with semantics (a11y
+      # greenlines + layout tree → tokens/wireframes in the exported catalog).
+      - name: Render catalog bundle
+        run: |
+          set -euo pipefail
+          compose-preview bundle pack --module :app --with-semantics \
+            -o "$GITHUB_WORKSPACE/meshcore-mobile-bundle.png"
+
+      # Join the render to catalog.spec.json and write the importable bundle.
+      # `source: {repo, ref, module}` lets a trusted, toolchain-equipped box
+      # live-rerender; it's inert on the desktop-only public server.
+      - name: Generate importable catalog
+        run: |
+          set -euo pipefail
+          node compose-ai-tools/scripts/design-artifacts/generate-design-catalog.mjs \
+            --spec catalog.spec.json \
+            --renders "$GITHUB_WORKSPACE/meshcore-mobile-bundle.png" \
+            --out "$GITHUB_WORKSPACE/out" \
+            --renderer "$(compose-preview --version | head -1)" \
+            --source-repo "${GITHUB_REPOSITORY}" \
+            --source-ref main \
+            --source-module :app \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.allow_incomplete) && '--allow-incomplete' || '' }}
+
+      - name: Publish to design-artifacts/meshcore-mobile
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd "$GITHUB_WORKSPACE/out"
+          git init -q
+          git checkout -q -b design-artifacts/meshcore-mobile
+          # Generated delivery branch — attributed to the repo owner, not a bot.
+          git config user.name 'Yuri Schimke'
+          git config user.email 'yuri@schimke.ee'
+          git add -A
+          git commit -q -m "chore(design-artifacts): regenerate meshcore-mobile catalog ($(date -u +%F))"
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/design-artifacts/meshcore-mobile"

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,0 +1,104 @@
+{
+  "$comment": "Design-catalog spec for the MeshCore mobile design system. Code-led: it declares which @Preview composables (by function name) make up the published sticker sheet, their grouping, and captions. Consumed by @design-parity/catalog-export (via compose-ai-tools' scripts/design-artifacts/generate-design-catalog.mjs) over a `compose-preview bundle pack --module :app` render to produce the importable design-artifacts/meshcore-mobile bundle the public preview server serves at /meshcore-mobile/. Each `preview` MUST equal the exact @Preview function name in :app (ee.schimke.meshcore.app.ui.ComponentPreviews).",
+  "system": "meshcore-mobile",
+  "title": "MeshCore Mobile",
+  "library": [
+    "androidx.compose.material3:material3",
+    "ee.schimke.meshcore:meshcore-components (MeshcoreTheme)"
+  ],
+  "module": "app",
+  "modes": ["light", "dark"],
+  "breakpoints": [{ "size": "compact", "widthDp": 412 }],
+  "groups": [
+    {
+      "name": "Device",
+      "components": [
+        {
+          "componentId": "DeviceSummaryCard/Populated",
+          "preview": "DeviceSummaryCardPopulatedPreview",
+          "caption": "The device summary card with radio, battery and signal populated."
+        },
+        {
+          "componentId": "DeviceSummaryCard/Loading",
+          "preview": "DeviceSummaryCardLoadingPreview",
+          "caption": "Loading / not-yet-known state."
+        }
+      ]
+    },
+    {
+      "name": "Contacts",
+      "components": [
+        {
+          "componentId": "ContactRow/Variants",
+          "preview": "ContactRowVariantsPreview",
+          "caption": "The four contact kinds: chat, repeater, room, sensor."
+        },
+        {
+          "componentId": "ContactList/Empty",
+          "preview": "ContactListEmptyPreview",
+          "caption": "Empty-state contact list."
+        },
+        {
+          "componentId": "ContactList/Few",
+          "preview": "ContactListFewPreview",
+          "caption": "A short contact list."
+        },
+        {
+          "componentId": "ContactList/Many",
+          "preview": "ContactListManyPreview",
+          "caption": "A long, scrollable contact list."
+        }
+      ]
+    },
+    {
+      "name": "Bluetooth",
+      "components": [
+        {
+          "componentId": "BleDeviceList/Empty",
+          "preview": "BleDeviceListEmptyPreview",
+          "caption": "No devices found while scanning."
+        },
+        {
+          "componentId": "BleDeviceList/Few",
+          "preview": "BleDeviceListFewPreview",
+          "caption": "A couple of discovered BLE devices."
+        },
+        {
+          "componentId": "BleDeviceList/Many",
+          "preview": "BleDeviceListManyPreview",
+          "caption": "A long, scrollable scan result list."
+        }
+      ]
+    },
+    {
+      "name": "Connection",
+      "components": [
+        {
+          "componentId": "TcpConnectPanel/Idle",
+          "preview": "TcpConnectPanelIdlePreview",
+          "caption": "TCP connect panel, idle."
+        },
+        {
+          "componentId": "TcpConnectPanel/Busy",
+          "preview": "TcpConnectPanelBusyPreview",
+          "caption": "TCP connect panel, connecting."
+        }
+      ]
+    },
+    {
+      "name": "Permissions",
+      "components": [
+        {
+          "componentId": "BlePermissionPanel/First",
+          "preview": "BlePermissionPanelFirstPreview",
+          "caption": "First-run Bluetooth permission request."
+        },
+        {
+          "componentId": "BlePermissionPanel/Denied",
+          "preview": "BlePermissionPanelDeniedPreview",
+          "caption": "Permission denied — how to recover."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Publish the MeshCore design system as a rendered, importable **design catalog**, served by the public preview server (preview.coo.ee) at **`/meshcore-mobile/`** — the same way `compose-m3` / `wear-m3` are published from compose-ai-tools.

- **`catalog.spec.json`** — the code-led component inventory for the `:app` `@Preview` sticker sheet (`ComponentPreviews`), grouped into Device / Contacts / Bluetooth / Connection / Permissions with captions. Each `preview` is the exact `@Preview` function name; the exporter joins on it.
- **`.github/workflows/design-artifacts.yml`** — renders `:app` via `compose-preview bundle pack --with-semantics`, runs the `@design-parity/catalog-export` driver from a compose-ai-tools checkout, and force-pushes the importable bundle (catalog.json + DTCG tokens + Figma variables + PNGs) to a clean `design-artifacts/meshcore-mobile` branch. Weekly + `workflow_dispatch`. The CLI is pinned to the applied plugin (`composePreviewPlugin`, currently 0.16.0), mirroring `compose-preview.yml`.

No app/runtime code changes — this is catalog data + CI plumbing, so there's no visual surface to diff here. The rendered stickers appear on the `design-artifacts/meshcore-mobile` branch after the first run.

## Test plan

The render only runs on GitHub (needs the Android SDK / Robolectric), so validate by dispatching:

1. Merge, then **Actions → Design Artifacts → Run workflow**. For the first run, set **`allow_incomplete: true`** — if any of the 13 catalog previews don't render or lack semantics, this publishes what did (so `/meshcore-mobile/` comes up) and logs the gaps; then tighten the spec and re-run fail-closed.
2. Confirm the `design-artifacts/meshcore-mobile` branch is created with `catalog.json` + `images/`.
3. Requires the companion compose-ai-tools PR (path routing + `SERVE_CATALOGS_UNLISTED`) merged + preview.coo.ee restarted for `https://preview.coo.ee/meshcore-mobile/` to resolve.

## Notes

- Renders `:app` (the 13-component sticker sheet) rather than `:meshcore-components`; easy to switch the `module` in the spec + `--source-module` if you'd prefer the shared-components screens.
- The workflow checks out `yschimke/compose-ai-tools@main` for the export driver — pin to a release tag once the path-URL deep-link change ships if you want full reproducibility.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh2DezRdwpjddGGEZ3nveE)_