### PR TITLE
feat(i18n): localize the device cards and rows across 17 locales

### DIFF
--- a/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">توسيع</string>
   <string name="cd_new_message">رسالة جديدة</string>
   <string name="cd_dismiss">تجاهل</string>
+  <string name="contact_type_repeater">مكرِّر</string>
+  <string name="contact_type_room">غرفة</string>
+  <string name="contact_type_sensor">مستشعر</string>
+  <string name="contact_type_contact">جهة اتصال</string>
+  <string name="cd_public_key">المفتاح العام</string>
+  <string name="cd_radio">الراديو</string>
+  <string name="cd_battery">البطارية</string>
+  <string name="cd_storage">التخزين</string>
+  <string name="cd_channel">قناة</string>
+  <string name="channel_index">القناة %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Ausklappen</string>
   <string name="cd_new_message">Neue Nachricht</string>
   <string name="cd_dismiss">Schließen</string>
+  <string name="contact_type_repeater">Repeater</string>
+  <string name="contact_type_room">Raum</string>
+  <string name="contact_type_sensor">Sensor</string>
+  <string name="contact_type_contact">Kontakt</string>
+  <string name="cd_public_key">Öffentlicher Schlüssel</string>
+  <string name="cd_radio">Funk</string>
+  <string name="cd_battery">Akku</string>
+  <string name="cd_storage">Speicher</string>
+  <string name="cd_channel">Kanal</string>
+  <string name="channel_index">Kanal %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Expandir</string>
   <string name="cd_new_message">Mensaje nuevo</string>
   <string name="cd_dismiss">Descartar</string>
+  <string name="contact_type_repeater">Repetidor</string>
+  <string name="contact_type_room">Sala</string>
+  <string name="contact_type_sensor">Sensor</string>
+  <string name="contact_type_contact">Contacto</string>
+  <string name="cd_public_key">Clave pública</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Batería</string>
+  <string name="cd_storage">Almacenamiento</string>
+  <string name="cd_channel">Canal</string>
+  <string name="channel_index">Canal %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Développer</string>
   <string name="cd_new_message">Nouveau message</string>
   <string name="cd_dismiss">Ignorer</string>
+  <string name="contact_type_repeater">Répéteur</string>
+  <string name="contact_type_room">Salon</string>
+  <string name="contact_type_sensor">Capteur</string>
+  <string name="contact_type_contact">Contact</string>
+  <string name="cd_public_key">Clé publique</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Batterie</string>
+  <string name="cd_storage">Stockage</string>
+  <string name="cd_channel">Canal</string>
+  <string name="channel_index">Canal %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">विस्तृत करें</string>
   <string name="cd_new_message">नया संदेश</string>
   <string name="cd_dismiss">खारिज करें</string>
+  <string name="contact_type_repeater">रिपीटर</string>
+  <string name="contact_type_room">रूम</string>
+  <string name="contact_type_sensor">सेंसर</string>
+  <string name="contact_type_contact">संपर्क</string>
+  <string name="cd_public_key">सार्वजनिक कुंजी</string>
+  <string name="cd_radio">रेडियो</string>
+  <string name="cd_battery">बैटरी</string>
+  <string name="cd_storage">स्टोरेज</string>
+  <string name="cd_channel">चैनल</string>
+  <string name="channel_index">चैनल %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Perluas</string>
   <string name="cd_new_message">Pesan baru</string>
   <string name="cd_dismiss">Tutup</string>
+  <string name="contact_type_repeater">Pengulang</string>
+  <string name="contact_type_room">Ruang</string>
+  <string name="contact_type_sensor">Sensor</string>
+  <string name="contact_type_contact">Kontak</string>
+  <string name="cd_public_key">Kunci publik</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Baterai</string>
+  <string name="cd_storage">Penyimpanan</string>
+  <string name="cd_channel">Saluran</string>
+  <string name="channel_index">Saluran %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Espandi</string>
   <string name="cd_new_message">Nuovo messaggio</string>
   <string name="cd_dismiss">Ignora</string>
