### PR TITLE
ci: seed and diagnose the BuildFetch remote build cache

### DIFF
--- a/.github/workflows/cache-diagnostics.yml
+++ b/.github/workflows/cache-diagnostics.yml
@@ -1,0 +1,42 @@
+name: Cache diagnostics
+
+# On-demand build-cache diagnostics (scripts/cache-diagnostics.sh). Not wired to
+# push/PR — it runs the build several times and is meant to be dispatched when
+# investigating the BuildFetch remote cache hit rate. It forces the remote cache
+# OFF (see the script), so it never reads from or writes to the shared remote.
+on:
+  workflow_dispatch:
+    inputs:
+      tasks:
+        description: 'Gradle tasks to probe (space-separated)'
+        default: ':app:assembleDebug :wear:assembleDebug test lintDebug'
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    name: Relocatability + cacheability probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      # JDK only — the Android SDK is preinstalled on ubuntu-latest, and we
+      # deliberately skip the shared setup-gradle Actions caching so the probe
+      # isn't perturbed by a restored Gradle home.
+      - uses: actions/setup-java@v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Run cache diagnostics
+        run: scripts/cache-diagnostics.sh ${{ inputs.tasks }}
+
+      - name: Upload raw Gradle logs
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: cache-diagnostics-logs
+          path: ${{ runner.temp }}/cache-diag/*.raw
+          if-no-files-found: ignore

--- a/scripts/cache-diagnostics.sh
+++ b/scripts/cache-diagnostics.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Build-cache diagnostics for the BuildFetch remote cache.
+#
+# Both probes run against the LOCAL build cache with the *remote* cache forced
+# off (no token, ON_CI unset), so results are deterministic and never touch or
+# pollute the shared BuildFetch remote.
+#
+#   1. relocatability (the priority — hypothesis #3)
+#      Build the SAME commit at two different absolute paths and diff each
+#      cacheable task's build-cache key. A key that differs between the two
+#      paths means the task encoded an absolute path (or other machine-local
+#      state) into its inputs, so it can NEVER hit across machines or checkouts.
+#      These are the tasks dragging the cross-machine hit rate down; fix them
+#      (e.g. the org.gradle.android.cache-fix plugin, or making the offending
+#      input path-relative).
+#
+#   2. cacheability (the general per-task breakdown)
+#      Build cold (populate) then warm (consume) at one path, and list every
+#      task that is NOT reused FROM-CACHE/UP-TO-DATE on the warm run — i.e.
+#      non-cacheable tasks or tasks with an unstable key.
+#
+# Usage:  scripts/cache-diagnostics.sh [gradle tasks...]
+# Default tasks mirror the ci.yml cache consumers.
+set -euo pipefail
+
+TASKS=("$@")
+if [ ${#TASKS[@]} -eq 0 ]; then
+  TASKS=(":app:assembleDebug" ":wear:assembleDebug" "test" "lintDebug")
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="${RUNNER_TEMP:-/tmp}/cache-diag"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+# Force the remote cache off regardless of ambient env and keep the local cache
+# on (settings.gradle.kts: no token => remote disabled; ON_CI unset => local
+# enabled). This isolates path-sensitivity from remote availability.
+unset BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN \
+      BUILDFETCH_MESHCORE_GRADLE_REMOTE_CACHE_TOKEN \
+      ON_CI 2>/dev/null || true
+
+# Two pristine checkouts of HEAD at deliberately different-length absolute paths.
+# `git archive` gives byte-identical trees; only the containing path differs, so
+# any per-task key difference is caused solely by that path.
+SHORT="$WORK/s"
+LONG="$WORK/long-path/nested-deeper/and-deeper-still"
+mkdir -p "$SHORT" "$LONG"
+git -C "$REPO_ROOT" archive --format=tar HEAD | tar -x -C "$SHORT"
+git -C "$REPO_ROOT" archive --format=tar HEAD | tar -x -C "$LONG"
+
+# The Android SDK is preinstalled on ubuntu-latest; point both trees at it
+# (local.properties is gitignored, so the archives don't carry one).
+SDK="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/usr/local/lib/android/sdk}}"
+printf 'sdk.dir=%s\n' "$SDK" > "$SHORT/local.properties"
+printf 'sdk.dir=%s\n' "$SDK" > "$LONG/local.properties"
+
+# Separate Gradle homes => full isolation (neither build's local cache can
+# satisfy the other, so every task executes and logs its key).
+GH_S="$WORK/gh-s"
+GH_L="$WORK/gh-l"
+
+# Clean build that prints each task's computed build-cache key.
+build_keys() { # <srcdir> <gradle-home> <label>
+  local src="$1" gh="$2" label="$3" raw="$WORK/$3.raw" keys="$WORK/$3.keys"
+  echo ">>> building at $src ($label)"
+  if ! ( cd "$src" && ./gradlew --no-daemon --build-cache -g "$gh" \
+           -Dorg.gradle.caching.debug=true --console=plain "${TASKS[@]}" ) \
+         > "$raw" 2>&1; then
+    echo "!!! build failed ($label); tail of log:"
+    tail -n 60 "$raw"
+    return 1
+  fi
+  # "Build cache key for task ':m:t' is <hash>" -> "<task> <hash>"
+  grep -E "Build cache key for task '" "$raw" \
+    | sed -E "s/.*task '([^']+)' is ([0-9a-f]+).*/\1 \2/" \
+    | sort -u > "$keys"
+}
+
+build_keys "$SHORT" "$GH_S" short
+build_keys "$LONG"  "$GH_L" long
+
+# Tasks present in both runs whose key differs => path-sensitive (non-relocatable).
+join -j 1 "$WORK/short.keys" "$WORK/long.keys" \
+  | awk '$2 != $3 { print $1 }' | sort -u > "$WORK/nonreloc.txt" || true
+
+# Warm rebuild at the short path (GH_S is now populated) => cacheability check.
+echo ">>> warm rebuild at $SHORT (cacheability)"
+( cd "$SHORT" && ./gradlew --no-daemon --build-cache -g "$GH_S" \
+    --console=plain "${TASKS[@]}" ) > "$WORK/warm.raw" 2>&1 || true
+# Task lines with no reuse suffix re-executed despite a warm cache.
+grep -E '^> Task :' "$WORK/warm.raw" \
+  | grep -vE '(FROM-CACHE|UP-TO-DATE|NO-SOURCE|SKIPPED)$' \
+  | sed -E 's/^> Task (:[^ ]+).*/\1/' | sort -u > "$WORK/uncached.txt" || true
+
+# ---- report ----------------------------------------------------------------
+reloc_count=$(wc -l < "$WORK/nonreloc.txt" | tr -d ' ')
+uncached_count=$(wc -l < "$WORK/uncached.txt" | tr -d ' ')
+total_keys=$(wc -l < "$WORK/short.keys" | tr -d ' ')
+
+{
+  echo "# Build-cache diagnostics"
+  echo
+  echo "Tasks probed: \`${TASKS[*]}\`"
+  echo
+  echo "## 1. Relocatability (cross-machine hit killers)"
+  echo
+  echo "$reloc_count of $total_keys cacheable tasks changed their build-cache key"
+  echo "when built at a different absolute path. These can never hit across"
+  echo "machines/checkouts:"
+  echo
+  if [ "$reloc_count" -gt 0 ]; then
+    echo '```'
+    cat "$WORK/nonreloc.txt"
+    echo '```'
+  else
+    echo "_None — all probed tasks are relocatable._"
+  fi
+  echo
+  echo "## 2. Cacheability (re-ran despite a warm local cache)"
+  echo
+  if [ "$uncached_count" -gt 0 ]; then
+    echo "$uncached_count tasks were not reused FROM-CACHE/UP-TO-DATE on a warm"
+    echo "rebuild — non-cacheable or unstable-key:"
+    echo
+    echo '```'
+    cat "$WORK/uncached.txt"
+    echo '```'
+  else
+    echo "_All probed tasks were reused on the warm rebuild._"
+  fi
+  echo
+  echo "Raw Gradle logs: \`$WORK/{short,long,warm}.raw\` (uploaded as an artifact in CI)."
+} | tee "$WORK/summary.md"
+
+# Mirror the summary into the CI job summary when running under Actions.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$WORK/summary.md" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Non-zero exit if any relocatability offender was found, so the job flags it.
+[ "$reloc_count" -eq 0 ]

