### PR TITLE
feat(i18n): localize the chat surface across 17 locales

### DIFF
--- a/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">جهاز</string>
   <string name="label_no_contacts">لا توجد جهات اتصال بعد</string>
+  <string name="chat_hint_message">رسالة</string>
+  <string name="chat_not_connected">غير متصل</string>
+  <string name="chat_empty">لا توجد رسائل بعد</string>
+  <string name="chat_status_sending">جارٍ الإرسال…</string>
+  <string name="chat_status_sent">تم الإرسال</string>
+  <string name="chat_status_delivered">تم التسليم</string>
+  <string name="chat_status_failed">فشل</string>
+  <string name="chat_status_failed_retry">فشل — انقر لإعادة المحاولة</string>
+  <string name="cd_send">إرسال</string>
+  <string name="cd_back">رجوع</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Gerät</string>
   <string name="label_no_contacts">Noch keine Kontakte</string>
+  <string name="chat_hint_message">Nachricht</string>
+  <string name="chat_not_connected">Nicht verbunden</string>
+  <string name="chat_empty">Noch keine Nachrichten</string>
+  <string name="chat_status_sending">Wird gesendet…</string>
+  <string name="chat_status_sent">Gesendet</string>
+  <string name="chat_status_delivered">Zugestellt</string>
+  <string name="chat_status_failed">Fehlgeschlagen</string>
+  <string name="chat_status_failed_retry">Fehlgeschlagen – zum Wiederholen tippen</string>
+  <string name="cd_send">Senden</string>
+  <string name="cd_back">Zurück</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Dispositivo</string>
   <string name="label_no_contacts">Aún no hay contactos</string>
+  <string name="chat_hint_message">Mensaje</string>
+  <string name="chat_not_connected">Sin conexión</string>
+  <string name="chat_empty">Aún no hay mensajes</string>
+  <string name="chat_status_sending">Enviando…</string>
+  <string name="chat_status_sent">Enviado</string>
+  <string name="chat_status_delivered">Entregado</string>
+  <string name="chat_status_failed">Error</string>
+  <string name="chat_status_failed_retry">Error: toca para reintentar</string>
+  <string name="cd_send">Enviar</string>
+  <string name="cd_back">Atrás</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Appareil</string>
   <string name="label_no_contacts">Aucun contact pour le moment</string>
+  <string name="chat_hint_message">Message</string>
+  <string name="chat_not_connected">Non connecté</string>
+  <string name="chat_empty">Aucun message pour le moment</string>
+  <string name="chat_status_sending">Envoi…</string>
+  <string name="chat_status_sent">Envoyé</string>
+  <string name="chat_status_delivered">Distribué</string>
+  <string name="chat_status_failed">Échec</string>
+  <string name="chat_status_failed_retry">Échec — appuyez pour réessayer</string>
+  <string name="cd_send">Envoyer</string>
+  <string name="cd_back">Retour</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">डिवाइस</string>
   <string name="label_no_contacts">अभी तक कोई संपर्क नहीं</string>
+  <string name="chat_hint_message">संदेश</string>
+  <string name="chat_not_connected">कनेक्ट नहीं है</string>
+  <string name="chat_empty">अभी तक कोई संदेश नहीं</string>
+  <string name="chat_status_sending">भेजा जा रहा है…</string>
+  <string name="chat_status_sent">भेजा गया</string>
+  <string name="chat_status_delivered">वितरित</string>
+  <string name="chat_status_failed">विफल</string>
+  <string name="chat_status_failed_retry">विफल — पुनः प्रयास के लिए टैप करें</string>
+  <string name="cd_send">भेजें</string>
+  <string name="cd_back">वापस</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Perangkat</string>
   <string name="label_no_contacts">Belum ada kontak</string>
+  <string name="chat_hint_message">Pesan</string>
+  <string name="chat_not_connected">Tidak terhubung</string>
+  <string name="chat_empty">Belum ada pesan</string>
+  <string name="chat_status_sending">Mengirim…</string>
+  <string name="chat_status_sent">Terkirim</string>
+  <string name="chat_status_delivered">Tersampaikan</string>
+  <string name="chat_status_failed">Gagal</string>
+  <string name="chat_status_failed_retry">Gagal — ketuk untuk mencoba lagi</string>
+  <string name="cd_send">Kirim</string>
+  <string name="cd_back">Kembali</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Dispositivo</string>
   <string name="label_no_contacts">Ancora nessun contatto</string>