+  <string name="contact_type_repeater">Ripetitore</string>
+  <string name="contact_type_room">Stanza</string>
+  <string name="contact_type_sensor">Sensore</string>
+  <string name="contact_type_contact">Contatto</string>
+  <string name="cd_public_key">Chiave pubblica</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Batteria</string>
+  <string name="cd_storage">Archiviazione</string>
+  <string name="cd_channel">Canale</string>
+  <string name="channel_index">Canale %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">展開</string>
   <string name="cd_new_message">新しいメッセージ</string>
   <string name="cd_dismiss">閉じる</string>
+  <string name="contact_type_repeater">リピーター</string>
+  <string name="contact_type_room">ルーム</string>
+  <string name="contact_type_sensor">センサー</string>
+  <string name="contact_type_contact">連絡先</string>
+  <string name="cd_public_key">公開鍵</string>
+  <string name="cd_radio">無線</string>
+  <string name="cd_battery">バッテリー</string>
+  <string name="cd_storage">ストレージ</string>
+  <string name="cd_channel">チャンネル</string>
+  <string name="channel_index">チャンネル %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">펼치기</string>
   <string name="cd_new_message">새 메시지</string>
   <string name="cd_dismiss">닫기</string>
+  <string name="contact_type_repeater">중계기</string>
+  <string name="contact_type_room">채팅방</string>
+  <string name="contact_type_sensor">센서</string>
+  <string name="contact_type_contact">연락처</string>
+  <string name="cd_public_key">공개 키</string>
+  <string name="cd_radio">무선</string>
+  <string name="cd_battery">배터리</string>
+  <string name="cd_storage">저장공간</string>
+  <string name="cd_channel">채널</string>
+  <string name="channel_index">채널 %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Uitvouwen</string>
   <string name="cd_new_message">Nieuw bericht</string>
   <string name="cd_dismiss">Sluiten</string>
+  <string name="contact_type_repeater">Repeater</string>
+  <string name="contact_type_room">Ruimte</string>
+  <string name="contact_type_sensor">Sensor</string>
+  <string name="contact_type_contact">Contact</string>
+  <string name="cd_public_key">Openbare sleutel</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Batterij</string>
+  <string name="cd_storage">Opslag</string>
+  <string name="cd_channel">Kanaal</string>
+  <string name="channel_index">Kanaal %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Rozwiń</string>
   <string name="cd_new_message">Nowa wiadomość</string>
   <string name="cd_dismiss">Odrzuć</string>
+  <string name="contact_type_repeater">Wzmacniak</string>
+  <string name="contact_type_room">Pokój</string>
+  <string name="contact_type_sensor">Czujnik</string>
+  <string name="contact_type_contact">Kontakt</string>
+  <string name="cd_public_key">Klucz publiczny</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Bateria</string>
+  <string name="cd_storage">Pamięć</string>
+  <string name="cd_channel">Kanał</string>
+  <string name="channel_index">Kanał %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Expandir</string>
   <string name="cd_new_message">Nova mensagem</string>
   <string name="cd_dismiss">Dispensar</string>
+  <string name="contact_type_repeater">Repetidor</string>
+  <string name="contact_type_room">Sala</string>
+  <string name="contact_type_sensor">Sensor</string>
+  <string name="contact_type_contact">Contato</string>
+  <string name="cd_public_key">Chave pública</string>
+  <string name="cd_radio">Rádio</string>
+  <string name="cd_battery">Bateria</string>
+  <string name="cd_storage">Armazenamento</string>
+  <string name="cd_channel">Canal</string>
+  <string name="channel_index">Canal %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Развернуть</string>
   <string name="cd_new_message">Новое сообщение</string>
   <string name="cd_dismiss">Закрыть</string>
