### PR TITLE
build: add BuildFetch remote Gradle build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
     name: Assemble (debug)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
+      # disables the cache there. Writes happen only on trusted main-branch builds.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: ./.github/actions/setup
@@ -40,6 +45,9 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: ./.github/actions/setup
@@ -61,6 +69,9 @@ jobs:
     name: Android lint
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: ./.github/actions/setup

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,37 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+// BuildFetch remote Gradle build cache. Complements the local build cache (org.gradle.caching=true
+// in gradle.properties) by sharing task outputs across CI runs and developer machines.
+//
+// Auth: the token is read from the BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN environment variable (best
+// for CI — see .github/actions/setup / .github/workflows/ci.yml) or a gradle property of the same
+// name (best for a mixed IDE + terminal dev setup — put it in ~/.gradle/gradle.properties). When no
+// token is resolvable the cache disables itself (isEnabled below), so fork PRs and un-provisioned
+// checkouts fall back to the local cache with no error.
+//
+// Push: writes are restricted to trusted CI builds. CI sets ON_CI=true only on main-branch runs, so
+// PRs and developer machines are read-only. The gate is value-based (not env-var presence) so an
+// explicit ON_CI=false is honoured as read-only.
+buildCache {
+    remote<HttpBuildCache> {
+        url = uri("https://cache.eu-central-a.buildfetch.com/vuFQad/gradle/")
+
+        credentials {
+            username = "token-auth"
+            password =
+                providers
+                    .environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
+                    .orElse(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN"))
+                    .orNull
+        }
+
+        isPush = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
+
+        isEnabled = credentials.password != null
+    }
+}
+
 include(":meshcore-core")
 include(":meshcore-transport-tcp")
 include(":meshcore-transport-ble")


### PR DESCRIPTION
## Summary

Wires the [BuildFetch](https://buildfetch.com) HTTP remote Gradle build cache into the build, alongside the existing local build cache (`org.gradle.caching=true`), so task outputs are shared across CI runs and developer machines.

- **`settings.gradle.kts`** — adds a `buildCache { remote<HttpBuildCache> { … } }` block pointing at the project cache (`https://cache.eu-central-a.buildfetch.com/vuFQad/gradle/`).
  - Auth token is read from the `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` env var (CI) or a gradle property of the same name (dev — e.g. `~/.gradle/gradle.properties`).
  - `isEnabled = credentials.password != null` — when no token resolves (fork PRs, un-provisioned checkouts), the remote cache disables itself and the build falls back to the local cache with no error.
  - Push is gated on the `ON_CI` value (value-based, so `ON_CI=false` is honoured as read-only).
- **`.github/workflows/ci.yml`** — the `build` / `test` / `lint` jobs export the token secret and set `ON_CI: ${{ github.ref == 'refs/heads/main' }}`, so **cache writes happen only on trusted `main`-branch builds**; PRs and developer machines are read-only, and fork PRs (no secret available) get no remote cache at all.

## Follow-up required before this is active

A repository secret named `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` must be added (a `cache:readwrite` token for the `main`-branch writes). Until it exists the block is a harmless no-op — `isEnabled` stays false.

## Test plan

- [x] `settings.gradle.kts` evaluates cleanly (verified locally: build proceeds past settings evaluation; the only failure was the pre-existing Gradle-version requirement in `app/build.gradle.kts`, unrelated to this change — the correct Gradle distribution and the Android SDK aren't available in the sandbox).
- [ ] CI (`Assemble` / `Unit tests` / `Android lint`) green on this PR — reads-only, no token required.
- [ ] After merge + secret provisioning: confirm cache writes on the next `main` build and cache hits on a subsequent PR.

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZNP9KNVXpZbwDVimAdw86)_