### PR TITLE
ci: harden @claude session and merge passing PRs on a schedule

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -73,5 +73,5 @@ jobs:
             }
           claude_args: >-
             --max-turns 100
-            --allowedTools "Bash(./gradlew:*)"
+            --allowedTools "Bash(./gradlew:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*)"
             --append-system-prompt "Follow the repo conventions in .claude/CLAUDE.md. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :app:composePreviewRenderAll, :wear:composePreviewRenderAll, or :meshcore-components:composePreviewRenderAll), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. If the affected screen has no @Preview, add one so it renders now and is diffed by the Compose Preview workflow on every future PR. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,9 +69,9 @@ jobs:
           settings: |
             {
               "includeCoAuthoredBy": false,
-              "attribution": { "coAuthoredBy": false }
+              "attribution": { "commit": "", "pr": "" }
             }
           claude_args: >-
             --max-turns 100
-            --allowedTools "Bash(./gradlew:*),Bash(git:*)"
+            --allowedTools "Bash(./gradlew:*)"
             --append-system-prompt "Follow the repo conventions in .claude/CLAUDE.md. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :app:composePreviewRenderAll, :wear:composePreviewRenderAll, or :meshcore-components:composePreviewRenderAll), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. If the affected screen has no @Preview, add one so it renders now and is diffed by the Compose Preview workflow on every future PR. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -38,8 +38,10 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const skipLabels = new Set(['no-automerge', 'autorelease: pending']);
+            // Only PRs targeting main — the CI gates this relies on are
+            // filtered to pull_request against main.
             const prs = await github.paginate(github.rest.pulls.list, {
-              owner, repo, state: 'open', per_page: 100,
+              owner, repo, state: 'open', base: 'main', per_page: 100,
             });
             let merged = 0;
             for (const stub of prs) {
@@ -57,8 +59,11 @@ jobs:
                 continue;
               }
               try {
+                // sha guard: reject the merge if the head moved after the
+                // mergeable_state check (race with a new push).
                 await github.rest.pulls.merge({
                   owner, repo, pull_number: pr.number, merge_method: 'squash',
+                  sha: pr.head.sha,
                 });
                 core.notice(`Merged #${pr.number}: ${pr.title}`);
                 merged++;
@@ -67,14 +72,16 @@ jobs:
               }
             }
             if (merged > 0) {
-              // GITHUB_TOKEN merges don't trigger push workflows; refresh the
-              // compose-preview baselines explicitly.
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner, repo, workflow_id: 'compose-preview.yml', ref: 'main',
-                });
-                core.info('Dispatched compose-preview.yml for new baselines');
-              } catch (e) {
-                core.warning(`compose-preview dispatch failed: ${e.message}`);
+              // GITHUB_TOKEN merges don't trigger push workflows; explicitly
+              // refresh the render baselines and the release-please PR.
+              for (const wf of ['compose-preview.yml', 'release-please.yml']) {
+                try {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner, repo, workflow_id: wf, ref: 'main',
+                  });
+                  core.info(`Dispatched ${wf}`);
+                } catch (e) {
+                  core.warning(`${wf} dispatch failed: ${e.message}`);
+                }
               }
             }

--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -1,0 +1,80 @@
+name: Scheduled Merge
+
+# Merges open PRs automatically once they pass the "Protect Main" merge
+# gates: every 30 minutes, any non-draft PR whose mergeable state is `clean`
+# (all required status checks green, no conflicts) is squash-merged.
+#
+# Opt-outs, checked per PR:
+#   - draft PRs are skipped
+#   - the `no-automerge` label blocks merging
+#   - release-please PRs (`autorelease: pending` label) are skipped so
+#     cutting a release stays a deliberate human action
+#
+# GITHUB_TOKEN merges don't fire push-to-main workflows, so after merging
+# this dispatches compose-preview.yml to refresh the render baselines.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: scheduled-merge
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Merge passing PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const skipLabels = new Set(['no-automerge', 'autorelease: pending']);
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            let merged = 0;
+            for (const stub of prs) {
+              if (stub.draft) continue;
+              if (stub.labels.some((l) => skipLabels.has(l.name))) {
+                core.info(`#${stub.number}: opt-out label — skip`);
+                continue;
+              }
+              // pulls.list doesn't populate mergeable_state; fetch the PR.
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: stub.number,
+              });
+              if (pr.mergeable_state !== 'clean') {
+                core.info(`#${pr.number}: ${pr.mergeable_state} — skip`);
+                continue;
+              }
+              try {
+                await github.rest.pulls.merge({
+                  owner, repo, pull_number: pr.number, merge_method: 'squash',
+                });
+                core.notice(`Merged #${pr.number}: ${pr.title}`);
+                merged++;
+              } catch (e) {
+                core.warning(`#${pr.number}: merge failed — ${e.message}`);
+              }
+            }
+            if (merged > 0) {
+              // GITHUB_TOKEN merges don't trigger push workflows; refresh the
+              // compose-preview baselines explicitly.
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo, workflow_id: 'compose-preview.yml', ref: 'main',
+                });
+                core.info('Dispatched compose-preview.yml for new baselines');
+              } catch (e) {
+                core.warning(`compose-preview dispatch failed: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Two follow-ups to #173:

**`claude.yml` fixes** (from Codex review findings on the cadence copy, applied to all copies):
- `settings.attribution` now uses the valid `{"commit": "", "pr": ""}` keys — the previous `coAuthoredBy` key was invalid and could have left the default `Co-Authored-By` trailer enabled, which would trip the `no-ai-coauthors` gate.
- Dropped `Bash(git:*)` from the allowlist: the action's built-in git tooling (add/commit plus a hardened push wrapper) covers the agent's needs, and raw git flags (`--receive-pack`, `-c core.sshCommand=…`) are an arbitrary-execution/exfiltration vector for prompt-injected PR content.

**New `scheduled-merge.yml`**: every 30 minutes, squash-merges open non-draft PRs whose `mergeable_state` is `clean` (all checks green, no conflicts). Opt-outs: drafts, a `no-automerge` label, and release-please PRs (`autorelease: pending`) so cutting a release stays deliberate. Because `GITHUB_TOKEN` merges don't fire push-to-main workflows, it dispatches `compose-preview.yml` after merging so render baselines stay fresh.

## Test plan

- Both workflows YAML-parsed locally; the merge script only calls documented REST endpoints via `actions/github-script`.
- The merge gate is `mergeable_state === 'clean'`, which requires all checks passing even before branch-protection rulesets exist; adding a "Protect Main" ruleset (required checks + squash-only, mirroring compose-ai-tools) tightens manual merges too — ruleset creation needs repo-admin API access, commands provided separately.
- After merge: verify the cron run in Actions → "Scheduled Merge" (or trigger via workflow_dispatch) and confirm it skips/merges as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThVExRiUTasR9ehW9gFSv)_