### PR TITLE
ci: skip caching the unused local build cache on pushing runs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,15 @@ inputs:
       Pass 'true' in publish/release jobs to prevent Gradle cache
       writes — avoids cache poisoning from untrusted PR runs.
     default: 'false'
+  exclude-local-build-cache:
+    description: >
+      Pass 'true' on the runs that push to the BuildFetch remote cache
+      (main-branch CI). settings.gradle.kts already disables Gradle's local
+      build cache on those runs so tasks execute-and-push to the remote;
+      this additionally stops setup-gradle from restoring/saving the (then
+      unused) local build cache to the GitHub Actions cache — saving cache
+      time and storage. Leave 'false' elsewhere so PR/dev runs keep it.
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -16,3 +25,4 @@ runs:
     - uses: gradle/actions/setup-gradle@v6.2.0
       with:
         cache-read-only: ${{ inputs.cache-read-only }}
+        gradle-home-cache-excludes: ${{ inputs.exclude-local-build-cache == 'true' && 'caches/build-cache-1' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          # Main-branch runs push to the BuildFetch remote cache (settings.gradle.kts disables the
+          # local cache there); don't restore/save the unused local build cache to the Actions cache.
+          exclude-local-build-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - run: ./gradlew :app:assembleDebug :wear:assembleDebug --stacktrace
 
@@ -53,6 +56,9 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          # Main-branch runs push to the BuildFetch remote cache (settings.gradle.kts disables the
+          # local cache there); don't restore/save the unused local build cache to the Actions cache.
+          exclude-local-build-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - run: ./gradlew test --stacktrace
 
@@ -77,6 +83,9 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          # Main-branch runs push to the BuildFetch remote cache (settings.gradle.kts disables the
+          # local cache there); don't restore/save the unused local build cache to the Actions cache.
+          exclude-local-build-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - run: ./gradlew lintDebug --stacktrace
 


### PR DESCRIPTION
## Summary

Follow-up to #208 (which disables Gradle's local build cache on the pushing main-branch runs so the BuildFetch remote cache actually gets seeded).

On those main runs Gradle now ignores the local cache, but `gradle/actions/setup-gradle` still **restores and re-saves** `caches/build-cache-1` to the GitHub Actions cache — wasting cache time and storage on a cache Gradle never reads. This adds an `exclude-local-build-cache` input to the repo-local `setup` composite action (`gradle-home-cache-excludes: caches/build-cache-1`) and sets it on the main-branch CI jobs. PR/dev runs keep the local cache.

The input defaults to `'false'`, so the other six workflows that call `./.github/actions/setup` (`compose-preview`, `design-parity`, `ktfmt`, `design-artifacts`, `claude`, `release-build`) are unaffected.

This is the native `gradle/actions` mechanism ([documented recommendation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md) for remote caches) for the same effect the `settings.gradle.kts` gate from #208 achieves in-build — the two are complementary: the settings gate stops Gradle *reading* the local cache; this stops the Actions cache *restoring/saving* it.

## Test plan

- [x] `yaml.safe_load` on both changed files → parses cleanly.
- [x] Expression `${{ inputs.exclude-local-build-cache == 'true' && 'caches/build-cache-1' || '' }}` yields the exclude path on main and an empty (no-op) value elsewhere.
- [x] New input defaults to `'false'`; other callers of `./.github/actions/setup` unchanged.