### PR TITLE
feat(catalog): render every design-catalog screen in light and dark

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
@@ -29,6 +29,13 @@ import ee.schimke.meshcore.components.ui.TcpConnectPanel
 import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 
+// Each catalog component renders in BOTH light and dark via @MeshcoreModes (a `name = "Light"` +
+// `name = "Dark", uiMode = NIGHT_YES` multipreview). MeshcoreTheme's default `darkTheme =
+// isSystemInDarkTheme()` follows the render's uiMode, so the Dark variant is a real dark render —
+// the design-catalog export folds the pair into one component the preview server's Light/Dark
+// toggle swaps in place. Each preview keeps its own widthDp (the catalog render width), so wrap the
+// two @Preview lines rather than a width-less shared annotation.
+
 // --- Shared fixtures ------------------------------------------------------
 
 private fun pk(fill: Byte): PublicKey =
@@ -71,10 +78,11 @@ private fun tenContacts(): List<Contact> {
 
 // --- DeviceSummaryCard ----------------------------------------------------
 
-@Preview(name = "DeviceSummaryCard — populated", widthDp = 310, heightDp = 170)
+@Preview(name = "Light", widthDp = 310, heightDp = 170)
+@Preview(name = "Dark", widthDp = 310, heightDp = 170, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DeviceSummaryCardPopulatedPreview() {
-    MeshcoreTheme(darkTheme = true) {
+    MeshcoreTheme {
             DeviceSummaryCard(
                 self = SelfInfo(
                     advertType = 1,
@@ -96,7 +104,8 @@ fun DeviceSummaryCardPopulatedPreview() {
         }
 }
 
-@Preview(showBackground = true, name = "DeviceSummaryCard — loading")
+@Preview(showBackground = true, name = "Light")
+@Preview(showBackground = true, name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DeviceSummaryCardLoadingPreview() {
     MeshcoreTheme {
@@ -108,7 +117,8 @@ fun DeviceSummaryCardLoadingPreview() {
 
 // --- ContactRow / ContactList --------------------------------------------
 
-@Preview(showBackground = true, name = "ContactRow — variants", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ContactRowVariantsPreview() {
     MeshcoreTheme {
@@ -121,7 +131,8 @@ fun ContactRowVariantsPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "ContactList — empty", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ContactListEmptyPreview() {
     MeshcoreTheme {
@@ -135,7 +146,8 @@ fun ContactListEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "ContactList — 2 items", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ContactListFewPreview() {
     MeshcoreTheme {
@@ -152,7 +164,8 @@ fun ContactListFewPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "ContactList — 10 items (scrolls)", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ContactListManyPreview() {
     MeshcoreTheme {
@@ -168,7 +181,8 @@ fun ContactListManyPreview() {
 
 // --- BleDeviceList --------------------------------------------------------
 
-@Preview(showBackground = true, name = "BleDeviceList — empty", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun BleDeviceListEmptyPreview() {
     MeshcoreTheme {
@@ -184,7 +198,8 @@ fun BleDeviceListEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "BleDeviceList — 2 devices", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun BleDeviceListFewPreview() {
     MeshcoreTheme {
@@ -202,7 +217,8 @@ fun BleDeviceListFewPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "BleDeviceList — 10 devices (scrolls)", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun BleDeviceListManyPreview() {
     MeshcoreTheme {
@@ -225,7 +241,8 @@ fun BleDeviceListManyPreview() {
 
 // --- TcpConnectPanel ------------------------------------------------------
 
-@Preview(showBackground = true, name = "TcpConnectPanel — idle", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun TcpConnectPanelIdlePreview() {
     MeshcoreTheme {
@@ -235,7 +252,8 @@ fun TcpConnectPanelIdlePreview() {
     }
 }
 
-@Preview(showBackground = true, name = "TcpConnectPanel — busy", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun TcpConnectPanelBusyPreview() {
     MeshcoreTheme {
@@ -247,7 +265,8 @@ fun TcpConnectPanelBusyPreview() {
 
 // --- BlePermissionPanel ---------------------------------------------------
 
-@Preview(showBackground = true, name = "BlePermissionPanel — first request", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun BlePermissionPanelFirstPreview() {
     MeshcoreTheme {
@@ -257,7 +276,8 @@ fun BlePermissionPanelFirstPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "BlePermissionPanel — denied", widthDp = 340)
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun BlePermissionPanelDeniedPreview() {
     MeshcoreTheme {

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreenPreviews.kt
@@ -1,5 +1,6 @@
 package ee.schimke.meshcore.app.ui
 
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,11 +53,13 @@ private fun previewSelf(name: String = "node-peak") = SelfInfo(
 )
 
 // --- Previews ---------------------------------------------------------------
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
 @Preview(
     showBackground = true,
     showSystemUi = true,
     device = Devices.PIXEL_7,
-    name = "Device — loading",
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
 fun DeviceBodyLoadingPreview() {
@@ -73,11 +76,13 @@ fun DeviceBodyLoadingPreview() {
     }
 }
 
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
 @Preview(
     showBackground = true,
     showSystemUi = true,
     device = Devices.PIXEL_7,
-    name = "Device — contacts loading",
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
 fun DeviceBodyNoContactsPreview() {
@@ -94,11 +99,13 @@ fun DeviceBodyNoContactsPreview() {
     }
 }
 
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
 @Preview(
     showBackground = true,
     showSystemUi = true,
     device = Devices.PIXEL_7,
-    name = "Device — low battery",
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
 fun DeviceBodyLowBatteryPreview() {
@@ -117,11 +124,13 @@ fun DeviceBodyLowBatteryPreview() {
     }
 }
 
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
 @Preview(
     showBackground = true,
     showSystemUi = true,
     device = Devices.PIXEL_7,
-    name = "Device — many contacts (scrolls)",
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
 fun DeviceBodyManyContactsPreview() {
@@ -162,11 +171,13 @@ fun DeviceBodyManyContactsPreview() {
     }
 }
 
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
 @Preview(
     showBackground = true,
     showSystemUi = true,
     device = Devices.PIXEL_7,
-    name = "Device — status connecting",
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
 fun DeviceStatusConnectingPreview() {
@@ -188,11 +199,13 @@ fun DeviceStatusConnectingPreview() {
     }
 }
 
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
 @Preview(
     showBackground = true,
     showSystemUi = true,
     device = Devices.PIXEL_7,
-    name = "Device — status failed",
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
 fun DeviceStatusFailedPreview() {

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ScannerScreen.kt
@@ -350,7 +350,14 @@ private fun PreviewSavedPopulated() {
 
 // --- Saved tab previews ---------------------------------------------------
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — Saved empty")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerSavedEmptyPreview() {
     MeshcoreTheme {
@@ -364,7 +371,14 @@ fun ScannerSavedEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — Saved populated")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerSavedPopulatedPreview() {
     MeshcoreTheme {
@@ -380,7 +394,14 @@ fun ScannerSavedPopulatedPreview() {
 
 // --- BLE tab previews -----------------------------------------------------
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — BLE permission needed")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerBlePermissionPreview() {
     MeshcoreTheme {
@@ -394,7 +415,14 @@ fun ScannerBlePermissionPreview() {
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — BLE scanning, 0 devices")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerBleEmptyPreview() {
     MeshcoreTheme {
@@ -408,7 +436,14 @@ fun ScannerBleEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — BLE scanning, 2 devices")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerBleFewPreview() {
     MeshcoreTheme {
@@ -422,7 +457,14 @@ fun ScannerBleFewPreview() {
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — BLE scanning, 10 devices (scrolls)")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerBleManyPreview() {
     MeshcoreTheme {
@@ -438,7 +480,14 @@ fun ScannerBleManyPreview() {
 
 // --- USB tab previews -----------------------------------------------------
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — USB, no ports")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerUsbEmptyPreview() {
     MeshcoreTheme {
@@ -452,7 +501,14 @@ fun ScannerUsbEmptyPreview() {
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — USB, 2 ports")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerUsbFewPreview() {
     MeshcoreTheme {
@@ -468,7 +524,14 @@ fun ScannerUsbFewPreview() {
 
 // --- TCP tab previews -----------------------------------------------------
 
-@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Scanner — TCP idle")
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Light")
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+    device = Devices.PIXEL_7,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 fun ScannerTcpPreview() {
     MeshcoreTheme {


### PR DESCRIPTION
## Summary

Gives every MeshCore design-catalog component a **light and a dark** render, so the public preview server (`preview.coo.ee/meshcore-mobile`) can actually toggle MeshCore's previews between themes.

Until now each catalog screen was a single `@Preview` in one theme, so the catalog served them theme-neutral and the preview server's Light/Dark control had nothing to swap for them. Each catalog component preview now carries a **`name = "Light"` + `name = "Dark", uiMode = UI_MODE_NIGHT_YES`** twin. `MeshcoreTheme` already defaults `darkTheme = isSystemInDarkTheme()`, which follows the render's `uiMode`, so the Dark variant is a real dark render. The design-catalog export folds the light+dark pair into one component (same mechanism as compose-ai-tools' `@CatalogModes`), and the preview server swaps each component between the two in place.

- Applied to the Contacts, Bluetooth, Connection, Permissions, Device and Scanner screen/component previews (`ComponentPreviews.kt`, `DeviceScreenPreviews.kt`, `ScannerScreen.kt`) — 28 functions, now **56 variants (28 × Light/Dark)**.
- Each preview keeps its own `widthDp` (it drives the catalog render width), so the two `@Preview` lines are inlined rather than a width-less shared annotation.
- Left as-is: the Foundation theme showcases (already per-theme by design) and the dedicated `Scanner/BleDark` preview.

Pairs with the preview server's new in-place Light/Dark swap (compose-ai-tools #2481).

## Visual evidence

Rendered by this repo's preview-diff CI at `fef44b6`. Each screen now has a Light and a Dark render (the Dark twin is a genuine dark-theme render, not the light one):

| Screen | Light | Dark |
| --- | --- | --- |
| Device — low battery | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/fef44b6d686bc364661295e5768a0f3cfa668d58/renders/app/DeviceBodyLowBatteryPreview_Light.png" width="200"> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/fef44b6d686bc364661295e5768a0f3cfa668d58/renders/app/DeviceBodyLowBatteryPreview_Dark.png" width="200"> |
| Contacts — many | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/fef44b6d686bc364661295e5768a0f3cfa668d58/renders/app/ContactListManyPreview_Light.png" width="200"> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/fef44b6d686bc364661295e5768a0f3cfa668d58/renders/app/ContactListManyPreview_Dark.png" width="200"> |
| Scanner — BLE (2 devices) | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/fef44b6d686bc364661295e5768a0f3cfa668d58/renders/app/ScannerBleFewPreview_Light.png" width="200"> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/fef44b6d686bc364661295e5768a0f3cfa668d58/renders/app/ScannerBleFewPreview_Dark.png" width="200"> |

(The full set — all 28 functions × Light/Dark — is in the sticky preview-diff comment below.) Once merged, `design-artifacts.yml` republishes the catalog and `preview.coo.ee/meshcore-mobile` shows a Light/Dark toggle that swaps each screen.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — compiles clean
- [x] `./gradlew ktfmtFormat` + pre-commit `ktfmtCheck` — formatted, passes
- [x] Preview-diff CI renders 56 new Light/Dark variants; spot-checked that the Dark renders are genuinely dark-theme (see table)
- [ ] CI: assemble / unit tests / lint
- [ ] Post-merge: `design-artifacts.yml` folds each component into a light+dark pair and republishes the catalog
