### PR TITLE
chore(design-artifacts): fold meshcore-components screens into the catalog

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -71,13 +71,28 @@ jobs:
 
       # Render the catalog module into a portable bundle with semantics (a11y
       # greenlines + layout tree → tokens/wireframes in the exported catalog).
-      - name: Render catalog bundle
+      - name: Render catalog bundle (:app, Android/Robolectric)
         run: |
           set -euo pipefail
           compose-preview bundle pack --module :app --with-semantics \
             -o "$GITHUB_WORKSPACE/meshcore-mobile-bundle.png"
 
-      # Join the render to catalog.spec.json and write the importable bundle.
+      # The Chat / Settings / Cached-device screens live in :meshcore-components
+      # (the shared CMP library) — previewed there for design-parity on the CMP
+      # desktop (Skiko) backend rather than re-authored as :app stickers. Render
+      # them as a second bundle so generate-design-catalog folds them in via
+      # --extra-renders; function names are unique across the two modules, so the
+      # join is unambiguous. UTF-8 forced: the component preview ids carry em-dashes.
+      - name: Render component screens (:meshcore-components, CMP desktop)
+        env:
+          LANG: C.UTF-8
+          LC_ALL: C.UTF-8
+        run: |
+          set -euo pipefail
+          compose-preview bundle pack --module meshcore-components --with-semantics \
+            -o "$GITHUB_WORKSPACE/meshcore-components-bundle.png" --timeout 600
+
+      # Join both renders to catalog.spec.json and write the importable bundle.
       # `source: {repo, ref, module}` lets a trusted, toolchain-equipped box
       # live-rerender; it's inert on the desktop-only public server.
       - name: Generate importable catalog
@@ -86,6 +101,7 @@ jobs:
           node compose-ai-tools/scripts/design-artifacts/generate-design-catalog.mjs \
             --spec catalog.spec.json \
             --renders "$GITHUB_WORKSPACE/meshcore-mobile-bundle.png" \
+            --extra-renders "$GITHUB_WORKSPACE/meshcore-components-bundle.png" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)" \
             --source-repo "${GITHUB_REPOSITORY}" \

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Design-catalog spec for the MeshCore mobile design system. Code-led: it declares which @Preview composables (by function name) make up the published sticker sheet, their grouping, and captions. Consumed by @design-parity/catalog-export (via compose-ai-tools' scripts/design-artifacts/generate-design-catalog.mjs) over a `compose-preview bundle pack --module :app` render to produce the importable design-artifacts/meshcore-mobile bundle the public preview server serves at /meshcore-mobile/. Each `preview` MUST equal the exact @Preview function name in :app (ee.schimke.meshcore.app.ui.ComponentPreviews). Each group's optional `section` is the top-level TAB the preview server buckets it under (Themes / Components / Screens / Animations / …) — one level above `name`, which becomes the sub-heading inside the tab; groups follow this file's order, so tabs read Themes → Components → Screens.",
+  "$comment": "Design-catalog spec for the MeshCore mobile design system. Code-led: it declares which @Preview composables (by function name) make up the published sticker sheet, their grouping, and captions. Consumed by @design-parity/catalog-export (via compose-ai-tools' scripts/design-artifacts/generate-design-catalog.mjs) over a `compose-preview bundle pack --module :app` render — plus a second `--module meshcore-components` (CMP desktop) render folded in via the generator's `--extra-renders` for the Screens that live in that library module — to produce the importable design-artifacts/meshcore-mobile bundle the public preview server serves at /meshcore-mobile/. Each `preview` MUST equal an exact @Preview function name: for Themes/Components/the app Screens it is in :app (ee.schimke.meshcore.app.ui.ComponentPreviews etc.); for the meshcore-components Screens (Chat/*, Settings/*, Device/Cached) it is in :meshcore-components (ee.schimke.meshcore.components.ui.*Previews), folded in via --extra-renders. Function names are unique across the two modules, so the join is unambiguous. Each group's optional `section` is the top-level TAB the preview server buckets it under (Themes / Components / Screens / Animations / …) — one level above `name`, which becomes the sub-heading inside the tab; groups follow this file's order, so tabs read Themes → Components → Screens.",
   "system": "meshcore-mobile",
   "title": "MeshCore Mobile",
   "library": [
@@ -240,6 +240,43 @@
           "componentId": "Device/StatusFailed",
           "preview": "DeviceStatusFailedPreview",
           "caption": "Device connection status — failed, with cause."
+        },
+        {
+          "componentId": "Device/Cached",
+          "preview": "CachedDeviceBodyPreview",
+          "caption": "Device screen — cached (offline) data, with the stale-data warning banner."
+        }
+      ]
+    },
+    {
+      "name": "Chat",
+      "section": "Screens",
+      "components": [
+        {
+          "componentId": "Chat/Contact",
+          "preview": "ContactChatPreview",
+          "caption": "Contact chat — a 1:1 direct-message thread."
+        },
+        {
+          "componentId": "Chat/Channel",
+          "preview": "ChannelChatPreview",
+          "caption": "Channel chat — a group broadcast channel."
+        },
+        {
+          "componentId": "Chat/Commands",
+          "preview": "CommandsPreview",
+          "caption": "Commands console — the device command/response log."
+        }
+      ]
+    },
+    {
+      "name": "Settings",
+      "section": "Screens",
+      "components": [
+        {
+          "componentId": "Settings/Ready",
+          "preview": "DeviceSettingsPreview",
+          "caption": "Device settings — discovered device, with the buzzer toggle."
         }
       ]
     }


### PR DESCRIPTION
## Summary

**Phase 3 (Option B): add the missing screens to the published catalog by rendering `:meshcore-components` into it — no duplication.**

The Contact chat, Channel chat, Commands, Device settings and cached-device screens live only in `:meshcore-components` (the shared CMP library), where they're already previewed for design-parity on the CMP desktop (Skiko) backend. Rather than re-author them as `:app` Robolectric stickers (duplicating ~200 lines of message/state fixtures), this folds a **second render bundle** into the catalog export via the generator's existing `--extra-renders`:

- **`design-artifacts.yml`**: add a `compose-preview bundle pack --module meshcore-components` (CMP desktop) render and pass it as `--extra-renders`. Function names are unique across `:app` and `:meshcore-components`, so the join is unambiguous.
- **`catalog.spec.json`**: add Screens groups **Chat** (`Contact` / `Channel` / `Commands`) and **Settings** (`Ready`), plus **`Device/Cached`** — referencing the existing meshcore-components preview functions. (42 catalog components; valid JSON.)

No preview or production code changes — the screens are existing previews; this only wires them into the catalog.

## Verification

`design-artifacts.yml` runs on schedule / `workflow_dispatch` (not on PRs), so the catalog render can't run on this PR. It's verified by **dispatching `design-artifacts.yml`** after merge — which also clears the Phase-1 staleness on the `design-artifacts/meshcore-mobile` delivery branch. The five screens already render on the CMP desktop backend for design-parity (see `design-parity/main`), so this is build-wiring + catalog config, not new rendering.

## Visual evidence

The five screens render via `compose-preview` on this PR (the `:meshcore-components` previews) — I'll embed the rendered PNGs here once that CI render completes.

## Test plan

- [ ] `No AI agents` (branch + identity) green
- [ ] `catalog.spec.json` valid JSON (42 components) · workflow YAML valid
- [ ] Post-merge: dispatch `design-artifacts.yml`, confirm the Chat/Settings/Cached screens land in the `design-artifacts/meshcore-mobile` bundle

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_