### PR TITLE
build: seed BuildFetch remote cache from CI (disable local cache on pushing runs)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,7 +60,20 @@ plugins {
 // Push: writes are restricted to trusted CI builds. CI sets ON_CI=true only on main-branch runs, so
 // PRs and developer machines are read-only. The gate is value-based (not env-var presence) so an
 // explicit ON_CI=false is honoured as read-only.
+val onCi = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
 buildCache {
+    // On the trusted main-branch runs, CI is the sole writer of the BuildFetch remote cache — and the
+    // only thing that populates it for every other consumer (PRs, developer machines). Gradle never
+    // re-uploads a *local* build-cache hit to the remote; it pushes to the remote only when a task
+    // actually executes. setup-gradle restores a warm local build cache (caches/build-cache-1) from
+    // the GitHub Actions cache, so without this every task resolves as FROM-CACHE (local), nothing is
+    // pushed, and the remote stays empty (dev machines then see 0 remote hits). Disabling the local
+    // cache on the pushing runs forces tasks to execute-and-push, or to hit the remote directly, so
+    // BuildFetch actually gets seeded. Off-CI and on PRs the local cache stays on (harmless — those
+    // runs don't push, and a redundant local cache just makes them faster).
+    local {
+        isEnabled = !onCi
+    }
     remote<HttpBuildCache> {
         url = uri("https://cache.eu-central-a.buildfetch.com/vuFQad/gradle/")
 
@@ -79,7 +92,7 @@ buildCache {
                     .orNull
         }
 
-        isPush = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
+        isPush = onCi
 
         isEnabled = credentials.password != null
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,40 +61,51 @@ plugins {
 // PRs and developer machines are read-only. The gate is value-based (not env-var presence) so an
 // explicit ON_CI=false is honoured as read-only.
 val onCi = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
+
+// Non-blank view of a single env var / gradle property: trims and drops empties so a present-but-empty
+// source doesn't shadow a later fallback (see the header comment).
+val nonBlank = { source: Provider<String> -> source.map { it.trim() }.filter { it.isNotEmpty() } }
+val cacheToken =
+    nonBlank(providers.environmentVariable("BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN"))
+        .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN")))
+        .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+        .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+        .orNull
+
+// True only when this run will actually push to the remote: a trusted main-branch run (ON_CI) with a
+// usable token. Anything else (PRs, dev machines, or a main run whose token is unprovisioned/blank)
+// does not push, so it must keep the local cache.
+val remotePushEnabled = onCi && cacheToken != null
+
 buildCache {
     // On the trusted main-branch runs, CI is the sole writer of the BuildFetch remote cache — and the
     // only thing that populates it for every other consumer (PRs, developer machines). Gradle never
     // re-uploads a *local* build-cache hit to the remote; it pushes to the remote only when a task
     // actually executes. setup-gradle restores a warm local build cache (caches/build-cache-1) from
-    // the GitHub Actions cache, so without this every task resolves as FROM-CACHE (local), nothing is
-    // pushed, and the remote stays empty (dev machines then see 0 remote hits). Disabling the local
+    // the GitHub Actions cache, so with it in place every task resolves as FROM-CACHE (local), nothing
+    // is pushed, and the remote stays empty (dev machines then see 0 remote hits). Disabling the local
     // cache on the pushing runs forces tasks to execute-and-push, or to hit the remote directly, so
-    // BuildFetch actually gets seeded. Off-CI and on PRs the local cache stays on (harmless — those
-    // runs don't push, and a redundant local cache just makes them faster).
+    // BuildFetch actually gets seeded.
+    //
+    // Gate this on remotePushEnabled, not just ON_CI: if the token is unprovisioned/blank the remote
+    // below disables itself, and disabling the local cache too would make that main run execute every
+    // cacheable task with *no* cache at all. Off-CI, on PRs, and on token-less main runs the local
+    // cache stays on (harmless when the remote is also active — those runs don't push — and the only
+    // cache left when the remote is off).
     local {
-        isEnabled = !onCi
+        isEnabled = !remotePushEnabled
     }
     remote<HttpBuildCache> {
         url = uri("https://cache.eu-central-a.buildfetch.com/vuFQad/gradle/")
 
         credentials {
             username = "token-auth"
-            // Non-blank view of a single env var / gradle property: trims and drops empties so a
-            // present-but-empty source doesn't shadow a later fallback (see the header comment).
-            val nonBlank = { source: Provider<String> ->
-                source.map { it.trim() }.filter { it.isNotEmpty() }
-            }
-            password =
-                nonBlank(providers.environmentVariable("BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN"))
-                    .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN")))
-                    .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
-                    .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
-                    .orNull
+            password = cacheToken
         }
 
         isPush = onCi
 
-        isEnabled = credentials.password != null
+        isEnabled = cacheToken != null
     }
 }
 


### PR DESCRIPTION
## Summary

The BuildFetch remote Gradle build cache authenticates correctly (`authenticated = true`) but was serving **zero hits** to developer machines — every task key returns HTTP 404 from `cache.eu-central-a.buildfetch.com/vuFQad/gradle/`, i.e. the cache is effectively empty.

Root cause: `gradle/actions/setup-gradle` restores a warm **local** `build-cache-1` from the GitHub Actions cache, so on the trusted main-branch runs every task resolves as `FROM-CACHE (local)`. Gradle only pushes an entry to the remote when the task actually **executes** — it never re-uploads a local-cache hit — so CI never populates BuildFetch, and every downstream consumer (PRs, dev machines) misses.

This disables Gradle's **local** build cache on the pushing runs (`ON_CI=true`, main only) so tasks execute-and-push and seed BuildFetch. Off-CI and on PRs the local cache stays enabled (redundant but harmless — those runs don't push).

## Test plan

- [x] Off-CI: `./gradlew :meshcore-core:help -i` → `Using local directory build cache` present (local enabled), remote pull-only.
- [x] `ON_CI=true ./gradlew :meshcore-core:help -i` → no local-cache line (local disabled on CI).
- [x] Direct probe of BuildFetch for local task keys returns 404 before this change (empty remote), confirming the diagnosis.
- [ ] After merge, the first main CI run seeds the remote (one-time slow run); subsequent PRs/dev builds should then get remote hits (verify with `mv ~/.gradle/caches/build-cache-1 aside; ./gradlew clean <task> --build-cache -i` → look for `from the remote build cache`).