### PR TITLE
feat(i18n): real translations for the 14 remaining locales

### DIFF
--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Dispositivo</string>
+  <string name="label_no_contacts">Aún no hay contactos</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Appareil</string>
+  <string name="label_no_contacts">Aucun contact pour le moment</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">डिवाइस</string>
+  <string name="label_no_contacts">अभी तक कोई संपर्क नहीं</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Perangkat</string>
+  <string name="label_no_contacts">Belum ada kontak</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Dispositivo</string>
+  <string name="label_no_contacts">Ancora nessun contatto</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">기기</string>
+  <string name="label_no_contacts">아직 연락처가 없습니다</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Apparaat</string>
+  <string name="label_no_contacts">Nog geen contacten</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Urządzenie</string>
+  <string name="label_no_contacts">Brak kontaktów</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Dispositivo</string>
+  <string name="label_no_contacts">Nenhum contato ainda</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Устройство</string>
+  <string name="label_no_contacts">Пока нет контактов</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">อุปกรณ์</string>
+  <string name="label_no_contacts">ยังไม่มีรายชื่อติดต่อ</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">Cihaz</string>
+  <string name="label_no_contacts">Henüz kişi yok</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">设备</string>
+  <string name="label_no_contacts">暂无联系人</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Scaffold: English copy, pending real translation for this locale. -->
 <resources>
-  <string name="label_device">Device</string>
-  <string name="label_no_contacts">No contacts yet</string>
+  <string name="label_device">裝置</string>
+  <string name="label_no_contacts">尚無聯絡人</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -2,8 +2,8 @@
 <!--
   MeshCore shared UI strings (Compose Multiplatform resources). Default / English base; per-locale
   overrides live in values-<locale>/strings.xml. The daemon's LocaleList provider renders any of the
-  published locales, which feeds the design catalog's locale axis. Real translations exist for
-  en / ja / ar / de; the other 13 locales are scaffolded as English copies to be filled in.
+  published locales, which feeds the design catalog's locale axis. Real translations exist for all 17
+  published locales (ar de es fr hi id it ja ko nl pl pt-BR ru th tr zh-CN zh-TW).
 -->
 <resources>
   <string name="label_device">Device</string>


### PR DESCRIPTION
## Summary

Completes the i18n walking skeleton (#230) by replacing the **14 English scaffold locales** with real translations of the two shared strings (`label_device`, `label_no_contacts`), so **all 17 published locales** now carry genuine translations (not English copies).

- Real translations for: `es, fr, hi, id, it, ko, nl, pl, pt-BR, ru, th, tr, zh-CN, zh-TW`
  (`ar / de / ja` already landed in #230; `en` is the base).
- Scaffold `<!-- Scaffold: English copy… -->` comments dropped from those files.
- Base `values/strings.xml` header comment refreshed to note full coverage across all 17 locales.

This is an **XML-only, additive** change — no Kotlin touched, so the default-locale render is unchanged. These strings feed the render daemon's per-locale rendering (`LocaleList` / `localeTag`), which powers the design catalog's **locale axis** and the Figma per-screen **locale strip** (en / ja / ar / de) in the later phases.

## Test plan

- [ ] `ktfmtCheck` / build green (no Kotlin in this diff)
- [ ] `Assemble (debug)` proves the generated `Res` still compiles with the expanded resource set
- [ ] Follow-ups (separate PRs): extract more UI strings surface-by-surface (chat, settings, TCP connect, permissions, scanner, `:app`), then wire the catalog's locale axis + Figma locale strip

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_