### PR TITLE
chore(previews): split ContactRow variants, add low-battery card state

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ComponentPreviews.kt
@@ -115,17 +115,80 @@ fun DeviceSummaryCardLoadingPreview() {
     }
 }
 
+// Low-battery state: DeviceSummaryCard's BatterySection switches to the tertiary "warn" tint and the
+// low-battery icon below 30%, which no standalone card preview otherwise exercises.
+@Preview(showBackground = true, name = "Light")
+@Preview(showBackground = true, name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun DeviceSummaryCardLowBatteryPreview() {
+    MeshcoreTheme {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+            DeviceSummaryCard(
+                self = SelfInfo(
+                    advertType = 1,
+                    txPowerDbm = 14,
+                    maxPowerDbm = 22,
+                    publicKey = pk(0xAB.toByte()),
+                    latitude = 53.0,
+                    longitude = -1.5,
+                    multiAcks = 0,
+                    advertLocationPolicy = 0,
+                    telemetryFlags = 0,
+                    manualAddContacts = 0,
+                    radio = RadioSettings(869_525_000, 125_000, 10, 5),
+                    name = "node-cabin",
+                ),
+                radio = RadioSettings(869_525_000, 125_000, 10, 5),
+                battery = BatteryInfo(3210, 3800, 4096),
+            )
+        }
+    }
+}
+
 // --- ContactRow / ContactList --------------------------------------------
+
+// One preview per contact kind (chat / repeater / room / sensor) so the catalog exports them as a
+// ContactRow component set keyed on type, instead of one stacked "variants" sticker.
 
 @Preview(showBackground = true, name = "Light", widthDp = 340)
 @Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun ContactRowVariantsPreview() {
+fun ContactRowChatPreview() {
     MeshcoreTheme {
         Column(Modifier.fillMaxWidth().padding(16.dp)) {
             ContactRow(contact("alice", pathLen = -1, fill = 0x11, type = ContactType.CHAT))
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun ContactRowRepeaterPreview() {
+    MeshcoreTheme {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             ContactRow(contact("bob-repeater", pathLen = 2, fill = 0x22, type = ContactType.REPEATER))
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun ContactRowRoomPreview() {
+    MeshcoreTheme {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             ContactRow(contact("common-room", pathLen = 0, fill = 0x33, type = ContactType.ROOM))
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Light", widthDp = 340)
+@Preview(showBackground = true, name = "Dark", widthDp = 340, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun ContactRowSensorPreview() {
+    MeshcoreTheme {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
             ContactRow(contact("soil-sensor-1", pathLen = 3, fill = 0x44, type = ContactType.SENSOR))
         }
     }

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -49,6 +49,11 @@
           "componentId": "DeviceSummaryCard/Loading",
           "preview": "DeviceSummaryCardLoadingPreview",
           "caption": "Loading / not-yet-known state."
+        },
+        {
+          "componentId": "DeviceSummaryCard/LowBattery",
+          "preview": "DeviceSummaryCardLowBatteryPreview",
+          "caption": "Low-battery warning tint (below 30%)."
         }
       ]
     },
@@ -57,9 +62,24 @@
       "section": "Components",
       "components": [
         {
-          "componentId": "ContactRow/Variants",
-          "preview": "ContactRowVariantsPreview",
-          "caption": "The four contact kinds: chat, repeater, room, sensor."
+          "componentId": "ContactRow/Chat",
+          "preview": "ContactRowChatPreview",
+          "caption": "Contact row — direct chat contact."
+        },
+        {
+          "componentId": "ContactRow/Repeater",
+          "preview": "ContactRowRepeaterPreview",
+          "caption": "Contact row — repeater."
+        },
+        {
+          "componentId": "ContactRow/Room",
+          "preview": "ContactRowRoomPreview",
+          "caption": "Contact row — room / group."
+        },
+        {
+          "componentId": "ContactRow/Sensor",
+          "preview": "ContactRowSensorPreview",
+          "caption": "Contact row — sensor."
         },
         {
           "componentId": "ContactList/Empty",


### PR DESCRIPTION
## Summary

Phase 1 of the design-catalog / Figma work — a focused cleanup of the component previews that feed the published `catalog.spec.json` sticker sheet.

- **Split** the combined `ContactRowVariantsPreview` (four contact kinds stacked in one sticker) into four single-type previews — `ContactRowChatPreview`, `ContactRowRepeaterPreview`, `ContactRowRoomPreview`, `ContactRowSensorPreview` — so the catalog exports `ContactRow` as a component **set** keyed on contact type rather than one flat "variants" tile.
- **Add** `DeviceSummaryCardLowBatteryPreview`, exercising the sub-30% battery **warning tint** (tertiary colour + low-battery icon) that no standalone card preview previously covered.
- `catalog.spec.json` updated to match: `ContactRow/{Chat,Repeater,Room,Sensor}` replace `ContactRow/Variants`, and `DeviceSummaryCard/LowBattery` is added (**37** catalog components total; valid JSON).

Previews + catalog spec only — no production code changes.

Follow-ups in later phases (tracked separately): the missing **screens** (Contact chat, Channel chat, Commands, Device settings, Cached device) land with the catalog screens-graph work, and `ScannerBleDark` is removed once dark becomes a theme *axis* rather than a standalone preview.

## Visual evidence

Rendered by CI (**Compose Preview**), commit-pinned to `62d0c49`.

**New — `DeviceSummaryCard/LowBattery`** — the sub-30% battery warning tint (tertiary colour + low-battery icon):

| Light | Dark |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/62d0c4951cc95951a9a7eb545031301d6f9e8850/renders/app/DeviceSummaryCardLowBatteryPreview_Light.png" width="240"/> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/62d0c4951cc95951a9a7eb545031301d6f9e8850/renders/app/DeviceSummaryCardLowBatteryPreview_Dark.png" width="240"/> |

**`ContactRow` — split one combined `Variants` sticker → four single-type previews** (a proper component set keyed on contact type):

| Chat | Repeater | Room | Sensor |
| --- | --- | --- | --- |
| <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/62d0c4951cc95951a9a7eb545031301d6f9e8850/renders/app/ContactRowChatPreview_Light.png" width="180"/> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/62d0c4951cc95951a9a7eb545031301d6f9e8850/renders/app/ContactRowRepeaterPreview_Light.png" width="180"/> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/62d0c4951cc95951a9a7eb545031301d6f9e8850/renders/app/ContactRowRoomPreview_Light.png" width="180"/> | <img src="https://raw.githubusercontent.com/yschimke/meshcore-mobile/62d0c4951cc95951a9a7eb545031301d6f9e8850/renders/app/ContactRowSensorPreview_Light.png" width="180"/> |

Dark variants rendered too (see the **Compose Preview** diff comment). The removed `ContactRowVariantsPreview` has no committed `preview_main` baseline yet — this is the first PR to render these — so there's no "before" image to embed; its removal is shown in the CI preview-diff.

## Test plan

- [x] `No AI agents` — branch name + commit/PR identity scan (author/committer is `Yuri Schimke <yuri@schimke.ee>`)
- [x] **Compose Preview** renders the five new previews (Light + Dark) without error
- [x] `catalog.spec.json` valid JSON (37 components)
- [ ] `ktfmtCheck` green
- [ ] `Assemble (debug)` / `Unit tests` / `Android lint` green

_Generated by [Claude Code]_