### PR TITLE
fix(design): give the screen Device group a distinct name

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -188,7 +188,7 @@
       ]
     },
     {
-      "name": "Device",
+      "name": "Device screen",
       "section": "Screens",
       "components": [
         {


### PR DESCRIPTION
## Summary

Follow-up to #224. Rename the **Screens**-section `Device` group to **`Device screen`** so it no longer shares a name with the **Components** `Device` group (DeviceSummaryCard).

### Why

As the Codex review on #224 flagged (P2): the published exporter (`generate-design-catalog.mjs`) still emits only `group: name` and ignores `section` until design-parity's section-aware `catalog-export` release propagates to it. In that window, a scheduled `design-artifacts.yml` regen would produce **two `Device` groups**, which merge / mislabel on the flat sticker sheet and lose the screen's distinct label.

A distinct group name fixes it in **both** worlds:
- **Now (flat, pre-section):** `Device` (Components) and `Device screen` (Screens) are separate, correctly-labelled groups.
- **Later (tabbed):** `Device screen` reads cleanly as a sub-heading under the **Screens** tab — no redundant `Screens · ` prefix to strip.

`section` tags are unchanged; only the one group name changes.

## Test plan

- [x] `catalog.spec.json` parses; 8 group names all **unique** (`Foundation, Device, Contacts, Bluetooth, Connection, Permissions, Scanner, Device screen`)
- [x] No component id / preview function name changes

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_