### PR TITLE
feat: resolve BuildFetch token per-project with general fallback

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,17 +38,24 @@ plugins {
 // BuildFetch remote Gradle build cache. Complements the local build cache (org.gradle.caching=true
 // in gradle.properties) by sharing task outputs across CI runs and developer machines.
 //
-// Auth: the token is read from the BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN environment variable (best
-// for CI — see .github/actions/setup / .github/workflows/ci.yml) or a gradle property of the same
-// name (best for a mixed IDE + terminal dev setup — put it in ~/.gradle/gradle.properties). When no
-// token is resolvable the cache disables itself (isEnabled below), so fork PRs and un-provisioned
-// checkouts fall back to the local cache with no error.
+// Auth: the token is resolved from the first non-blank of, in order:
+//   1. env  BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN   (project-specific)
+//   2. prop BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN
+//   3. env  BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN            (shared / general fallback)
+//   4. prop BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN
+// The project-specific name lets a developer hold a separate readonly token per BuildFetch project
+// in a single ~/.gradle/gradle.properties (this repo and compose-ai-tools point at different caches,
+// so one shared token can't authenticate both). The general name stays as a fallback — it's what CI
+// exports (see .github/workflows/ci.yml) and what a single-project setup can use. Env wins over a
+// gradle property of the same name so CI overrides a stray local property.
 //
 // The token is treated as absent unless it is non-blank. CI declares the env var unconditionally
 // (`BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.… }}`), so an unprovisioned secret or a fork
 // PR exports it as an empty string — which Gradle's `environmentVariable(...)` still reports as
-// *present*. Filtering blanks preserves the intended no-op (empty ⇒ cache disabled) and lets the
-// gradle-property fallback apply even when the env var is present-but-empty.
+// *present*. Filtering each source for blanks independently preserves the intended no-op (empty ⇒
+// cache disabled) and lets a later source take over even when an earlier one is present-but-empty.
+// When nothing resolves the cache disables itself (isEnabled below), so fork PRs and un-provisioned
+// checkouts fall back to the local cache with no error.
 //
 // Push: writes are restricted to trusted CI builds. CI sets ON_CI=true only on main-branch runs, so
 // PRs and developer machines are read-only. The gate is value-based (not env-var presence) so an
@@ -59,17 +66,16 @@ buildCache {
 
         credentials {
             username = "token-auth"
+            // Non-blank view of a single env var / gradle property: trims and drops empties so a
+            // present-but-empty source doesn't shadow a later fallback (see the header comment).
+            val nonBlank = { source: Provider<String> ->
+                source.map { it.trim() }.filter { it.isNotEmpty() }
+            }
             password =
-                providers
-                    .environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() }
-                    .orElse(
-                        providers
-                            .gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")
-                            .map { it.trim() }
-                            .filter { it.isNotEmpty() }
-                    )
+                nonBlank(providers.environmentVariable("BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN"))
+                    .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN")))
+                    .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+                    .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
                     .orNull
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #205 / #206. The BuildFetch token is now resolved from the first **non-blank** of, in order:

1. env `BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN` — project-specific
2. gradle property `BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN`
3. env `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` — shared / general fallback
4. gradle property `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN`

### Why

This repo and compose-ai-tools point at **different** BuildFetch caches, so a single shared token can't authenticate both. A project-specific name lets a developer keep a separate `cache:readonly` token per project in one `~/.gradle/gradle.properties`:

```properties
BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN=<meshcore readonly token>
BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN=<compose-ai-tools readonly token>
```

The general `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` stays as a fallback — it's what CI exports today (no secret rename needed) and what a single-project setup can use. Env wins over a gradle property of the same name so CI overrides a stray local property.

### Blank-handling preserved

Each source is trimmed and filtered for blanks **independently** before the fallback, so a present-but-empty value (e.g. the env var CI exports unconditionally when the secret is unset, or on fork PRs) doesn't shadow a later source and doesn't enable the cache with an empty password — the intended no-op from #206 still holds across all four sources.

### CI / secrets — no change required

`ci.yml` continues to export the general `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` from the existing repo secret, which is picked up by source #3. Nothing to re-provision.

## Test plan

- [x] `settings.gradle.kts` evaluates cleanly (verified locally: build proceeds past settings evaluation, failing only on the pre-existing Gradle-version requirement in `app/build.gradle.kts`, unrelated to this change — the correct Gradle distribution and Android SDK aren't available in the sandbox).
- [ ] CI green on this PR.

_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZNP9KNVXpZbwDVimAdw86)_