### PR TITLE
fix(hooks): make session-start CLAUDE_ENV_FILE append idempotent

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -37,7 +37,14 @@ sdkmanager --sdk_root="$ANDROID_SDK_ROOT" \
   "platforms;android-$COMPILE_SDK" \
   "build-tools;$BUILD_TOOLS_VERSION" >/dev/null
 
-if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+# Export for later tool calls via $CLAUDE_ENV_FILE. Append at most ONCE, guarded
+# on a marker: SessionStart re-fires on resume/compact, and a bare `>>` would
+# re-append these lines every time. Claude Code inlines this file into each
+# `bash -c` preamble to apply the env, so an ever-growing file eventually blows
+# past the kernel's 128 KiB single-argument limit (MAX_ARG_STRLEN) and every
+# shell command dies with E2BIG. The guard keeps it to a single copy. (The PATH
+# line also prepends, so re-appending would compound PATH on each sourcing too.)
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qF "export ANDROID_HOME=" "$CLAUDE_ENV_FILE" 2>/dev/null; then
   {
     echo "export ANDROID_HOME=\"$ANDROID_SDK_ROOT\""
     echo "export ANDROID_SDK_ROOT=\"$ANDROID_SDK_ROOT\""


### PR DESCRIPTION
## Summary

`session-start.sh` appended its three `export` lines to `$CLAUDE_ENV_FILE` with a bare `>>` and no guard. `SessionStart` re-fires on **resume / compact**, so across a long Claude-Code-on-the-web session those lines accumulate. Claude Code applies the hook env by **inlining `$CLAUDE_ENV_FILE` into each `bash -c` preamble**, so the ever-growing file eventually pushes the command string past the kernel's **128 KiB single-argument limit** (`MAX_ARG_STRLEN` = 32 × page size = 131072 bytes) → **`E2BIG` on every shell command**, including `echo hi`.

Observed in a long session: the `bash -c` argument grew to ~130–134 KB (while the process **environment** stayed ~6 KB — the duplicated `export` lines all resolve to the same few vars, so the bloat is in the *sourcing text*, not the resulting env). Every `Bash` call died; `Read`/`Edit`/MCP kept working since they don't spawn a shell.

## Fix

Guard the append on an `export ANDROID_HOME=` marker so the block writes **at most once**, no matter how many times the hook fires on resume/compact. Also added a comment documenting *why*, so it isn't innocently reverted to a bare `>>`.

Note: the `export PATH="…:$PATH"` line **prepends**, so the un-guarded re-append was also compounding `PATH` on every sourcing — the guard fixes that too.

## Test plan

- Shell-script only; no build/app impact.
- First `SessionStart` (marker absent) appends the exports as before; subsequent resume/compact fires (marker present) skip the append → `$CLAUDE_ENV_FILE` stays a single copy and the `bash -c` preamble stays small. No behavior change to a normal (single-start) session.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWWMcA4XFhj7qbDNVNrM8e)_