--- a/scripts/cache-diagnostics.sh
+++ b/scripts/cache-diagnostics.sh
@@ -84,8 +84,19 @@ build_keys "$LONG"  "$GH_L" long
 join -j 1 "$WORK/short.keys" "$WORK/long.keys" \
   | awk '$2 != $3 { print $1 }' | sort -u > "$WORK/nonreloc.txt" || true
 
-# Warm rebuild at the short path (GH_S is now populated) => cacheability check.
-echo ">>> warm rebuild at $SHORT (cacheability)"
+# Cacheability: consume GH_S (now populated) from a CLEAN tree at the SAME path
+# as the populating build. Re-extracting wipes all build/ outputs and
+# incremental state, so Gradle can't shortcut a task to UP-TO-DATE without
+# reading the cache (otherwise a non-cacheable-but-up-to-date task would be
+# silently omitted). Keeping the same path means a non-relocatable-but-cacheable
+# task still resolves FROM-CACHE, so this measures cacheability, not
+# relocatability. Anything that still executes is genuinely non-cacheable or has
+# an unstable key.
+echo ">>> warm rebuild at $SHORT from a clean tree (cacheability)"
+rm -rf "$SHORT"
+mkdir -p "$SHORT"
+git -C "$REPO_ROOT" archive --format=tar HEAD | tar -x -C "$SHORT"
+printf 'sdk.dir=%s\n' "$SDK" > "$SHORT/local.properties"
 ( cd "$SHORT" && ./gradlew --no-daemon --build-cache -g "$GH_S" \
     --console=plain "${TASKS[@]}" ) > "$WORK/warm.raw" 2>&1 || true
 # Task lines with no reuse suffix re-executed despite a warm cache.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,8 +46,9 @@ plugins {
 // The project-specific name lets a developer hold a separate readonly token per BuildFetch project
 // in a single ~/.gradle/gradle.properties (this repo and compose-ai-tools point at different caches,
 // so one shared token can't authenticate both). The general name stays as a fallback — it's what CI
