### PR TITLE
feat(catalog): add theme-picker and saved-devices screens to the design catalog

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -279,6 +279,38 @@
           "caption": "Device settings — discovered device, with the buzzer toggle."
         }
       ]
+    },
+    {
+      "name": "Saved devices",
+      "section": "Screens",
+      "components": [
+        {
+          "componentId": "SavedDevices/Populated",
+          "preview": "SavedDevicesPopulatedPreview",
+          "caption": "Saved-devices list — a favourited BLE device, a second device and a TCP entry."
+        },
+        {
+          "componentId": "SavedDevices/Empty",
+          "preview": "SavedDevicesEmptyPreview",
+          "caption": "Saved-devices list — empty state with the connect-once hint."
+        }
+      ]
+    },
+    {
+      "name": "Theme picker",
+      "section": "Screens",
+      "components": [
+        {
+          "componentId": "ThemePicker/MeshcoreSystem",
+          "preview": "ThemePickerMeshcoreSystemPreview",
+          "caption": "Theme picker — MeshCore palette, follow-system mode."
+        },
+        {
+          "componentId": "ThemePicker/DynamicDark",
+          "preview": "ThemePickerDynamicDarkPreview",
+          "caption": "Theme picker — dynamic (Material You) palette, dark mode."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

First increment of the design-catalog work (post-i18n): extends the **Screens** section of
`catalog.spec.json` so more top-level app surfaces are published to `design-artifacts/meshcore-mobile`.

- **Saved devices** — adds `SavedDevices/Populated` + `SavedDevices/Empty` (existing
  `SavedDevicesPopulatedPreview` / `SavedDevicesEmptyPreview`, previously only surfaced indirectly via
  the Scanner Saved tab).
- **Theme picker** — adds `ThemePicker/MeshcoreSystem` + `ThemePicker/DynamicDark` (existing
  `ThemePickerMeshcoreSystemPreview` / `ThemePickerDynamicDarkPreview`).

These are pure spec additions referencing previews the module already renders in CI (both appear in the
preview-diff bot's "Unchanged" set), so they carry no render risk. No Kotlin changes.

## Deferred: Login screen
An initial version of this PR also added `LoginPromptPreview` / `LoginErrorPreview` fixtures for the
room/repeater login dialog. The preview-diff render run showed **both failed to render** (no PNG) — the
`LoginDialog` puts an `OutlinedTextField` inside an `AlertDialog`, which the Robolectric preview
sandbox doesn't render cleanly (the text-field-less `ThemePicker` `AlertDialog` previews render fine).
Rather than ship broken catalog entries, the Login fixtures were dropped from this PR; catalog coverage
for the login dialog needs a render approach that survives the Robolectric sandbox (or the CMP-desktop
path) and is tracked as a follow-up.

## Test plan
- [x] `catalog.spec.json` validated as JSON (12 groups, 6 under Screens).
- [x] The two added screens (Saved devices, Theme picker) render in CI — both are in the preview-diff bot's Unchanged list.
- [x] No Kotlin changes (`LoginDialog.kt` is identical to `main`); `no-ai-coauthors` gate: sole commit authored + committed as `Yuri Schimke <yuri@schimke.ee>`.
- [ ] After merge, dispatch `design-artifacts.yml` to republish `design-artifacts/meshcore-mobile`.

## Larger follow-up (not in this PR)
The locale (en/ja/ar/de, Arabic RTL) and per-screen device/theme **axes** from the design plan are a
separate, larger feature in `compose-ai-tools` — the catalog pipeline (`bundle pack` →
`generate-design-catalog.mjs`) doesn't fan out render-override matrices today.

_Generated by [Claude Code](https://claude.ai/code)_