### PR TITLE
feat(i18n): adopt Compose Resources, localize first shared strings (17 locales)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ compose-material-icons-extended = { module = "androidx.compose.material:material
 compose-ui-text-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts", version = "1.11.4" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-preview-annotations = { module = "ee.schimke.composeai:preview-annotations", version.ref = "composePreviewAnnotations" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }

--- a/meshcore-components/build.gradle.kts
+++ b/meshcore-components/build.gradle.kts
@@ -42,6 +42,9 @@ kotlin {
       // KMP variant of preview-annotations (0.16.14+). Reflection-only markers, no runtime
       // footprint.
       implementation(libs.compose.preview.annotations)
+      // Compose Multiplatform string resources: UI copy resolves from the shared
+      // commonMain/composeResources/values*/strings.xml, so the daemon localizes per locale.
+      implementation(libs.compose.components.resources)
     }
     val androidMain by getting {
       dependencies {
@@ -56,4 +59,11 @@ kotlin {
       }
     }
   }
+}
+
+// Generate a PUBLIC `Res` accessor so :app catalog previews (and any consumer) resolve
+// the shared string resources too — mirrors :samples:design-catalog-m3-shared.
+compose.resources {
+  publicResClass = true
+  packageOfResClass = "ee.schimke.meshcore.components.generated.resources"
 }

--- a/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="label_device">جهاز</string>
+  <string name="label_no_contacts">لا توجد جهات اتصال بعد</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="label_device">Gerät</string>
+  <string name="label_no_contacts">Noch keine Kontakte</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="label_device">デバイス</string>
+  <string name="label_no_contacts">連絡先がまだありません</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Scaffold: English copy, pending real translation for this locale. -->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MeshCore shared UI strings (Compose Multiplatform resources). Default / English base; per-locale
+  overrides live in values-<locale>/strings.xml. The daemon's LocaleList provider renders any of the
+  published locales, which feeds the design catalog's locale axis. Real translations exist for
+  en / ja / ar / de; the other 13 locales are scaffolded as English copies to be filled in.
+-->
+<resources>
+  <string name="label_device">Device</string>
+  <string name="label_no_contacts">No contacts yet</string>
+</resources>

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceCards.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceCards.kt
@@ -28,6 +28,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.label_device
+import ee.schimke.meshcore.components.generated.resources.label_no_contacts
 import ee.schimke.meshcore.components.ui.icons.MeshIcons
 import ee.schimke.meshcore.core.model.BatteryInfo
 import ee.schimke.meshcore.core.model.ChannelInfo
@@ -35,6 +38,7 @@ import ee.schimke.meshcore.core.model.Contact
 import ee.schimke.meshcore.core.model.ContactType
 import ee.schimke.meshcore.core.model.RadioSettings
 import ee.schimke.meshcore.core.model.SelfInfo
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Elevated "hero" card showing identity + radio + battery for the currently connected MeshCore
@@ -58,7 +62,7 @@ fun DeviceSummaryCard(
       verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
       Text(
-        text = self?.name ?: "Device",
+        text = self?.name ?: stringResource(Res.string.label_device),
         style = MaterialTheme.typography.titleLarge,
         color = MaterialTheme.colorScheme.onSurface,
       )
@@ -279,7 +283,7 @@ fun ContactListEmpty(modifier: Modifier = Modifier) {
     )
     Spacer(Modifier.size(8.dp))
     Text(
-      text = "No contacts yet",
+      text = stringResource(Res.string.label_no_contacts),
       style = MaterialTheme.typography.bodySmall,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
     )


### PR DESCRIPTION
## Summary

**Phase 2, walking skeleton** — adopt Compose Multiplatform string resources in `:meshcore-components` and localize the first two shared strings, establishing the whole i18n pipeline before extracting the rest surface-by-surface.

- **`build.gradle.kts`**: add `compose.components.resources` + a **public `Res`** class (`compose.resources { publicResClass = true; packageOfResClass = "…components.generated.resources" }`), so both the components *and* `:app` resolve the same generated strings.
- **`DeviceCards.kt`**: `"Device"` (DeviceSummaryCard fallback) and `"No contacts yet"` (ContactList empty) → `stringResource(Res.string.…)`.
- **17 locale files** under `commonMain/composeResources/values*/strings.xml`: real **en / ja / ar / de**; English-copy **scaffolds** for the other 13 (`es, fr, hi, id, it, ko, nl, pl, pt-BR, ru, th, tr, zh-CN, zh-TW`), marked for translation.

Once strings live in `composeResources`, the render pipeline can produce **per-locale** stickers via a `localeTag` override — the foundation for the catalog's locale axis and the Figma locale strip (a later step; this PR is the extraction + translations).

## Visual evidence

The **default (English)** rendering is unchanged — `label_device` = "Device", `label_no_contacts` = "No contacts yet" render identically — so this extraction is **behavior-preserving for the default locale**, and the `Compose Preview` diff on this PR should show **no pixel change** (the evidence that it didn't regress the default render). Per-locale (ja/ar/de) rendering is exercised later via the daemon `localeTag`, not by the default preview render.

## Test plan

- [ ] CI `Assemble (debug)` / build green — proves the `compose.resources` wiring + generated `Res` compile (can't run gradle in this sandbox; CI is the gate)
- [ ] `ktfmtCheck` green
- [ ] `Compose Preview` renders `DeviceBody*` / `DeviceSummaryCard*` with no default-locale diff
- [ ] Follow-ups: extract the remaining UI strings surface-by-surface (chat, settings, TCP connect, permissions, scanner, `:app` screens) + fill the 13 scaffold locales

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_