+  <string name="contact_type_repeater">Ретранслятор</string>
+  <string name="contact_type_room">Комната</string>
+  <string name="contact_type_sensor">Датчик</string>
+  <string name="contact_type_contact">Контакт</string>
+  <string name="cd_public_key">Открытый ключ</string>
+  <string name="cd_radio">Радио</string>
+  <string name="cd_battery">Батарея</string>
+  <string name="cd_storage">Хранилище</string>
+  <string name="cd_channel">Канал</string>
+  <string name="channel_index">Канал %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">ขยาย</string>
   <string name="cd_new_message">ข้อความใหม่</string>
   <string name="cd_dismiss">ปิด</string>
+  <string name="contact_type_repeater">รีพีทเตอร์</string>
+  <string name="contact_type_room">ห้อง</string>
+  <string name="contact_type_sensor">เซนเซอร์</string>
+  <string name="contact_type_contact">รายชื่อติดต่อ</string>
+  <string name="cd_public_key">คีย์สาธารณะ</string>
+  <string name="cd_radio">วิทยุ</string>
+  <string name="cd_battery">แบตเตอรี่</string>
+  <string name="cd_storage">ที่จัดเก็บ</string>
+  <string name="cd_channel">ช่อง</string>
+  <string name="channel_index">ช่อง %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">Genişlet</string>
   <string name="cd_new_message">Yeni mesaj</string>
   <string name="cd_dismiss">Kapat</string>
+  <string name="contact_type_repeater">Yineleyici</string>
+  <string name="contact_type_room">Oda</string>
+  <string name="contact_type_sensor">Sensör</string>
+  <string name="contact_type_contact">Kişi</string>
+  <string name="cd_public_key">Ortak anahtar</string>
+  <string name="cd_radio">Telsiz</string>
+  <string name="cd_battery">Pil</string>
+  <string name="cd_storage">Depolama</string>
+  <string name="cd_channel">Kanal</string>
+  <string name="channel_index">Kanal %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">展开</string>
   <string name="cd_new_message">新消息</string>
   <string name="cd_dismiss">关闭</string>
+  <string name="contact_type_repeater">中继器</string>
+  <string name="contact_type_room">房间</string>
+  <string name="contact_type_sensor">传感器</string>
+  <string name="contact_type_contact">联系人</string>
+  <string name="cd_public_key">公钥</string>
+  <string name="cd_radio">无线电</string>
+  <string name="cd_battery">电池</string>
+  <string name="cd_storage">存储</string>
+  <string name="cd_channel">频道</string>
+  <string name="channel_index">频道 %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -37,4 +37,14 @@
   <string name="cd_expand">展開</string>
   <string name="cd_new_message">新訊息</string>
   <string name="cd_dismiss">關閉</string>
+  <string name="contact_type_repeater">中繼器</string>
+  <string name="contact_type_room">房間</string>
+  <string name="contact_type_sensor">感測器</string>
+  <string name="contact_type_contact">聯絡人</string>
+  <string name="cd_public_key">公鑰</string>
+  <string name="cd_radio">無線電</string>
+  <string name="cd_battery">電池</string>
+  <string name="cd_storage">儲存空間</string>
+  <string name="cd_channel">頻道</string>
+  <string name="channel_index">頻道 %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -43,4 +43,14 @@
   <string name="cd_expand">Expand</string>
   <string name="cd_new_message">New message</string>
   <string name="cd_dismiss">Dismiss</string>
