### PR TITLE
perf(build): apply android-cache-fix for relocatable lint/annotation tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.protobuf) apply false
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.tapmoc) apply false
+    alias(libs.plugins.androidCacheFix) apply false
 }
 
 subprojects {
@@ -20,6 +21,23 @@ subprojects {
     extensions.configure<com.ncorti.ktfmt.gradle.KtfmtExtension> {
         googleStyle()
     }
+
+    // Make AGP's path-sensitive tasks relocatable so they hit the BuildFetch
+    // remote cache across machines/checkouts. The cache-diagnostics workflow
+    // flagged lintAnalyze* and extract*Annotations as non-relocatable (their
+    // build-cache keys change with the absolute checkout path); the
+    // org.gradle.android.cache-fix plugin normalises those inputs. Apply it
+    // wherever an Android plugin is present (com.android.application on :app /
+    // :wear, and com.android.kotlin.multiplatform.library on the KMP libraries).
+    val cacheFixId = rootProject.libs.plugins.androidCacheFix.get().pluginId
+    listOf(
+        "com.android.application",
+        "com.android.library",
+        "com.android.kotlin.multiplatform.library",
+    )
+        .forEach { androidPluginId ->
+            pluginManager.withPlugin(androidPluginId) { apply(plugin = cacheFixId) }
+        }
 }
 
 // Wires .githooks/ as the repository's hooks directory. One-time bootstrap:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "9.3.0"
+androidCacheFix = "3.0.3"
 playPublisher = "4.0.0"
 android-compileSdk = "37"
 android-minSdk = "35"
@@ -123,6 +124,7 @@ aboutlibraries-compose-wear-m3 = { module = "com.mikepenz:aboutlibraries-compose
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
+androidCacheFix = { id = "org.gradle.android.cache-fix", version.ref = "androidCacheFix" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
## Why

The `Cache diagnostics` workflow ([run 29685551302](https://github.com/yschimke/meshcore-mobile/actions/runs/29685551302)) flagged **13 of 101 cacheable tasks as non-relocatable** — their build-cache keys change with the absolute checkout path, so they can never hit the BuildFetch remote cache across machines/runners:

- **Android Lint analysis (6):** `:app` and `:wear` `lintAnalyzeDebug` / `…DebugAndroidTest` / `…DebugUnitTest`
- **Annotation extraction (7):** `extractAndroidMainAnnotations` on `:meshcore-components`, `:meshcore-core`, `:meshcore-data`, `:meshcore-mobile`, `:meshcore-session`, `:meshcore-transport-ble`, `:meshcore-transport-usb`

(The expensive `compile*Kotlin` / KSP / protobuf tasks are already relocatable — this is only the lint + annotation clusters.)

## What

Apply [`org.gradle.android.cache-fix`](https://github.com/gradle/android-cache-fix-gradle-plugin) `3.0.3` to every module that applies an Android plugin (via `pluginManager.withPlugin` in the root `subprojects {}`). The plugin normalises the absolute-path inputs on exactly these AGP task types so their keys become path-independent.

## Caveat + verification

AGP here is **9.3.0**, which is newer than cache-fix 3.0.3's tested range, so the plugin may log an "untested AGP version" warning and the version-gated workarounds might not fully engage. This is **verified empirically, not assumed**: I'm re-running the `Cache diagnostics` workflow on this branch — if the 13 non-relocatable tasks drop toward 0, the fix works; if not, this PR shouldn't merge as-is and I'll iterate (newer cache-fix, or a targeted normalization). I'll post the result here.

## Test plan

- CI `Assemble (debug)` / `Unit tests` / `Android lint` must stay green (confirms the plugin doesn't break the AGP 9.3 build).
- `Cache diagnostics` re-run on this branch: relocatability offender count should fall from 13.


---
_Generated by [Claude Code](https://claude.ai/code/session_015NS1efXXJY9CriM38xrQkF)_