### PR TITLE
feat(i18n): localize the connection-status views across 17 locales

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreen.kt
@@ -75,6 +75,10 @@ import ee.schimke.meshcore.components.ui.ContactListEmpty
 import ee.schimke.meshcore.components.ui.ContactRow
 import ee.schimke.meshcore.components.ui.DeviceSummaryCard
 import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.status_connection_failed
+import ee.schimke.meshcore.components.generated.resources.title_connecting
+import ee.schimke.meshcore.components.generated.resources.title_disconnecting
+import ee.schimke.meshcore.components.generated.resources.title_retrying
 import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.launch
 

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceScreen.kt
@@ -74,6 +74,8 @@ import ee.schimke.meshcore.components.ui.LastMessageInfo
 import ee.schimke.meshcore.components.ui.ContactListEmpty
 import ee.schimke.meshcore.components.ui.ContactRow
 import ee.schimke.meshcore.components.ui.DeviceSummaryCard
+import ee.schimke.meshcore.components.generated.resources.Res
+import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.launch
 
 /** Channel name used for the device commands interface. */
@@ -146,7 +148,7 @@ fun DeviceScreen(
             onNavigateToSettings = onNavigateToSettings,
         )
         is ConnectionUiState.Connecting -> DeviceStatusView(
-            title = "Connecting",
+            title = stringResource(Res.string.title_connecting),
             onCancel = { controller.cancel() },
             onOpenThemePicker = onOpenThemePicker,
             status = DeviceConnectStatus.Connecting(
@@ -155,7 +157,7 @@ fun DeviceScreen(
             ),
         )
         is ConnectionUiState.Retrying -> DeviceStatusView(
-            title = "Retrying (${s.attempt}/${s.maxAttempts})",
+            title = stringResource(Res.string.title_retrying, s.attempt, s.maxAttempts),
             onCancel = { controller.cancel() },
             onOpenThemePicker = onOpenThemePicker,
             status = DeviceConnectStatus.Connecting(
@@ -164,7 +166,7 @@ fun DeviceScreen(
             ),
         )
         is ConnectionUiState.Failed -> DeviceStatusView(
-            title = "Connection failed",
+            title = stringResource(Res.string.status_connection_failed),
             onCancel = { controller.dismissError() },
             onOpenThemePicker = onOpenThemePicker,
             status = DeviceConnectStatus.Failed(s.cause),
@@ -174,7 +176,7 @@ fun DeviceScreen(
             // about to be popped by the LaunchedEffect above, so the
             // user never sees a flash of blank screen.
             DeviceStatusView(
-                title = "Disconnecting",
+                title = stringResource(Res.string.title_disconnecting),
                 onCancel = { onDisconnected() },
                 onOpenThemePicker = onOpenThemePicker,
                 status = DeviceConnectStatus.Connecting(

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceStatusViews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceStatusViews.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ee.schimke.meshcore.app.ui.theme.Dimens
+import ee.schimke.meshcore.components.generated.resources.Res
+import org.jetbrains.compose.resources.stringResource
 
 // --- Connecting / Failed status view ----------------------------------------
 
@@ -67,10 +69,10 @@ fun DeviceStatusView(
                 title = { Text(title, style = MaterialTheme.typography.titleLarge) },
                 actions = {
                     IconButton(onClick = onOpenThemePicker) {
-                        Icon(Icons.Rounded.Contrast, contentDescription = "Theme")
+                        Icon(Icons.Rounded.Contrast, contentDescription = stringResource(Res.string.cd_theme))
                     }
                     IconButton(onClick = onCancel) {
-                        Icon(Icons.AutoMirrored.Rounded.Logout, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Rounded.Logout, contentDescription = stringResource(Res.string.cd_back))
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -145,12 +147,12 @@ private fun ConnectingCard(
                 Spacer(Modifier.size(Dimens.M))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "Connecting…",
+                        text = stringResource(Res.string.status_connecting),
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                     Text(
-                        text = "Waiting for the radio to respond — ${remainingS}s",
+                        text = stringResource(Res.string.status_waiting_radio, remainingS),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
@@ -165,7 +167,7 @@ private fun ConnectingCard(
             OutlinedButton(
                 onClick = onCancel,
                 modifier = Modifier.fillMaxWidth(),
-            ) { Text("Cancel") }
+            ) { Text(stringResource(Res.string.btn_cancel)) }
         }
     }
 }
@@ -201,23 +203,23 @@ private fun FailureCard(cause: Throwable, onRetry: () -> Unit) {
                 )
                 Spacer(Modifier.size(Dimens.S))
                 Text(
-                    text = "Connection failed",
+                    text = stringResource(Res.string.status_connection_failed),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onErrorContainer,
                 )
             }
             Text(
-                text = cause.message ?: "Unknown error",
+                text = cause.message ?: stringResource(Res.string.status_unknown_error),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onErrorContainer,
             )
-            OutlinedButton(onClick = onRetry) { Text("Back to scanner") }
+            OutlinedButton(onClick = onRetry) { Text(stringResource(Res.string.btn_back_to_scanner)) }
         }
     }
     OutlinedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(
-                text = "Details",
+                text = stringResource(Res.string.label_details),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceStatusViews.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/DeviceStatusViews.kt
@@ -33,6 +33,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ee.schimke.meshcore.app.ui.theme.Dimens
 import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.btn_back_to_scanner
+import ee.schimke.meshcore.components.generated.resources.btn_cancel
+import ee.schimke.meshcore.components.generated.resources.cd_back
+import ee.schimke.meshcore.components.generated.resources.cd_theme
+import ee.schimke.meshcore.components.generated.resources.label_details
+import ee.schimke.meshcore.components.generated.resources.status_connecting
+import ee.schimke.meshcore.components.generated.resources.status_connection_failed
+import ee.schimke.meshcore.components.generated.resources.status_unknown_error
+import ee.schimke.meshcore.components.generated.resources.status_waiting_radio
 import org.jetbrains.compose.resources.stringResource
 
 // --- Connecting / Failed status view ----------------------------------------

--- a/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">غير معروف</string>
   <string name="settings_buzzer_off">إيقاف</string>
   <string name="settings_buzzer_on">تشغيل (%1$s)</string>
+  <string name="status_connecting">جارٍ الاتصال…</string>
+  <string name="status_waiting_radio">في انتظار استجابة الراديو — %1$d ث</string>
+  <string name="btn_cancel">إلغاء</string>
+  <string name="status_connection_failed">فشل الاتصال</string>
+  <string name="status_unknown_error">خطأ غير معروف</string>
+  <string name="btn_back_to_scanner">العودة إلى الماسح</string>
+  <string name="label_details">التفاصيل</string>
+  <string name="title_connecting">جارٍ الاتصال</string>
+  <string name="title_retrying">إعادة المحاولة (%1$d/%2$d)</string>
+  <string name="title_disconnecting">جارٍ قطع الاتصال</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Unbekannt</string>
   <string name="settings_buzzer_off">Aus</string>
   <string name="settings_buzzer_on">An (%1$s)</string>
+  <string name="status_connecting">Verbindung wird hergestellt…</string>
+  <string name="status_waiting_radio">Warte auf Antwort des Funkmoduls — %1$ds</string>
+  <string name="btn_cancel">Abbrechen</string>
+  <string name="status_connection_failed">Verbindung fehlgeschlagen</string>
+  <string name="status_unknown_error">Unbekannter Fehler</string>
+  <string name="btn_back_to_scanner">Zurück zum Scanner</string>
+  <string name="label_details">Details</string>
+  <string name="title_connecting">Verbindung wird hergestellt</string>
+  <string name="title_retrying">Erneuter Versuch (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Verbindung wird getrennt</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Desconocido</string>
   <string name="settings_buzzer_off">Apagado</string>
   <string name="settings_buzzer_on">Encendido (%1$s)</string>
+  <string name="status_connecting">Conectando…</string>
+  <string name="status_waiting_radio">Esperando respuesta de la radio — %1$ds</string>
+  <string name="btn_cancel">Cancelar</string>
+  <string name="status_connection_failed">Error de conexión</string>
+  <string name="status_unknown_error">Error desconocido</string>
+  <string name="btn_back_to_scanner">Volver al escáner</string>
+  <string name="label_details">Detalles</string>
+  <string name="title_connecting">Conectando</string>
+  <string name="title_retrying">Reintentando (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Desconectando</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Inconnu</string>
   <string name="settings_buzzer_off">Désactivé</string>
   <string name="settings_buzzer_on">Activé (%1$s)</string>
+  <string name="status_connecting">Connexion…</string>
+  <string name="status_waiting_radio">En attente de la réponse de la radio — %1$ds</string>
+  <string name="btn_cancel">Annuler</string>
+  <string name="status_connection_failed">Échec de la connexion</string>
+  <string name="status_unknown_error">Erreur inconnue</string>
+  <string name="btn_back_to_scanner">Retour au scanner</string>
+  <string name="label_details">Détails</string>
+  <string name="title_connecting">Connexion</string>
+  <string name="title_retrying">Nouvelle tentative (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Déconnexion</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">अज्ञात</string>
   <string name="settings_buzzer_off">बंद</string>
   <string name="settings_buzzer_on">चालू (%1$s)</string>
+  <string name="status_connecting">कनेक्ट हो रहा है…</string>
+  <string name="status_waiting_radio">रेडियो के जवाब की प्रतीक्षा — %1$d सेकंड</string>
+  <string name="btn_cancel">रद्द करें</string>
+  <string name="status_connection_failed">कनेक्शन विफल</string>
+  <string name="status_unknown_error">अज्ञात त्रुटि</string>
+  <string name="btn_back_to_scanner">स्कैनर पर वापस जाएँ</string>
+  <string name="label_details">विवरण</string>
+  <string name="title_connecting">कनेक्ट हो रहा है</string>
+  <string name="title_retrying">पुनः प्रयास (%1$d/%2$d)</string>
+  <string name="title_disconnecting">डिस्कनेक्ट हो रहा है</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Tidak diketahui</string>
   <string name="settings_buzzer_off">Mati</string>
   <string name="settings_buzzer_on">Nyala (%1$s)</string>
+  <string name="status_connecting">Menghubungkan…</string>
+  <string name="status_waiting_radio">Menunggu respons radio — %1$d dtk</string>
+  <string name="btn_cancel">Batal</string>
+  <string name="status_connection_failed">Koneksi gagal</string>
+  <string name="status_unknown_error">Kesalahan tidak diketahui</string>
+  <string name="btn_back_to_scanner">Kembali ke pemindai</string>
+  <string name="label_details">Detail</string>
+  <string name="title_connecting">Menghubungkan</string>
+  <string name="title_retrying">Mencoba lagi (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Memutuskan</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Sconosciuto</string>
   <string name="settings_buzzer_off">Spento</string>
   <string name="settings_buzzer_on">Acceso (%1$s)</string>
+  <string name="status_connecting">Connessione…</string>
+  <string name="status_waiting_radio">In attesa della risposta della radio — %1$ds</string>
+  <string name="btn_cancel">Annulla</string>
+  <string name="status_connection_failed">Connessione non riuscita</string>
+  <string name="status_unknown_error">Errore sconosciuto</string>
+  <string name="btn_back_to_scanner">Torna allo scanner</string>
+  <string name="label_details">Dettagli</string>
+  <string name="title_connecting">Connessione</string>
+  <string name="title_retrying">Nuovo tentativo (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Disconnessione</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">不明</string>
   <string name="settings_buzzer_off">オフ</string>
   <string name="settings_buzzer_on">オン (%1$s)</string>
+  <string name="status_connecting">接続中…</string>
+  <string name="status_waiting_radio">無線の応答を待機中 — %1$d秒</string>
+  <string name="btn_cancel">キャンセル</string>
+  <string name="status_connection_failed">接続に失敗しました</string>
+  <string name="status_unknown_error">不明なエラー</string>
+  <string name="btn_back_to_scanner">スキャナーに戻る</string>
+  <string name="label_details">詳細</string>
+  <string name="title_connecting">接続中</string>
+  <string name="title_retrying">再試行中 (%1$d/%2$d)</string>
+  <string name="title_disconnecting">切断中</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">알 수 없음</string>
   <string name="settings_buzzer_off">꺼짐</string>
   <string name="settings_buzzer_on">켜짐 (%1$s)</string>
+  <string name="status_connecting">연결 중…</string>
+  <string name="status_waiting_radio">무선 응답 대기 중 — %1$d초</string>
+  <string name="btn_cancel">취소</string>
+  <string name="status_connection_failed">연결 실패</string>
+  <string name="status_unknown_error">알 수 없는 오류</string>
+  <string name="btn_back_to_scanner">스캐너로 돌아가기</string>
+  <string name="label_details">세부정보</string>
+  <string name="title_connecting">연결 중</string>
+  <string name="title_retrying">재시도 중 (%1$d/%2$d)</string>
+  <string name="title_disconnecting">연결 해제 중</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Onbekend</string>
   <string name="settings_buzzer_off">Uit</string>
   <string name="settings_buzzer_on">Aan (%1$s)</string>
+  <string name="status_connecting">Verbinden…</string>
+  <string name="status_waiting_radio">Wachten op reactie van de radio — %1$ds</string>
+  <string name="btn_cancel">Annuleren</string>
+  <string name="status_connection_failed">Verbinding mislukt</string>
+  <string name="status_unknown_error">Onbekende fout</string>
+  <string name="btn_back_to_scanner">Terug naar scanner</string>
+  <string name="label_details">Details</string>
+  <string name="title_connecting">Verbinden</string>
+  <string name="title_retrying">Opnieuw proberen (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Verbinding verbreken</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Nieznany</string>
   <string name="settings_buzzer_off">Wył.</string>
   <string name="settings_buzzer_on">Wł. (%1$s)</string>
+  <string name="status_connecting">Łączenie…</string>
+  <string name="status_waiting_radio">Oczekiwanie na odpowiedź radia — %1$ds</string>
+  <string name="btn_cancel">Anuluj</string>
+  <string name="status_connection_failed">Połączenie nieudane</string>
+  <string name="status_unknown_error">Nieznany błąd</string>
+  <string name="btn_back_to_scanner">Powrót do skanera</string>
+  <string name="label_details">Szczegóły</string>
+  <string name="title_connecting">Łączenie</string>
+  <string name="title_retrying">Ponawianie (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Rozłączanie</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Desconhecido</string>
   <string name="settings_buzzer_off">Desligado</string>
   <string name="settings_buzzer_on">Ligado (%1$s)</string>
+  <string name="status_connecting">Conectando…</string>
+  <string name="status_waiting_radio">Aguardando resposta do rádio — %1$ds</string>
+  <string name="btn_cancel">Cancelar</string>
+  <string name="status_connection_failed">Falha na conexão</string>
+  <string name="status_unknown_error">Erro desconhecido</string>
+  <string name="btn_back_to_scanner">Voltar ao scanner</string>
+  <string name="label_details">Detalhes</string>
+  <string name="title_connecting">Conectando</string>
+  <string name="title_retrying">Tentando novamente (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Desconectando</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Неизвестно</string>
   <string name="settings_buzzer_off">Выкл.</string>
   <string name="settings_buzzer_on">Вкл. (%1$s)</string>
+  <string name="status_connecting">Подключение…</string>
+  <string name="status_waiting_radio">Ожидание ответа радио — %1$d с</string>
+  <string name="btn_cancel">Отмена</string>
+  <string name="status_connection_failed">Не удалось подключиться</string>
+  <string name="status_unknown_error">Неизвестная ошибка</string>
+  <string name="btn_back_to_scanner">Назад к сканеру</string>
+  <string name="label_details">Подробности</string>
+  <string name="title_connecting">Подключение</string>
+  <string name="title_retrying">Повтор (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Отключение</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">ไม่ทราบ</string>
   <string name="settings_buzzer_off">ปิด</string>
   <string name="settings_buzzer_on">เปิด (%1$s)</string>
+  <string name="status_connecting">กำลังเชื่อมต่อ…</string>
+  <string name="status_waiting_radio">กำลังรอการตอบสนองจากวิทยุ — %1$d วิ</string>
+  <string name="btn_cancel">ยกเลิก</string>
+  <string name="status_connection_failed">การเชื่อมต่อล้มเหลว</string>
+  <string name="status_unknown_error">ข้อผิดพลาดที่ไม่รู้จัก</string>
+  <string name="btn_back_to_scanner">กลับไปที่ตัวสแกน</string>
+  <string name="label_details">รายละเอียด</string>
+  <string name="title_connecting">กำลังเชื่อมต่อ</string>
+  <string name="title_retrying">กำลังลองใหม่ (%1$d/%2$d)</string>
+  <string name="title_disconnecting">กำลังตัดการเชื่อมต่อ</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">Bilinmiyor</string>
   <string name="settings_buzzer_off">Kapalı</string>
   <string name="settings_buzzer_on">Açık (%1$s)</string>
+  <string name="status_connecting">Bağlanıyor…</string>
+  <string name="status_waiting_radio">Telsizin yanıt vermesi bekleniyor — %1$ds</string>
+  <string name="btn_cancel">İptal</string>
+  <string name="status_connection_failed">Bağlantı başarısız</string>
+  <string name="status_unknown_error">Bilinmeyen hata</string>
+  <string name="btn_back_to_scanner">Tarayıcıya dön</string>
+  <string name="label_details">Ayrıntılar</string>
+  <string name="title_connecting">Bağlanıyor</string>
+  <string name="title_retrying">Yeniden deneniyor (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Bağlantı kesiliyor</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">未知</string>
   <string name="settings_buzzer_off">关闭</string>
   <string name="settings_buzzer_on">开启 (%1$s)</string>
+  <string name="status_connecting">正在连接…</string>
+  <string name="status_waiting_radio">正在等待无线电响应 — %1$d秒</string>
+  <string name="btn_cancel">取消</string>
+  <string name="status_connection_failed">连接失败</string>
+  <string name="status_unknown_error">未知错误</string>
+  <string name="btn_back_to_scanner">返回扫描器</string>
+  <string name="label_details">详情</string>
+  <string name="title_connecting">正在连接</string>
+  <string name="title_retrying">正在重试 (%1$d/%2$d)</string>
+  <string name="title_disconnecting">正在断开连接</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -54,4 +54,14 @@
   <string name="settings_buzzer_unknown">未知</string>
   <string name="settings_buzzer_off">關閉</string>
   <string name="settings_buzzer_on">開啟 (%1$s)</string>
+  <string name="status_connecting">正在連線…</string>
+  <string name="status_waiting_radio">正在等待無線電回應 — %1$d秒</string>
+  <string name="btn_cancel">取消</string>
+  <string name="status_connection_failed">連線失敗</string>
+  <string name="status_unknown_error">未知錯誤</string>
+  <string name="btn_back_to_scanner">返回掃描器</string>
+  <string name="label_details">詳細資料</string>
+  <string name="title_connecting">正在連線</string>
+  <string name="title_retrying">正在重試 (%1$d/%2$d)</string>
+  <string name="title_disconnecting">正在中斷連線</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -60,4 +60,14 @@
   <string name="settings_buzzer_unknown">Unknown</string>
   <string name="settings_buzzer_off">Off</string>
   <string name="settings_buzzer_on">On (%1$s)</string>
+  <string name="status_connecting">Connecting…</string>
+  <string name="status_waiting_radio">Waiting for the radio to respond — %1$ds</string>
+  <string name="btn_cancel">Cancel</string>
+  <string name="status_connection_failed">Connection failed</string>
+  <string name="status_unknown_error">Unknown error</string>
+  <string name="btn_back_to_scanner">Back to scanner</string>
+  <string name="label_details">Details</string>
+  <string name="title_connecting">Connecting</string>
+  <string name="title_retrying">Retrying (%1$d/%2$d)</string>
+  <string name="title_disconnecting">Disconnecting</string>
 </resources>


### PR DESCRIPTION
## Summary

Localizes the `:app` device connection-status surface — the full-screen views shown while a
transport is connecting, retrying, disconnecting, or after a connection failure. This continues the
comprehensive i18n effort (`#230`–`#237`); the `meshcore-components` module is already fully
localized, and this is the first of the two remaining `:app` batches.

New strings are added to the shared `meshcore-components/composeResources` catalog (reused by `:app`
via the `api(libs.compose.components.resources)` exposure landed in `#237`) with real translations
for all 17 published locales (`ar de es fr hi id it ja ko nl pl pt-BR ru th tr zh-CN zh-TW`).

### Strings localized
- **`DeviceStatusViews.kt`** — `Connecting…`, `Waiting for the radio to respond — %1$ds`, `Cancel`,
  `Connection failed`, `Unknown error`, `Back to scanner`, `Details`, and the top-bar `Theme` / `Back`
  content descriptions (reusing existing `cd_theme` / `cd_back`).
- **`DeviceScreen.kt`** — the `DeviceStatusView` titles: `Connecting`, `Retrying (%1$d/%2$d)`,
  `Connection failed`, `Disconnecting`.

### New resource keys
`status_connecting`, `status_waiting_radio`, `btn_cancel`, `status_connection_failed`,
`status_unknown_error`, `btn_back_to_scanner`, `label_details`, `title_connecting`, `title_retrying`,
`title_disconnecting` — added across all 18 `values*/strings.xml` files (base + 17 locales).

Format args (`%1$d`, `%2$d`) are preserved in every locale; unit/brand tokens and the em-dash follow
the established catalog conventions.

## Test plan
- [ ] CI `Assemble (debug)` compiles `:app` with the shared `Res` accessors.
- [ ] `ktfmtCheck` passes (`meshcore-components` XML only; `:app` edits match the existing 4-space style).
- [ ] Spot-check the connecting / failed / retrying views render translated text under the locale axis.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv7gVZDkeziE6sNTf8rsnV)_