### PR TITLE
feat(i18n): localize the device settings screen across 17 locales

### DIFF
--- a/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">التخزين</string>
   <string name="cd_channel">قناة</string>
   <string name="channel_index">القناة %1$d</string>
+  <string name="settings_discovering">جارٍ اكتشاف قدرات الجهاز…</string>
+  <string name="settings_none">لم يتم اكتشاف إعدادات قابلة للتهيئة</string>
+  <string name="settings_buzzer">الجرس</string>
+  <string name="settings_buzzer_updating">جارٍ التحديث…</string>
+  <string name="settings_buzzer_unknown">غير معروف</string>
+  <string name="settings_buzzer_off">إيقاف</string>
+  <string name="settings_buzzer_on">تشغيل (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Speicher</string>
   <string name="cd_channel">Kanal</string>
   <string name="channel_index">Kanal %1$d</string>
+  <string name="settings_discovering">Gerätefunktionen werden erkannt…</string>
+  <string name="settings_none">Keine konfigurierbaren Einstellungen erkannt</string>
+  <string name="settings_buzzer">Summer</string>
+  <string name="settings_buzzer_updating">Wird aktualisiert…</string>
+  <string name="settings_buzzer_unknown">Unbekannt</string>
+  <string name="settings_buzzer_off">Aus</string>
+  <string name="settings_buzzer_on">An (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Almacenamiento</string>
   <string name="cd_channel">Canal</string>
   <string name="channel_index">Canal %1$d</string>
+  <string name="settings_discovering">Detectando capacidades del dispositivo…</string>
+  <string name="settings_none">No se detectaron ajustes configurables</string>
+  <string name="settings_buzzer">Zumbador</string>
+  <string name="settings_buzzer_updating">Actualizando…</string>
+  <string name="settings_buzzer_unknown">Desconocido</string>
+  <string name="settings_buzzer_off">Apagado</string>
+  <string name="settings_buzzer_on">Encendido (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Stockage</string>
   <string name="cd_channel">Canal</string>
   <string name="channel_index">Canal %1$d</string>
+  <string name="settings_discovering">Détection des capacités de l’appareil…</string>
+  <string name="settings_none">Aucun réglage configurable détecté</string>
+  <string name="settings_buzzer">Buzzer</string>
+  <string name="settings_buzzer_updating">Mise à jour…</string>
+  <string name="settings_buzzer_unknown">Inconnu</string>
+  <string name="settings_buzzer_off">Désactivé</string>
+  <string name="settings_buzzer_on">Activé (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">स्टोरेज</string>
   <string name="cd_channel">चैनल</string>
   <string name="channel_index">चैनल %1$d</string>
+  <string name="settings_discovering">डिवाइस क्षमताओं का पता लगाया जा रहा है…</string>
+  <string name="settings_none">कोई कॉन्फ़िगर करने योग्य सेटिंग नहीं मिली</string>
+  <string name="settings_buzzer">बजर</string>
+  <string name="settings_buzzer_updating">अपडेट हो रहा है…</string>
+  <string name="settings_buzzer_unknown">अज्ञात</string>
+  <string name="settings_buzzer_off">बंद</string>
+  <string name="settings_buzzer_on">चालू (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Penyimpanan</string>
   <string name="cd_channel">Saluran</string>
   <string name="channel_index">Saluran %1$d</string>
+  <string name="settings_discovering">Mendeteksi kemampuan perangkat…</string>
+  <string name="settings_none">Tidak ada pengaturan yang dapat dikonfigurasi</string>
+  <string name="settings_buzzer">Bel</string>
+  <string name="settings_buzzer_updating">Memperbarui…</string>
+  <string name="settings_buzzer_unknown">Tidak diketahui</string>
+  <string name="settings_buzzer_off">Mati</string>
+  <string name="settings_buzzer_on">Nyala (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Archiviazione</string>
   <string name="cd_channel">Canale</string>
   <string name="channel_index">Canale %1$d</string>
+  <string name="settings_discovering">Rilevamento delle funzionalità del dispositivo…</string>
+  <string name="settings_none">Nessuna impostazione configurabile rilevata</string>
+  <string name="settings_buzzer">Cicalino</string>
+  <string name="settings_buzzer_updating">Aggiornamento…</string>
+  <string name="settings_buzzer_unknown">Sconosciuto</string>
+  <string name="settings_buzzer_off">Spento</string>
+  <string name="settings_buzzer_on">Acceso (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">ストレージ</string>
   <string name="cd_channel">チャンネル</string>
   <string name="channel_index">チャンネル %1$d</string>
+  <string name="settings_discovering">デバイスの機能を検出中…</string>
+  <string name="settings_none">設定可能な項目が見つかりません</string>
+  <string name="settings_buzzer">ブザー</string>
+  <string name="settings_buzzer_updating">更新中…</string>
+  <string name="settings_buzzer_unknown">不明</string>
+  <string name="settings_buzzer_off">オフ</string>
+  <string name="settings_buzzer_on">オン (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">저장공간</string>
   <string name="cd_channel">채널</string>
   <string name="channel_index">채널 %1$d</string>
+  <string name="settings_discovering">기기 기능을 감지하는 중…</string>
+  <string name="settings_none">구성 가능한 설정이 없습니다</string>
+  <string name="settings_buzzer">부저</string>
+  <string name="settings_buzzer_updating">업데이트 중…</string>
+  <string name="settings_buzzer_unknown">알 수 없음</string>
+  <string name="settings_buzzer_off">꺼짐</string>
+  <string name="settings_buzzer_on">켜짐 (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Opslag</string>
   <string name="cd_channel">Kanaal</string>
   <string name="channel_index">Kanaal %1$d</string>
+  <string name="settings_discovering">Apparaatmogelijkheden detecteren…</string>
+  <string name="settings_none">Geen configureerbare instellingen gevonden</string>
+  <string name="settings_buzzer">Zoemer</string>
+  <string name="settings_buzzer_updating">Bijwerken…</string>
+  <string name="settings_buzzer_unknown">Onbekend</string>
+  <string name="settings_buzzer_off">Uit</string>
+  <string name="settings_buzzer_on">Aan (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Pamięć</string>
   <string name="cd_channel">Kanał</string>
   <string name="channel_index">Kanał %1$d</string>
+  <string name="settings_discovering">Wykrywanie możliwości urządzenia…</string>
+  <string name="settings_none">Nie wykryto konfigurowalnych ustawień</string>
+  <string name="settings_buzzer">Brzęczyk</string>
+  <string name="settings_buzzer_updating">Aktualizowanie…</string>
+  <string name="settings_buzzer_unknown">Nieznany</string>
+  <string name="settings_buzzer_off">Wył.</string>
+  <string name="settings_buzzer_on">Wł. (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Armazenamento</string>
   <string name="cd_channel">Canal</string>
   <string name="channel_index">Canal %1$d</string>
+  <string name="settings_discovering">Detectando recursos do dispositivo…</string>
+  <string name="settings_none">Nenhuma configuração ajustável detectada</string>
+  <string name="settings_buzzer">Campainha</string>
+  <string name="settings_buzzer_updating">Atualizando…</string>
+  <string name="settings_buzzer_unknown">Desconhecido</string>
+  <string name="settings_buzzer_off">Desligado</string>
+  <string name="settings_buzzer_on">Ligado (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Хранилище</string>
   <string name="cd_channel">Канал</string>
   <string name="channel_index">Канал %1$d</string>
+  <string name="settings_discovering">Определение возможностей устройства…</string>
+  <string name="settings_none">Настраиваемые параметры не обнаружены</string>
+  <string name="settings_buzzer">Зуммер</string>
+  <string name="settings_buzzer_updating">Обновление…</string>
+  <string name="settings_buzzer_unknown">Неизвестно</string>
+  <string name="settings_buzzer_off">Выкл.</string>
+  <string name="settings_buzzer_on">Вкл. (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">ที่จัดเก็บ</string>
   <string name="cd_channel">ช่อง</string>
   <string name="channel_index">ช่อง %1$d</string>
+  <string name="settings_discovering">กำลังตรวจหาความสามารถของอุปกรณ์…</string>
+  <string name="settings_none">ไม่พบการตั้งค่าที่กำหนดได้</string>
+  <string name="settings_buzzer">ออด</string>
+  <string name="settings_buzzer_updating">กำลังอัปเดต…</string>
+  <string name="settings_buzzer_unknown">ไม่ทราบ</string>
+  <string name="settings_buzzer_off">ปิด</string>
+  <string name="settings_buzzer_on">เปิด (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">Depolama</string>
   <string name="cd_channel">Kanal</string>
   <string name="channel_index">Kanal %1$d</string>
+  <string name="settings_discovering">Cihaz özellikleri algılanıyor…</string>
+  <string name="settings_none">Yapılandırılabilir ayar bulunamadı</string>
+  <string name="settings_buzzer">Zil</string>
+  <string name="settings_buzzer_updating">Güncelleniyor…</string>
+  <string name="settings_buzzer_unknown">Bilinmiyor</string>
+  <string name="settings_buzzer_off">Kapalı</string>
+  <string name="settings_buzzer_on">Açık (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">存储</string>
   <string name="cd_channel">频道</string>
   <string name="channel_index">频道 %1$d</string>
+  <string name="settings_discovering">正在检测设备功能…</string>
+  <string name="settings_none">未检测到可配置的设置</string>
+  <string name="settings_buzzer">蜂鸣器</string>
+  <string name="settings_buzzer_updating">更新中…</string>
+  <string name="settings_buzzer_unknown">未知</string>
+  <string name="settings_buzzer_off">关闭</string>
+  <string name="settings_buzzer_on">开启 (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -47,4 +47,11 @@
   <string name="cd_storage">儲存空間</string>
   <string name="cd_channel">頻道</string>
   <string name="channel_index">頻道 %1$d</string>
+  <string name="settings_discovering">正在偵測裝置功能…</string>
+  <string name="settings_none">未偵測到可設定的項目</string>
+  <string name="settings_buzzer">蜂鳴器</string>
+  <string name="settings_buzzer_updating">更新中…</string>
+  <string name="settings_buzzer_unknown">未知</string>
+  <string name="settings_buzzer_off">關閉</string>
+  <string name="settings_buzzer_on">開啟 (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -53,4 +53,11 @@
   <string name="cd_storage">Storage</string>
   <string name="cd_channel">Channel</string>
   <string name="channel_index">Channel %1$d</string>
+  <string name="settings_discovering">Discovering device capabilities…</string>
+  <string name="settings_none">No configurable settings detected</string>
+  <string name="settings_buzzer">Buzzer</string>
+  <string name="settings_buzzer_updating">Updating…</string>
+  <string name="settings_buzzer_unknown">Unknown</string>
+  <string name="settings_buzzer_off">Off</string>
+  <string name="settings_buzzer_on">On (%1$s)</string>
 </resources>

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBody.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBody.kt
@@ -23,7 +23,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.cd_back
+import ee.schimke.meshcore.components.generated.resources.label_device_settings
+import ee.schimke.meshcore.components.generated.resources.settings_buzzer
+import ee.schimke.meshcore.components.generated.resources.settings_buzzer_off
+import ee.schimke.meshcore.components.generated.resources.settings_buzzer_on
+import ee.schimke.meshcore.components.generated.resources.settings_buzzer_unknown
+import ee.schimke.meshcore.components.generated.resources.settings_buzzer_updating
+import ee.schimke.meshcore.components.generated.resources.settings_discovering
+import ee.schimke.meshcore.components.generated.resources.settings_none
 import ee.schimke.meshcore.components.ui.icons.MeshIcons
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Render state for the device settings screen. The stateful `DeviceSettingsScreen` wrapper in
@@ -65,8 +76,17 @@ fun DeviceSettingsBody(
     modifier = modifier,
     topBar = {
       TopAppBar(
-        title = { Text("Device Settings", style = MaterialTheme.typography.titleMedium) },
-        navigationIcon = { IconButton(onClick = onBack) { Icon(MeshIcons.ArrowBack, "Back") } },
+        title = {
+          Text(
+            stringResource(Res.string.label_device_settings),
+            style = MaterialTheme.typography.titleMedium,
+          )
+        },
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(MeshIcons.ArrowBack, stringResource(Res.string.cd_back))
+          }
+        },
         actions = {
           Icon(
             MeshIcons.Settings,
@@ -91,7 +111,7 @@ fun DeviceSettingsBody(
             CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
             Spacer(Modifier.size(12.dp))
             Text(
-              "Discovering device capabilities…",
+              stringResource(Res.string.settings_discovering),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -106,7 +126,7 @@ fun DeviceSettingsBody(
         is DeviceSettingsUiState.Ready ->
           if (!state.hasBuzzer) {
             Text(
-              text = "No configurable settings detected",
+              text = stringResource(Res.string.settings_none),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
               modifier = Modifier.padding(vertical = 24.dp),
@@ -135,17 +155,17 @@ private fun BuzzerRow(mode: String?, loading: Boolean, onToggle: (wantOn: Boolea
   ) {
     Column(modifier = Modifier.weight(1f)) {
       Text(
-        text = "Buzzer",
+        text = stringResource(Res.string.settings_buzzer),
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onSurface,
       )
       Text(
         text =
           when {
-            loading -> "Updating…"
-            mode == null -> "Unknown"
-            mode == "off" -> "Off"
-            else -> "On ($mode)"
+            loading -> stringResource(Res.string.settings_buzzer_updating)
+            mode == null -> stringResource(Res.string.settings_buzzer_unknown)
+            mode == "off" -> stringResource(Res.string.settings_buzzer_off)
+            else -> stringResource(Res.string.settings_buzzer_on, mode)
           },
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Summary

Surface **#4** of the comprehensive i18n sweep — and the one that **completes the `meshcore-components` module**. Extracts the `DeviceSettingsBody` buzzer + discovery strings to Compose resources with real translations across all 17 published locales.

**7 strings extracted:**
- Discovery states — `Discovering device capabilities…`, `No configurable settings detected`
- Buzzer row — `Buzzer` label + the status `when`: `Updating…` / `Unknown` / `Off` / `On (%1$s)` (the mode is passed as the `%1$s` format arg)

The screen **title** and **back** button reuse the existing `label_device_settings` / `cd_back` keys (already on `main` from the Device/Chat surfaces). The `mode == "off"` comparison stays a literal — it's protocol data, not UI copy.

## Test plan

- [ ] `ktfmtCheck` green (formatted in place against the ktfmt jar)
- [ ] `Assemble (debug)` — validates the reused + new `Res.string.*` accessors compile
- [ ] `Compose Preview` renders the settings screen unchanged for the default (en) locale

## Sweep progress
1. Chat ✅ merged (#233)
2. Device ✅ merged (#234)
3. Device cards / rows ✅ merged (#235)
4. **DeviceSettings ← this PR** — completes `meshcore-components`
5. `:app` screens (final surface)

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_