### PR TITLE
build: make gRPC protobuf codegen relocatable for remote cache

### DIFF
--- a/meshcore-grpc-service/build.gradle.kts
+++ b/meshcore-grpc-service/build.gradle.kts
@@ -32,6 +32,15 @@ protobuf {
         create("grpc") { option("lite") }
         create("grpckt") { option("lite") }
       }
+      // Make GenerateProtoTask relocatable across machines so it restores from
+      // the remote (BuildFetch) build cache. The jar-based grpckt plugin is
+      // launched through a `java` trampoline, and the task records the absolute
+      // path of that JDK as a cache-key input (`javaExecutablePath`). That path
+      // differs between CI and developer/agent machines, so this was the one
+      // task that never hit the remote cache. The generated sources don't
+      // depend on which JVM runs the plugin, so pin the input to a bare `java`
+      // (resolved from PATH at execution time) to keep the key machine-neutral.
+      task.javaExecutablePath.set("java")
     }
   }
 }


### PR DESCRIPTION
## Summary

`:meshcore-grpc-service:generateProto` was the **only** cacheable task that never restored from the BuildFetch remote build cache — every other cacheable task in a clean `:app:assembleDebug :wear:assembleDebug` did (measured: 69/70 restored from remote on a fresh checkout with the local cache wiped).

Root cause: `GenerateProtoTask` (protobuf-gradle-plugin 0.10.0) declares **`javaExecutablePath`** — the absolute path of the JDK that launches the jar-based `grpckt` codegen plugin — as a build-cache-key input. Every other input on the task is content- or relative-path-normalized (relocatable), but this one is the raw machine path, which differs between CI's `setup-java` toolcache and developer/agent machines. That single input defeated cross-machine reuse.

## Fix

Pin the launcher to a bare `java` (resolved from PATH at execution time) inside the existing `generateProtoTasks.all().forEach` block:

```kotlin
task.javaExecutablePath.set("java")
```

The generated sources are identical regardless of which JVM runs the plugin, so the cache key becomes machine-neutral without changing output. `java` is on PATH on CI (`setup-java`) and in the agent/dev environments.

## Verification

- Confirmed via Gradle's `-Dorg.gradle.caching.debug` that `javaExecutablePath` was the sole machine-specific cache-key input; all others use `RELATIVE_PATH`/`IGNORED_PATH` normalization.
- After the fix, the `javaExecutablePath` input fingerprint changes to the fingerprint of the literal string `"java"`, and no absolute machine path remains in any value input.
- `:meshcore-grpc-service:generateProto` builds successfully and regenerates the `grpckt` stub (the `java` trampoline resolves from PATH).
- Full `:app:assembleDebug :wear:assembleDebug` is green — nothing downstream is affected.

## Note

This deliberately changes the task's cache key, so the first `main` build after merge repopulates the remote entry under the new machine-neutral key. From then on every machine (CI, dev, agent) computes the same key and restores it — taking a clean assemble from 70/70 cacheable → 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117Jv4jHdjsJb7cVQk25NNG)_