+  <string name="chat_hint_message">Messaggio</string>
+  <string name="chat_not_connected">Non connesso</string>
+  <string name="chat_empty">Ancora nessun messaggio</string>
+  <string name="chat_status_sending">Invio…</string>
+  <string name="chat_status_sent">Inviato</string>
+  <string name="chat_status_delivered">Consegnato</string>
+  <string name="chat_status_failed">Non riuscito</string>
+  <string name="chat_status_failed_retry">Non riuscito — tocca per riprovare</string>
+  <string name="cd_send">Invia</string>
+  <string name="cd_back">Indietro</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">デバイス</string>
   <string name="label_no_contacts">連絡先がまだありません</string>
+  <string name="chat_hint_message">メッセージ</string>
+  <string name="chat_not_connected">未接続</string>
+  <string name="chat_empty">メッセージはまだありません</string>
+  <string name="chat_status_sending">送信中…</string>
+  <string name="chat_status_sent">送信済み</string>
+  <string name="chat_status_delivered">配信済み</string>
+  <string name="chat_status_failed">失敗</string>
+  <string name="chat_status_failed_retry">失敗 — タップして再試行</string>
+  <string name="cd_send">送信</string>
+  <string name="cd_back">戻る</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">기기</string>
   <string name="label_no_contacts">아직 연락처가 없습니다</string>
+  <string name="chat_hint_message">메시지</string>
+  <string name="chat_not_connected">연결되지 않음</string>
+  <string name="chat_empty">아직 메시지가 없습니다</string>
+  <string name="chat_status_sending">보내는 중…</string>
+  <string name="chat_status_sent">전송됨</string>
+  <string name="chat_status_delivered">전달됨</string>
+  <string name="chat_status_failed">실패</string>
+  <string name="chat_status_failed_retry">실패 — 다시 시도하려면 탭하세요</string>
+  <string name="cd_send">보내기</string>
+  <string name="cd_back">뒤로</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Apparaat</string>
   <string name="label_no_contacts">Nog geen contacten</string>
+  <string name="chat_hint_message">Bericht</string>
+  <string name="chat_not_connected">Niet verbonden</string>
+  <string name="chat_empty">Nog geen berichten</string>
+  <string name="chat_status_sending">Verzenden…</string>
+  <string name="chat_status_sent">Verzonden</string>
+  <string name="chat_status_delivered">Bezorgd</string>
+  <string name="chat_status_failed">Mislukt</string>
+  <string name="chat_status_failed_retry">Mislukt — tik om opnieuw te proberen</string>
+  <string name="cd_send">Verzenden</string>
+  <string name="cd_back">Terug</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Urządzenie</string>
   <string name="label_no_contacts">Brak kontaktów</string>
+  <string name="chat_hint_message">Wiadomość</string>
+  <string name="chat_not_connected">Brak połączenia</string>
+  <string name="chat_empty">Brak wiadomości</string>
+  <string name="chat_status_sending">Wysyłanie…</string>
+  <string name="chat_status_sent">Wysłano</string>
+  <string name="chat_status_delivered">Dostarczono</string>
+  <string name="chat_status_failed">Nieudane</string>
+  <string name="chat_status_failed_retry">Nieudane — dotknij, aby ponowić</string>
+  <string name="cd_send">Wyślij</string>
+  <string name="cd_back">Wstecz</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Dispositivo</string>
   <string name="label_no_contacts">Nenhum contato ainda</string>
+  <string name="chat_hint_message">Mensagem</string>
+  <string name="chat_not_connected">Desconectado</string>
+  <string name="chat_empty">Nenhuma mensagem ainda</string>
+  <string name="chat_status_sending">Enviando…</string>
+  <string name="chat_status_sent">Enviado</string>
+  <string name="chat_status_delivered">Entregue</string>
+  <string name="chat_status_failed">Falhou</string>
+  <string name="chat_status_failed_retry">Falhou — toque para tentar novamente</string>
+  <string name="cd_send">Enviar</string>
+  <string name="cd_back">Voltar</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Устройство</string>
   <string name="label_no_contacts">Пока нет контактов</string>
+  <string name="chat_hint_message">Сообщение</string>
+  <string name="chat_not_connected">Нет подключения</string>
+  <string name="chat_empty">Сообщений пока нет</string>
+  <string name="chat_status_sending">Отправка…</string>
+  <string name="chat_status_sent">Отправлено</string>
+  <string name="chat_status_delivered">Доставлено</string>
+  <string name="chat_status_failed">Ошибка</string>
+  <string name="chat_status_failed_retry">Ошибка — нажмите, чтобы повторить</string>
+  <string name="cd_send">Отправить</string>
+  <string name="cd_back">Назад</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">อุปกรณ์</string>
   <string name="label_no_contacts">ยังไม่มีรายชื่อติดต่อ</string>
