### PR TITLE
feat(i18n): localize the commands and channel screen titles in :app

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ChannelChatScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ChannelChatScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import ee.schimke.meshcore.app.di.LocalAppGraph
 import ee.schimke.meshcore.app.connection.ConnectionUiState
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.channel_index
 import ee.schimke.meshcore.components.ui.ChatBody
 import ee.schimke.meshcore.components.ui.ChatMessage
 import ee.schimke.meshcore.components.ui.MessageStatus
@@ -19,6 +21,7 @@ import android.util.Log
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Instant
+import org.jetbrains.compose.resources.stringResource
 
 private const val TAG = "MeshSend"
 
@@ -110,7 +113,7 @@ fun ChannelChatScreen(
 
     ChatBody(
         title = channelName,
-        subtitle = "Channel $channelIndex",
+        subtitle = stringResource(Res.string.channel_index, channelIndex),
         messages = messages,
         draft = draft,
         onDraftChange = { draft = it },

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/CommandsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/CommandsScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ee.schimke.meshcore.app.di.LocalAppGraph
 import ee.schimke.meshcore.app.connection.ConnectionUiState
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.menu_commands
 import ee.schimke.meshcore.components.ui.ChatBody
 import ee.schimke.meshcore.components.ui.ChatMessage
 import ee.schimke.meshcore.components.ui.MessageStatus
@@ -25,6 +27,7 @@ import ee.schimke.meshcore.data.entity.MessageStatus as DbMessageStatus
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Instant
+import org.jetbrains.compose.resources.stringResource
 
 private const val TAG = "MeshSend"
 
@@ -111,7 +114,7 @@ fun CommandsScreen(
     }
 
     ChatBody(
-        title = "Commands",
+        title = stringResource(Res.string.menu_commands),
         messages = messages,
         draft = draft,
         onDraftChange = { draft = it },

--- a/meshcore-components/build.gradle.kts
+++ b/meshcore-components/build.gradle.kts
@@ -44,7 +44,9 @@ kotlin {
       implementation(libs.compose.preview.annotations)
       // Compose Multiplatform string resources: UI copy resolves from the shared
       // commonMain/composeResources/values*/strings.xml, so the daemon localizes per locale.
-      implementation(libs.compose.components.resources)
+      // Exposed as api (not implementation) so consumers get the generated public Res +
+      // stringResource API on their compile classpath — :app reuses these same strings.
+      api(libs.compose.components.resources)
     }
     val androidMain by getting {
       dependencies {


### PR DESCRIPTION
## Summary

Starts the final i18n surface — the **`:app` screens** — with the two lowest-risk changes: the `CommandsScreen` title and `ChannelChatScreen` subtitle now resolve from the shared Compose resources, **reusing** `menu_commands` and `channel_index` (already localized in all 17 locales via the merged `meshcore-components` work).

No new strings — this is deliberately a small first step that **confirms `:app` resolves the public `Res`** exposed by `:meshcore-components` (`publicResClass = true` was set up in the walking skeleton precisely so `:app` and the component module share one generated resource set). Once green, the remaining `:app` screens (scanner, login, saved devices, connection status, theme picker) follow with their new strings.

## Test plan

- [ ] `Assemble (debug)` — **the key check**: proves `:app` can import `ee.schimke.meshcore.components.generated.resources.*`
- [ ] `ktfmtCheck` green
- [ ] `Compose Preview` renders the commands/channel screens unchanged for the default (en) locale

## Sweep progress
`meshcore-components` module ✅ fully localized (#233–#236 merged). `:app` screens: this PR is the first slice; scanner / login / saved-devices / connection-status / theme-picker to follow.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_