### PR TITLE
feat(design): section the published catalog into tabs

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Design-catalog spec for the MeshCore mobile design system. Code-led: it declares which @Preview composables (by function name) make up the published sticker sheet, their grouping, and captions. Consumed by @design-parity/catalog-export (via compose-ai-tools' scripts/design-artifacts/generate-design-catalog.mjs) over a `compose-preview bundle pack --module :app` render to produce the importable design-artifacts/meshcore-mobile bundle the public preview server serves at /meshcore-mobile/. Each `preview` MUST equal the exact @Preview function name in :app (ee.schimke.meshcore.app.ui.ComponentPreviews).",
+  "$comment": "Design-catalog spec for the MeshCore mobile design system. Code-led: it declares which @Preview composables (by function name) make up the published sticker sheet, their grouping, and captions. Consumed by @design-parity/catalog-export (via compose-ai-tools' scripts/design-artifacts/generate-design-catalog.mjs) over a `compose-preview bundle pack --module :app` render to produce the importable design-artifacts/meshcore-mobile bundle the public preview server serves at /meshcore-mobile/. Each `preview` MUST equal the exact @Preview function name in :app (ee.schimke.meshcore.app.ui.ComponentPreviews). Each group's optional `section` is the top-level TAB the preview server buckets it under (Themes / Components / Screens / Animations / …) — one level above `name`, which becomes the sub-heading inside the tab; groups follow this file's order, so tabs read Themes → Components → Screens.",
   "system": "meshcore-mobile",
   "title": "MeshCore Mobile",
   "library": [
@@ -12,6 +12,7 @@
   "groups": [
     {
       "name": "Foundation",
+      "section": "Themes",
       "components": [
         {
           "componentId": "Theme/MeshCore-Light",
@@ -37,6 +38,7 @@
     },
     {
       "name": "Device",
+      "section": "Components",
       "components": [
         {
           "componentId": "DeviceSummaryCard/Populated",
@@ -52,6 +54,7 @@
     },
     {
       "name": "Contacts",
+      "section": "Components",
       "components": [
         {
           "componentId": "ContactRow/Variants",
@@ -77,6 +80,7 @@
     },
     {
       "name": "Bluetooth",
+      "section": "Components",
       "components": [
         {
           "componentId": "BleDeviceList/Empty",
@@ -97,6 +101,7 @@
     },
     {
       "name": "Connection",
+      "section": "Components",
       "components": [
         {
           "componentId": "TcpConnectPanel/Idle",
@@ -112,6 +117,7 @@
     },
     {
       "name": "Permissions",
+      "section": "Components",
       "components": [
         {
           "componentId": "BlePermissionPanel/First",
@@ -126,7 +132,8 @@
       ]
     },
     {
-      "name": "Screens · Scanner",
+      "name": "Scanner",
+      "section": "Screens",
       "components": [
         {
           "componentId": "Scanner/SavedEmpty",
@@ -181,7 +188,8 @@
       ]
     },
     {
-      "name": "Screens · Device",
+      "name": "Device",
+      "section": "Screens",
       "components": [
         {
           "componentId": "Device/Loading",


### PR DESCRIPTION
## Summary

Tag each catalog group in `catalog.spec.json` with the top-level **`section`** the preview server now renders as a tab, so `preview.coo.ee/meshcore-mobile/` opens with **Themes → Components → Screens** tabs instead of one long grid.

| Section | Groups |
|---|---|
| **Themes** | Foundation |
| **Components** | Device · Contacts · Bluetooth · Connection · Permissions |
| **Screens** | Scanner · Device |

The two screen groups are renamed `Screens · Scanner` / `Screens · Device` → `Scanner` / `Device` (the tab already carries "Screens"). Groups stay the sub-heading inside a tab and follow file order, so the tabs come out in the intended order. `group` is display-only, so the rename is safe. Preview function names / component ids are untouched.

## Depends on

- **yschimke/design-parity#233** — `section` in `@design-parity/catalog-export`
- **yschimke/compose-ai-tools#2561** — `serve` renders the tabs + the generator threads `section`

The tabs go live after those ship and the `design-artifacts/meshcore-mobile` branch regenerates (via `design-artifacts.yml`). Until then this is an inert, additive metadata field.

## Test plan

- [x] `catalog.spec.json` parses; 8 groups map to **Themes → Components → Screens** (33 previews total, unchanged)
- [x] No component id / preview function name changes — only group `section` tags (+ two cosmetic group renames)

Here's how the published page looks with the tabs (rendered from the compose-ai-tools fixture in #2561):

![meshcore-mobile tabbed page — light](https://raw.githubusercontent.com/yschimke/compose-ai-tools/eaa2dc550f9be0405f027f2b9264fb39f9afd36d/docs/images/serve-tabs-sections-light.png)

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_