+  <string name="chat_hint_message">ข้อความ</string>
+  <string name="chat_not_connected">ไม่ได้เชื่อมต่อ</string>
+  <string name="chat_empty">ยังไม่มีข้อความ</string>
+  <string name="chat_status_sending">กำลังส่ง…</string>
+  <string name="chat_status_sent">ส่งแล้ว</string>
+  <string name="chat_status_delivered">ส่งถึงแล้ว</string>
+  <string name="chat_status_failed">ล้มเหลว</string>
+  <string name="chat_status_failed_retry">ล้มเหลว — แตะเพื่อลองใหม่</string>
+  <string name="cd_send">ส่ง</string>
+  <string name="cd_back">ย้อนกลับ</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">Cihaz</string>
   <string name="label_no_contacts">Henüz kişi yok</string>
+  <string name="chat_hint_message">Mesaj</string>
+  <string name="chat_not_connected">Bağlı değil</string>
+  <string name="chat_empty">Henüz mesaj yok</string>
+  <string name="chat_status_sending">Gönderiliyor…</string>
+  <string name="chat_status_sent">Gönderildi</string>
+  <string name="chat_status_delivered">İletildi</string>
+  <string name="chat_status_failed">Başarısız</string>
+  <string name="chat_status_failed_retry">Başarısız — yeniden denemek için dokunun</string>
+  <string name="cd_send">Gönder</string>
+  <string name="cd_back">Geri</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">设备</string>
   <string name="label_no_contacts">暂无联系人</string>
+  <string name="chat_hint_message">消息</string>
+  <string name="chat_not_connected">未连接</string>
+  <string name="chat_empty">暂无消息</string>
+  <string name="chat_status_sending">发送中…</string>
+  <string name="chat_status_sent">已发送</string>
+  <string name="chat_status_delivered">已送达</string>
+  <string name="chat_status_failed">失败</string>
+  <string name="chat_status_failed_retry">失败 — 点按重试</string>
+  <string name="cd_send">发送</string>
+  <string name="cd_back">返回</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -2,4 +2,14 @@
 <resources>
   <string name="label_device">裝置</string>
   <string name="label_no_contacts">尚無聯絡人</string>
+  <string name="chat_hint_message">訊息</string>
+  <string name="chat_not_connected">未連線</string>
+  <string name="chat_empty">尚無訊息</string>
+  <string name="chat_status_sending">傳送中…</string>
+  <string name="chat_status_sent">已傳送</string>
+  <string name="chat_status_delivered">已送達</string>
+  <string name="chat_status_failed">失敗</string>
+  <string name="chat_status_failed_retry">失敗 — 點按重試</string>
+  <string name="cd_send">傳送</string>
+  <string name="cd_back">返回</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -8,4 +8,14 @@
 <resources>
   <string name="label_device">Device</string>
   <string name="label_no_contacts">No contacts yet</string>
+  <string name="chat_hint_message">Message</string>
+  <string name="chat_not_connected">Not connected</string>
+  <string name="chat_empty">No messages yet</string>
+  <string name="chat_status_sending">Sending…</string>
+  <string name="chat_status_sent">Sent</string>
+  <string name="chat_status_delivered">Delivered</string>
+  <string name="chat_status_failed">Failed</string>
+  <string name="chat_status_failed_retry">Failed — tap to retry</string>
+  <string name="cd_send">Send</string>
+  <string name="cd_back">Back</string>
 </resources>

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBody.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBody.kt
@@ -15,7 +15,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.cd_back
+import ee.schimke.meshcore.components.generated.resources.chat_hint_message
 import ee.schimke.meshcore.components.ui.icons.MeshIcons
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Stateless chat screen body: a top bar (title + optional subtitle + back), the scrollable message
@@ -36,7 +40,7 @@ fun ChatBody(
   modifier: Modifier = Modifier,
   subtitle: String? = null,
   inputEnabled: Boolean = true,
-  inputPlaceholder: String = "Message",
+  inputPlaceholder: String = stringResource(Res.string.chat_hint_message),
   onRetry: ((ChatMessage) -> Unit)? = null,
   actions: @Composable RowScope.() -> Unit = {},
 ) {
@@ -56,7 +60,11 @@ fun ChatBody(
             }
           }
         },
-        navigationIcon = { IconButton(onClick = onBack) { Icon(MeshIcons.ArrowBack, "Back") } },
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(MeshIcons.ArrowBack, stringResource(Res.string.cd_back))
+          }
+        },
         actions = actions,
         colors =
           TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatComponents.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatComponents.kt