+  <string name="contact_type_repeater">Repeater</string>
+  <string name="contact_type_room">Room</string>
+  <string name="contact_type_sensor">Sensor</string>
+  <string name="contact_type_contact">Contact</string>
+  <string name="cd_public_key">Public key</string>
+  <string name="cd_radio">Radio</string>
+  <string name="cd_battery">Battery</string>
+  <string name="cd_storage">Storage</string>
+  <string name="cd_channel">Channel</string>
+  <string name="channel_index">Channel %1$d</string>
 </resources>

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceCards.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceCards.kt
@@ -29,6 +29,16 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.cd_battery
+import ee.schimke.meshcore.components.generated.resources.cd_channel
+import ee.schimke.meshcore.components.generated.resources.cd_public_key
+import ee.schimke.meshcore.components.generated.resources.cd_radio
+import ee.schimke.meshcore.components.generated.resources.cd_storage
+import ee.schimke.meshcore.components.generated.resources.channel_index
+import ee.schimke.meshcore.components.generated.resources.contact_type_contact
+import ee.schimke.meshcore.components.generated.resources.contact_type_repeater
+import ee.schimke.meshcore.components.generated.resources.contact_type_room
+import ee.schimke.meshcore.components.generated.resources.contact_type_sensor
 import ee.schimke.meshcore.components.generated.resources.label_device
 import ee.schimke.meshcore.components.generated.resources.label_no_contacts
 import ee.schimke.meshcore.components.ui.icons.MeshIcons