-// exports (see .github/workflows/ci.yml) and what a single-project setup can use. Env wins over a
-// gradle property of the same name so CI overrides a stray local property.
+// exports (the ci.yml build/test/lint jobs plus the preview/render workflows: compose-preview,
+// design-parity, design-artifacts) and what a single-project setup can use. Env wins over a gradle
+// property of the same name so CI overrides a stray local property.
 //
 // The token is treated as absent unless it is non-blank. CI declares the env var unconditionally
 // (`BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.… }}`), so an unprovisioned secret or a fork


### PR DESCRIPTION
## Why

The BuildFetch remote build-cache hit ratio is sitting at ~23% (≈1/4). Investigating the config turned up a concrete seeding gap plus a need to confirm the leading structural suspect.

## What

**1. Seed the remote cache from the preview/render workflows.** `compose-preview`, `design-parity`, and `design-artifacts` all ran Gradle without the `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN`, so they could neither *read* the compile outputs `ci.yml` already seeds nor *push* their render task outputs. They now use the exact same wiring as `ci.yml`:
- export the token so every run **reads** the remote,
- gate push + local-build-cache-disable on `main` (`ON_CI`) so those runs **seed** the render-specific tasks (Compose `@Preview` renders, CMP-desktop `bundle pack`, `:app` Robolectric catalog render).

Effect: PR preview jobs stop re-running compile from scratch and hit `ci.yml`'s cache; devs running the same renders locally hit the seeded outputs instead of always missing.

**2. Add a build-cache diagnostic** (`scripts/cache-diagnostics.sh` + `cache-diagnostics.yml`, manual `workflow_dispatch`):
- **Relocatability** — builds the same commit at two different absolute paths and diffs each cacheable task's build-cache key. A key that changes with the path is non-relocatable and can never hit across machines/checkouts (the leading suspect for the low cross-machine rate). The job fails if any offender is found, so it also guards against regressions.
- **Cacheability** — a warm rebuild that lists tasks which re-ran despite a populated local cache.
- Forces the remote cache **off**, so it never reads from or pollutes the shared remote.

`settings.gradle.kts` header comment updated to note the preview/render workflows now export the token too.

## Test plan

- `python3 -c 'yaml.safe_load(...)'` on all four touched/added workflows — valid.
- `bash -n scripts/cache-diagnostics.sh` — syntax OK.
- No product code changes; behaviour is CI/build-cache plumbing only.
- The diagnostic is `workflow_dispatch`-only and becomes runnable once this lands on `main`; its first real (Android SDK) run is on CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_015NS1efXXJY9CriM38xrQkF)_