### PR TITLE
chore(renovate): extend shared yschimke/renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,86 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits",
-    ":timezone(Europe/London)"
-  ],
-  "schedule": ["before 6am on monday"],
-  "labels": ["dependencies"],
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 0,
-  "rangeStrategy": "pin",
+  "extends": ["github>yschimke/renovate-config"],
   "packageRules": [
-    {
-      "matchManagers": ["gradle", "gradle-wrapper"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": false
-    },
-    {
-      "description": "Ignore the legacy-API -compat artifacts (e.g. kotlinx-datetime 0.8.0-0.6.x-compat)",
-      "matchPackageNames": ["/^org\\.jetbrains\\.kotlinx($|[.:])/"],
-      "allowedVersions": "!/-compat$/"
-    },
-    {
-      "groupName": "Kotlin",
-      "matchPackageNames": [
-        "/^org\\.jetbrains\\.kotlin($|[.:])/",
-        "/^org\\.jetbrains\\.kotlinx($|[.:])/"
-      ]
-    },
-    {
-      "groupName": "Compose Multiplatform",
-      "matchPackageNames": [
-        "/^org\\.jetbrains\\.compose($|[.:])/",
-        "/^org\\.jetbrains\\.androidx\\.lifecycle($|[.:])/",
-        "/^org\\.jetbrains\\.androidx\\.navigation($|[.:])/"
-      ]
-    },
-    {
-      "groupName": "AndroidX",
-      "matchPackageNames": ["/^androidx\\./"]
-    },
-    {
-      "groupName": "Wear Compose",
-      "matchPackageNames": [
-        "/^androidx\\.wear($|[.:])/",
-        "/^com\\.google\\.android\\.horologist($|[.:])/"
-      ]
-    },
-    {
-      "groupName": "Room / SQLite",
-      "matchPackageNames": [
-        "/^androidx\\.room($|[.:])/",
-        "/^androidx\\.sqlite($|[.:])/"
-      ]
-    },
-    {
-      "groupName": "gRPC",
-      "matchPackageNames": [
-        "/^io\\.grpc($|[.:])/",
-        "/^com\\.google\\.protobuf($|[.:])/"
-      ]
-    },
-    {
-      "groupName": "Ktor",
-      "matchPackageNames": ["/^io\\.ktor($|[.:])/"]
-    },
     {
       "groupName": "Wire",
       "matchPackageNames": ["/^com\\.squareup\\.wire($|[.:])/"]
-    },
-    {
-      "groupName": "Android Gradle Plugin",
-      "matchPackageNames": [
-        "com.android.application",
-        "com.android.library",
-        "com.android.tools.build:gradle"
-      ]
-    },
-    {
-      "groupName": "GitHub Actions",
-      "matchManagers": ["github-actions"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replaces the hand-maintained `renovate.json` groupings with an `extends` of the new shared preset [`yschimke/renovate-config`](https://github.com/yschimke/renovate-config), keeping only the Wire group that's specific to this repo.

The preset clusters updates **by release train** rather than namespace:

- **kotlin** — stdlib + Kotlin Gradle plugins + Compose compiler plugin **+ KSP** (KSP tracks the compiler version — this was the one real gap in the old config, where KSP could desync from Kotlin in a separate PR).
- **compose-multiplatform**, **androidx-compose**, **androidx-wear** (+ Horologist), **androidx-room** (+ SQLite), **grpc** (+ protobuf) — lockstep trains.
- **kotlinx**, **ktor**, **androidx** (catch-all for the independently-versioned small libs) — convenience groups.
- **android-gradle-plugin**, **github-actions** — infra.
- **Wire** — kept repo-local (Wire isn't used by the other repos).

Net effect is nearly identical to the previous grouping (Kotlin/Compose MP/AndroidX/Wear/Room/gRPC/Ktor/Wire/AGP/Actions), with two improvements: KSP now rides with Kotlin, and the cluster definitions live in one shared place instead of being copy-pasted per repo.

## Test plan

- `renovate.json` validated as JSON.
- Preset resolves to `github>yschimke/renovate-config` (published on `main`).
- Renovate's own validation runs on the next scheduled pass (Mondays, 06:00 Europe/London); the dependency dashboard will reflect the regrouped PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QUvbNL2qcqRutHD9WKnAgw)_