@@ -31,8 +31,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.cd_send
+import ee.schimke.meshcore.components.generated.resources.chat_empty
+import ee.schimke.meshcore.components.generated.resources.chat_hint_message
+import ee.schimke.meshcore.components.generated.resources.chat_not_connected
+import ee.schimke.meshcore.components.generated.resources.chat_status_delivered
+import ee.schimke.meshcore.components.generated.resources.chat_status_failed
+import ee.schimke.meshcore.components.generated.resources.chat_status_failed_retry
+import ee.schimke.meshcore.components.generated.resources.chat_status_sending
+import ee.schimke.meshcore.components.generated.resources.chat_status_sent
 import ee.schimke.meshcore.components.ui.icons.MeshIcons
 import kotlin.time.Instant
+import org.jetbrains.compose.resources.stringResource
 
 /** Presentation model for a single chat message. */
 data class ChatMessage(
@@ -73,7 +84,7 @@ fun ChatMessageList(
   if (messages.isEmpty()) {
     Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Text(
-        text = "No messages yet",
+        text = stringResource(Res.string.chat_empty),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
       )
@@ -182,10 +193,12 @@ fun ChatBubble(message: ChatMessage, modifier: Modifier = Modifier, onRetry: (()
             ) { status ->
               val statusText =
                 when (status) {
-                  MessageStatus.Sending -> "Sending…"
-                  MessageStatus.Sent -> "Sent"
-                  MessageStatus.Confirmed -> "Delivered"
-                  MessageStatus.Failed -> if (onRetry != null) "Failed — tap to retry" else "Failed"
+                  MessageStatus.Sending -> stringResource(Res.string.chat_status_sending)
+                  MessageStatus.Sent -> stringResource(Res.string.chat_status_sent)
+                  MessageStatus.Confirmed -> stringResource(Res.string.chat_status_delivered)
+                  MessageStatus.Failed ->
+                    if (onRetry != null) stringResource(Res.string.chat_status_failed_retry)
+                    else stringResource(Res.string.chat_status_failed)
                 }
               Text(
                 text = statusText,
@@ -221,7 +234,7 @@ fun ChatInput(
   onValueChange: (String) -> Unit,
   onSend: () -> Unit,
   enabled: Boolean = true,
-  placeholder: String = "Message",
+  placeholder: String = stringResource(Res.string.chat_hint_message),
   modifier: Modifier = Modifier,
 ) {
   Row(
@@ -232,7 +245,9 @@ fun ChatInput(
       value = value,
       onValueChange = onValueChange,
       enabled = enabled,
-      placeholder = { Text(if (enabled) placeholder else "Not connected") },
+      placeholder = {
+        Text(if (enabled) placeholder else stringResource(Res.string.chat_not_connected))
+      },
       singleLine = true,
       modifier = Modifier.weight(1f),
       shape = RoundedCornerShape(24.dp),
@@ -241,7 +256,7 @@ fun ChatInput(
     IconButton(onClick = onSend, enabled = enabled && value.isNotBlank()) {
       Icon(
         imageVector = MeshIcons.Send,
-        contentDescription = "Send",
+        contentDescription = stringResource(Res.string.cd_send),
         tint =
           if (enabled && value.isNotBlank()) MaterialTheme.colorScheme.primary
           else MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Summary

First surface of the **comprehensive i18n** sweep. Extracts the hardcoded chat UI strings from `ChatBody` / `ChatComponents` to Compose resources and adds real translations across all 17 published locales.

**10 strings extracted:** message-input hint, empty-thread state, the five send-status labels (`sending` / `sent` / `delivered` / `failed` / `failed → tap to retry`), the not-connected placeholder, and the `Send` / `Back` content descriptions. Technical glyphs (`SNR`, the `·` separator) stay as literals.

Notable: `ChatBody.inputPlaceholder` and `ChatInput.placeholder` now default to `stringResource(...)` in the **`@Composable` default-arg** position — this PR deliberately validates that pattern (and the `Res` accessor wiring) on a small surface before the larger Device surface.

## Plan — surface-by-surface, each its own PR

Comprehensive i18n, sequenced so each PR stays reviewable and independently CI-verified:

1. **Chat** — `ChatBody` / `ChatComponents` ← this PR
2. **Device** — `DeviceBody`: section headers with counts, filter chips, empty states, toolbar content descriptions
3. **Device cards / rows** — `DeviceCards`: contact/channel rows, type labels, battery/radio a11y — includes refactoring the non-`@Composable` `typeLabel()`
4. **Device settings** — `DeviceSettingsBody`: buzzer + discovery states
5. **`:app` screens** — permissions, scanner, TCP connect, theme picker

## Test plan

- [ ] `ktfmtCheck` green (verified locally against the ktfmt jar — imports sorted, no reflow)
- [ ] `Assemble (debug)` proves the generated `Res.string.*` accessors compile
- [ ] `Compose Preview` renders the chat screens unchanged for the default (en) locale

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_