### PR TITLE
fix: treat blank BuildFetch token as absent

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,12 @@ plugins {
 // token is resolvable the cache disables itself (isEnabled below), so fork PRs and un-provisioned
 // checkouts fall back to the local cache with no error.
 //
+// The token is treated as absent unless it is non-blank. CI declares the env var unconditionally
+// (`BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.… }}`), so an unprovisioned secret or a fork
+// PR exports it as an empty string — which Gradle's `environmentVariable(...)` still reports as
+// *present*. Filtering blanks preserves the intended no-op (empty ⇒ cache disabled) and lets the
+// gradle-property fallback apply even when the env var is present-but-empty.
+//
 // Push: writes are restricted to trusted CI builds. CI sets ON_CI=true only on main-branch runs, so
 // PRs and developer machines are read-only. The gate is value-based (not env-var presence) so an
 // explicit ON_CI=false is honoured as read-only.
@@ -56,7 +62,14 @@ buildCache {
             password =
                 providers
                     .environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
-                    .orElse(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN"))
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+                    .orElse(
+                        providers
+                            .gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
+                            .map { it.trim() }
+                            .filter { it.isNotEmpty() }
+                    )
                     .orNull
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #205. Fixes the P2 raised in review there: a blank BuildFetch token should disable the remote cache, but it was enabling it with an empty password.

`ci.yml` declares `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.… }}` unconditionally, so when the secret is unset — notably on **fork PRs** — GitHub expands it to an empty string *but still exports the env var*. Gradle's `environmentVariable(...)` reports a set-but-empty variable as **present**, so:

- `.orElse(gradleProperty(...))` never fell back to the gradle property, and
- `isEnabled = credentials.password != null` became `"" != null` → **true**, enabling the remote cache with an empty password and issuing unauthenticated cache requests — the opposite of the intended no-op.

### Fix

Trim and drop blank values before the `orElse` fallback, so:
- an empty/blank env var is treated as absent → the cache disables itself (intended no-op), and
- the gradle-property fallback still applies even when the env var is present-but-empty.

```kotlin
password =
    providers
        .environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
        .map { it.trim() }
        .filter { it.isNotEmpty() }
        .orElse(
            providers
                .gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
                .map { it.trim() }
                .filter { it.isNotEmpty() }
        )
        .orNull
```

No behaviour change for provisioned builds (the real token is non-blank); this only affects the empty-token path. `Provider.filter` is available since Gradle 8.5 (repo is on 9.6.1).

## Test plan

- [x] `settings.gradle.kts` evaluates cleanly (verified locally: the build proceeds past settings evaluation and fails only on the pre-existing Gradle-version requirement in `app/build.gradle.kts`, unrelated to this change — the correct Gradle distribution and Android SDK aren't available in the sandbox).
- [ ] CI green on this PR.

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZNP9KNVXpZbwDVimAdw86)_