@@ -75,7 +85,10 @@ fun DeviceSummaryCard(
 
 @Composable
 private fun PubkeyLine(hex: String?) {
-  IconLabelRow(icon = MeshIcons.Fingerprint, contentDescription = "Public key") {
+  IconLabelRow(
+    icon = MeshIcons.Fingerprint,
+    contentDescription = stringResource(Res.string.cd_public_key),
+  ) {
     Text(
       text = hex?.take(16) ?: "—",
       style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
@@ -86,7 +99,7 @@ private fun PubkeyLine(hex: String?) {
 
 @Composable
 fun RadioLine(radio: RadioSettings) {
-  IconLabelRow(icon = MeshIcons.Wifi, contentDescription = "Radio") {
+  IconLabelRow(icon = MeshIcons.Wifi, contentDescription = stringResource(Res.string.cd_radio)) {
     Text(
       text =
         buildString {
@@ -120,7 +133,12 @@ fun BatterySection(battery: BatteryInfo) {
     }
   Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-      Icon(icon, contentDescription = "Battery", tint = tint, modifier = Modifier.size(18.dp))
+      Icon(
+        icon,
+        contentDescription = stringResource(Res.string.cd_battery),
+        tint = tint,
+        modifier = Modifier.size(18.dp),
+      )
       Text(
         text = "  $percent% · ${battery.millivolts} mV",
         style = MaterialTheme.typography.bodyMedium,
@@ -135,7 +153,10 @@ fun BatterySection(battery: BatteryInfo) {
       color = if (warn) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.primary,
       trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
     )
-    IconLabelRow(icon = MeshIcons.Storage, contentDescription = "Storage") {
+    IconLabelRow(
+      icon = MeshIcons.Storage,
+      contentDescription = stringResource(Res.string.cd_storage),
+    ) {
       Text(
         text = "${battery.storageUsedKb} / ${battery.storageTotalKb} kB",
         style = MaterialTheme.typography.bodySmall,
@@ -173,12 +194,13 @@ private fun Contact.iconFor(): ImageVector =
     else -> MeshIcons.Person
   }
 
+@Composable
 private fun Contact.typeLabel(): String =
   when (type) {
-    ContactType.REPEATER -> "Repeater"
-    ContactType.ROOM -> "Room"
-    ContactType.SENSOR -> "Sensor"
-    else -> "Contact"
+    ContactType.REPEATER -> stringResource(Res.string.contact_type_repeater)
+    ContactType.ROOM -> stringResource(Res.string.contact_type_room)
+    ContactType.SENSOR -> stringResource(Res.string.contact_type_sensor)
+    else -> stringResource(Res.string.contact_type_contact)
   }
 
 /**
@@ -187,6 +209,7 @@ private fun Contact.typeLabel(): String =
  */
 @Composable
 fun ContactRow(contact: Contact, onClick: (() -> Unit)? = null, modifier: Modifier = Modifier) {
+  val typeLabel = contact.typeLabel()
   Card(
     modifier = modifier.fillMaxWidth(),
     onClick = onClick ?: {},
@@ -208,7 +231,7 @@ fun ContactRow(contact: Contact, onClick: (() -> Unit)? = null, modifier: Modifi
         ) {
           Icon(
             imageVector = contact.iconFor(),
-            contentDescription = contact.typeLabel(),
+            contentDescription = typeLabel,
             tint = MaterialTheme.colorScheme.onSecondaryContainer,
             modifier = Modifier.size(20.dp).align(Alignment.CenterVertically),
           )
@@ -226,7 +249,7 @@ fun ContactRow(contact: Contact, onClick: (() -> Unit)? = null, modifier: Modifi
         Text(
           text =
             buildString {
-              append(contact.typeLabel())
+              append(typeLabel)
               append(" · ")
               append(if (contact.isFlood) "flood" else "${contact.pathLength} hops")
             },
@@ -294,6 +317,7 @@ fun ContactListEmpty(modifier: Modifier = Modifier) {
 
 @Composable
 fun ChannelRow(channel: ChannelInfo, onClick: (() -> Unit)? = null, modifier: Modifier = Modifier) {
+  val channelLabel = stringResource(Res.string.channel_index, channel.index)
   Card(
     modifier = modifier.fillMaxWidth(),
     onClick = onClick ?: {},
@@ -315,7 +339,7 @@ fun ChannelRow(channel: ChannelInfo, onClick: (() -> Unit)? = null, modifier: Mo
         ) {
           Icon(
             imageVector = MeshIcons.Groups,
-            contentDescription = "Channel",
+            contentDescription = stringResource(Res.string.cd_channel),
             tint = MaterialTheme.colorScheme.onTertiaryContainer,
             modifier = Modifier.size(20.dp).align(Alignment.CenterVertically),
           )
@@ -326,12 +350,12 @@ fun ChannelRow(channel: ChannelInfo, onClick: (() -> Unit)? = null, modifier: Mo
         verticalArrangement = Arrangement.spacedBy(2.dp),
       ) {
         Text(
-          text = channel.name.ifBlank { "Channel ${channel.index}" },
+          text = channel.name.ifBlank { channelLabel },
           style = MaterialTheme.typography.titleMedium,
           color = MaterialTheme.colorScheme.onSurface,
         )
         Text(
-          text = "Channel ${channel.index}",
+          text = channelLabel,
           style = MaterialTheme.typography.bodySmall,
           color = MaterialTheme.colorScheme.onSurfaceVariant,
         )


### PR DESCRIPTION
## Summary

Surface **#3** of the comprehensive i18n sweep. Extracts the `DeviceCards` contact/channel row and summary-card strings to Compose resources with real translations across all 17 published locales.

**10 strings extracted:**
- **Contact type labels** — `Repeater` / `Room` / `Sensor` / `Contact` (used for the row icon a11y description and subtitle)
- **Channel index** — `Channel %1$d` (positional format arg; drives the row title fallback + subtitle)
- **Summary-card a11y** — `Public key` / `Radio` / `Battery` / `Storage` content descriptions, plus the channel-row `Channel` icon description

**Notable refactor:** `Contact.typeLabel()` becomes `@Composable`, and `ContactRow` / `ChannelRow` hoist the resolved label into a `val` (`typeLabel`, `channelLabel`) so the non-composable `buildString { }` / `ifBlank { }` lambdas can consume it.

Left as literals (technical, consistent with the `SNR` decision): the radio settings units (`MHz`/`BW`/`SF`/`CR`/`kHz`), battery `%`/`mV`, storage `kB`, the `—` empty-key glyph, animation labels, and the `flood` / `N hops` routing terms.

## Test plan

- [ ] `ktfmtCheck` green (formatted in place against the ktfmt jar)
- [ ] `Assemble (debug)` — validates the `@Composable typeLabel()` refactor + format-arg accessor compile
- [ ] `Compose Preview` renders contact/channel rows unchanged for the default (en) locale

## Sweep progress
1. Chat ✅ merged (#233)
2. Device ✅ merged (#234)
3. **Device cards / rows ← this PR**
4. DeviceSettings
5. `:app` screens

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_