### PR TITLE
fix(ci): bump design-parity pin 0.1.18 -> 0.1.24

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"
-          npx -y design-parity@0.1.18 run \
+          npx -y design-parity@0.1.24 run \
             --repo . \
             --components "$components" \
             --candidate-bundles build/design-parity/candidates.bundle.png \


### PR DESCRIPTION
## Summary

The `design-parity.yml` workflow pins `design-parity@0.1.18`, which crashes reading the very candidate bundle the workflow feeds it.

Any preview without an explicit `@Preview(widthDp = …)` serializes `widthDp` as JSON `null` in the compose-preview bundle (kotlinx `encodeDefaults = true` + `explicitNulls`). In 0.1.18, `normalizeSize` only guarded `undefined`, so JSON `null` throws a `TypeError` during candidate load. All of meshcore's parity previews are unset-width, so every push-to-main run dies in the "Run design-parity" step and `design-parity/main` never refreshes.

Fixed upstream in design-parity core (`normalizeSize` accepts `null`, shipped **v0.1.22**). This bumps the pin to the current latest **0.1.24**, which also picks up the `@ColorCatalog`/`@TypographyCatalog` bundle-token reads relevant to the recent `@ThemeCatalog` work.

The change is one line: `.github/workflows/design-parity.yml:110`.

## Test plan

- [ ] The `Design parity artifacts` workflow reaches the "Run design-parity" step without a `TypeError` in candidate load (previously failed 100% on push to `main`).
- [ ] `design-parity/main` is force-updated with a fresh candidate bundle + report on the next push to `main`.

Can't fully exercise this in the sandbox (needs the CI runner's compose-preview render + node toolchain), so verification is the next `main` push / a manual `workflow_dispatch`.

## Note

Left untouched (separate concern): the same workflow still hardcodes the compose-preview CLI at `version: "0.16.0"` (line 44) while the sibling `compose-preview.yml` derives it from the catalog — a version-skew inconsistency worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_017saGwsNTtoYEJmJ5rmMrgZ)_