### PR TITLE
feat(catalog): add theme foundations + screens to the design catalog

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ThemeFoundationPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ThemeFoundationPreviews.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -36,9 +35,9 @@ import ee.schimke.meshcore.app.ui.theme.MeshcoreTheme
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun Swatch(label: String, color: Color, onColor: Color) {
+private fun RowScope.Swatch(label: String, color: Color, onColor: Color) {
   Box(
-    Modifier.size(width = 52.dp, height = 40.dp).clip(RoundedCornerShape(8.dp)).background(color),
+    Modifier.weight(1f).height(40.dp).clip(RoundedCornerShape(8.dp)).background(color),
     contentAlignment = Alignment.Center,
   ) {
     Text(label, color = onColor, style = MaterialTheme.typography.labelSmall)
@@ -71,7 +70,7 @@ private fun ThemeFoundation(title: String, tagline: String) {
         Text(title, style = MaterialTheme.typography.titleLarge, color = cs.primary)
         Text(tagline, style = MaterialTheme.typography.labelMedium, color = cs.onSurfaceVariant)
       }
-      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         Swatch("P", cs.primary, cs.onPrimary)
         Swatch("PC", cs.primaryContainer, cs.onPrimaryContainer)
         Swatch("S", cs.secondary, cs.onSecondary)

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ThemeFoundationPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ThemeFoundationPreviews.kt
@@ -1,0 +1,135 @@
+package ee.schimke.meshcore.app.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.meshcore.app.ui.theme.MeshcoreTheme
+
+// ---------------------------------------------------------------------------
+// Theme-foundation showcase.
+//
+// Renders a theme's colour roles, surface-elevation strip and type ramp as a
+// single tile, for both the branded MeshcoreTheme and the untinted Material 3
+// baseline (light + dark each). Published in the design catalog so the theme
+// foundations sit alongside the components that use them.
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun Swatch(label: String, color: Color, onColor: Color) {
+  Box(
+    Modifier.size(width = 52.dp, height = 40.dp).clip(RoundedCornerShape(8.dp)).background(color),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(label, color = onColor, style = MaterialTheme.typography.labelSmall)
+  }
+}
+
+@Composable
+private fun RowScope.SurfaceBand(label: String, color: Color, onColor: Color, outline: Color) {
+  Box(
+    Modifier.weight(1f)
+      .height(32.dp)
+      .clip(RoundedCornerShape(6.dp))
+      .background(color)
+      .border(1.dp, outline, RoundedCornerShape(6.dp)),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(label, color = onColor, style = MaterialTheme.typography.labelSmall)
+  }
+}
+
+@Composable
+private fun ThemeFoundation(title: String, tagline: String) {
+  val cs = MaterialTheme.colorScheme
+  Surface(color = cs.background) {
+    Column(
+      Modifier.fillMaxWidth().padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Column {
+        Text(title, style = MaterialTheme.typography.titleLarge, color = cs.primary)
+        Text(tagline, style = MaterialTheme.typography.labelMedium, color = cs.onSurfaceVariant)
+      }
+      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Swatch("P", cs.primary, cs.onPrimary)
+        Swatch("PC", cs.primaryContainer, cs.onPrimaryContainer)
+        Swatch("S", cs.secondary, cs.onSecondary)
+        Swatch("T", cs.tertiary, cs.onTertiary)
+        Swatch("Sv", cs.surfaceVariant, cs.onSurfaceVariant)
+        Swatch("E", cs.error, cs.onError)
+      }
+      Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        SurfaceBand("0", cs.surface, cs.onSurface, cs.outlineVariant)
+        SurfaceBand("1", cs.surfaceContainerLowest, cs.onSurface, cs.outlineVariant)
+        SurfaceBand("2", cs.surfaceContainerLow, cs.onSurface, cs.outlineVariant)
+        SurfaceBand("3", cs.surfaceContainer, cs.onSurface, cs.outlineVariant)
+        SurfaceBand("4", cs.surfaceContainerHigh, cs.onSurface, cs.outlineVariant)
+        SurfaceBand("5", cs.surfaceContainerHighest, cs.onSurface, cs.outlineVariant)
+      }
+      Column {
+        Text("Display", style = MaterialTheme.typography.displaySmall, color = cs.onBackground)
+        Text("Headline", style = MaterialTheme.typography.headlineSmall, color = cs.onBackground)
+        Text("Title", style = MaterialTheme.typography.titleMedium, color = cs.onBackground)
+        Text(
+          "Body — the quick brown fox jumps over the lazy dog",
+          style = MaterialTheme.typography.bodyMedium,
+          color = cs.onSurfaceVariant,
+        )
+        Text("LABEL", style = MaterialTheme.typography.labelLarge, color = cs.primary)
+      }
+    }
+  }
+}
+
+@Preview(name = "Foundation — MeshCore light", widthDp = 360)
+@Composable
+fun ThemeFoundationMeshcoreLightPreview() {
+  MeshcoreTheme(darkTheme = false) {
+    ThemeFoundation("MeshCore", "Light · Orbitron / Space Grotesk / JetBrains Mono")
+  }
+}
+
+@Preview(name = "Foundation — MeshCore dark", widthDp = 360)
+@Composable
+fun ThemeFoundationMeshcoreDarkPreview() {
+  MeshcoreTheme(darkTheme = true) {
+    ThemeFoundation("MeshCore", "Dark · Orbitron / Space Grotesk / JetBrains Mono")
+  }
+}
+
+@Preview(name = "Foundation — Material 3 light", widthDp = 360)
+@Composable
+fun ThemeFoundationMaterial3LightPreview() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    ThemeFoundation("Material 3", "Light · baseline (untinted) reference")
+  }
+}
+
+@Preview(name = "Foundation — Material 3 dark", widthDp = 360)
+@Composable
+fun ThemeFoundationMaterial3DarkPreview() {
+  MaterialTheme(colorScheme = darkColorScheme()) {
+    ThemeFoundation("Material 3", "Dark · baseline (untinted) reference")
+  }
+}

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -11,6 +11,31 @@
   "breakpoints": [{ "size": "compact", "widthDp": 412 }],
   "groups": [
     {
+      "name": "Foundation",
+      "components": [
+        {
+          "componentId": "Theme/MeshCore-Light",
+          "preview": "ThemeFoundationMeshcoreLightPreview",
+          "caption": "MeshCore theme — colour roles, elevation and type (light)."
+        },
+        {
+          "componentId": "Theme/MeshCore-Dark",
+          "preview": "ThemeFoundationMeshcoreDarkPreview",
+          "caption": "MeshCore theme (dark)."
+        },
+        {
+          "componentId": "Theme/Material3-Light",
+          "preview": "ThemeFoundationMaterial3LightPreview",
+          "caption": "Material 3 baseline (untinted) reference (light)."
+        },
+        {
+          "componentId": "Theme/Material3-Dark",
+          "preview": "ThemeFoundationMaterial3DarkPreview",
+          "caption": "Material 3 baseline (dark)."
+        }
+      ]
+    },
+    {
       "name": "Device",
       "components": [
         {
@@ -97,6 +122,96 @@
           "componentId": "BlePermissionPanel/Denied",
           "preview": "BlePermissionPanelDeniedPreview",
           "caption": "Permission denied — how to recover."
+        }
+      ]
+    },
+    {
+      "name": "Screens · Scanner",
+      "components": [
+        {
+          "componentId": "Scanner/SavedEmpty",
+          "preview": "ScannerSavedEmptyPreview",
+          "caption": "Scanner, Saved tab — no saved devices yet."
+        },
+        {
+          "componentId": "Scanner/SavedPopulated",
+          "preview": "ScannerSavedPopulatedPreview",
+          "caption": "Scanner, Saved tab — a favourited BLE device + a TCP device."
+        },
+        {
+          "componentId": "Scanner/BlePermission",
+          "preview": "ScannerBlePermissionPreview",
+          "caption": "Scanner, BLE tab — permission request panel."
+        },
+        {
+          "componentId": "Scanner/BleEmpty",
+          "preview": "ScannerBleEmptyPreview",
+          "caption": "Scanner, BLE tab — scanning, nothing found yet."
+        },
+        {
+          "componentId": "Scanner/BleFew",
+          "preview": "ScannerBleFewPreview",
+          "caption": "Scanner, BLE tab — a couple of discovered devices."
+        },
+        {
+          "componentId": "Scanner/BleMany",
+          "preview": "ScannerBleManyPreview",
+          "caption": "Scanner, BLE tab — a long, scrolling result list."
+        },
+        {
+          "componentId": "Scanner/UsbEmpty",
+          "preview": "ScannerUsbEmptyPreview",
+          "caption": "Scanner, USB tab — no serial ports."
+        },
+        {
+          "componentId": "Scanner/UsbFew",
+          "preview": "ScannerUsbFewPreview",
+          "caption": "Scanner, USB tab — a couple of serial ports."
+        },
+        {
+          "componentId": "Scanner/Tcp",
+          "preview": "ScannerTcpPreview",
+          "caption": "Scanner, TCP tab — the connect form."
+        },
+        {
+          "componentId": "Scanner/BleDark",
+          "preview": "ScannerBleDarkPreview",
+          "caption": "Scanner, Saved tab populated (dark theme)."
+        }
+      ]
+    },
+    {
+      "name": "Screens · Device",
+      "components": [
+        {
+          "componentId": "Device/Loading",
+          "preview": "DeviceBodyLoadingPreview",
+          "caption": "Device screen — self-info still loading."
+        },
+        {
+          "componentId": "Device/NoContacts",
+          "preview": "DeviceBodyNoContactsPreview",
+          "caption": "Device screen — self known, contacts still loading."
+        },
+        {
+          "componentId": "Device/LowBattery",
+          "preview": "DeviceBodyLowBatteryPreview",
+          "caption": "Device screen — populated, low-battery reading."
+        },
+        {
+          "componentId": "Device/ManyContacts",
+          "preview": "DeviceBodyManyContactsPreview",
+          "caption": "Device screen — many contacts + a channel-message banner."
+        },
+        {
+          "componentId": "Device/StatusConnecting",
+          "preview": "DeviceStatusConnectingPreview",
+          "caption": "Device connection status — connecting."
+        },
+        {
+          "componentId": "Device/StatusFailed",
+          "preview": "DeviceStatusFailedPreview",
+          "caption": "Device connection status — failed, with cause."
         }
       ]
     }


### PR DESCRIPTION
## Summary

Broadens the MeshCore design-artifact sticker sheet from **13 → 33** entries so it spans **themes + components + screens**, not just components.

- **New `app/.../ui/ThemeFoundationPreviews.kt`** — a theme-foundation showcase (colour-role swatches + surface-elevation strip + type ramp) rendered four ways: the branded `MeshcoreTheme` (light + dark) and the untinted **Material 3 baseline** (light + dark). Modelled on the HA `ThemeShowcase` pattern.
- **`catalog.spec.json`** gains:
  - a leading **Foundation** group (the 4 new theme tiles);
  - **Screens · Scanner** (10) and **Screens · Device** (6) groups — these `@Preview`s already existed in `:app` (`ScannerScreen.kt`, `DeviceScreenPreviews.kt`) and are simply surfaced now.

## Why

Part of a cross-repo pass to give each design catalog the full spread — theme foundations (built-in Material 3 + the custom theme), components, and screens.

## Test plan / notes

- `catalog.spec.json` is valid JSON; all 33 `preview` names resolve to real `@Preview` funs in `:app` (scripted cross-check, 0 missing). The 4 new names are the foundation previews added here.
- The new file uses only APIs already present in the repo: the `MeshcoreTheme` wrapper and M3 `surfaceContainer*` / `outlineVariant` roles (both used elsewhere in `:app`/`meshcore-components`), plus `lightColorScheme()`/`darkColorScheme()` for the baseline. Formatted with ktfmt google-style.
- ⚠️ I could not run Gradle locally (the Gradle distribution download is blocked in this sandbox), so **compilation is validated by CI** rather than locally. If `compileDebugKotlin` or `ktfmtCheck` flag anything, I'll follow up on this branch.
- Recommend dispatching the Design Artifacts regen with **allow_incomplete = true** first, in case any surfaced screen preview needs a fixture tweak to rasterise headless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfwSvvqbTmGMHMVtwQXKi4)_