### PR TITLE
fix(design-artifacts): tolerate the unrenderable compose-m3 metadata previews

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -167,19 +167,33 @@ jobs:
           CLI="$GITHUB_WORKSPACE/compose-ai-tools/cli/build/install/compose-preview/bin/compose-preview"
           BLOB="$(jq -r .themeColors design/meshcore-theme-colors.json)"
           SRC=compose-m3-artifacts/bundle/compose-m3-bundle.png
+          OUT="$GITHUB_WORKSPACE/compose-m3-rethemed"
           # Re-theme every published preview to PNG + editable figma-svg, rehydrating
           # the externalized fonts from the branch's pool. Under xvfb so the desktop
           # daemon has a display (matches compose-ai-tools' desktop-render jobs).
+          #
+          # The color/type/shape "catalog" previews (Palette colours / Typeface type
+          # styles / Shape shapes) are metadata sheets the daemon can't resolve on the
+          # --knob path — the catalog exporter excludes them too — so `bundle render`
+          # reports them as failures and exits non-zero. Don't let that fail the job;
+          # instead require that the rest re-themed (guarding a broad render failure),
+          # then repack.
           xvfb-run -a -s "-screen 0 2000x1400x24" \
             "$CLI" bundle render "$SRC" \
               --knob "theme.colors=$BLOB" \
               --res compose-m3-artifacts/bundle/res \
               --svg \
-              -o "$GITHUB_WORKSPACE/compose-m3-rethemed"
+              -o "$OUT" || echo "bundle render exited non-zero (expected for the metadata sheets)"
+          count=$(find "$OUT" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l)
+          echo "re-themed $count preview PNG(s)"
+          if [ "$count" -lt 70 ]; then
+            echo "::error::only $count re-themed previews — the render broadly failed"
+            exit 1
+          fi
           # Swap the re-themed PNG + figma-svg back into the bundle → a drop-in
           # re-themed bundle the catalog exporter consumes like the original.
           "$CLI" bundle repack "$SRC" \
-            --renders "$GITHUB_WORKSPACE/compose-m3-rethemed" \
+            --renders "$OUT" \
             -o "$GITHUB_WORKSPACE/compose-m3-meshcore.png"
 
       - name: Fold the re-themed compose-m3 catalog in as a "Material 3" tab

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -185,9 +185,20 @@ jobs:
               --svg \
               -o "$OUT" || echo "bundle render exited non-zero (expected for the metadata sheets)"
           count=$(find "$OUT" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l)
-          echo "re-themed $count preview PNG(s)"
+          svgcount=$(find "$OUT" -maxdepth 1 -name '*.svg' 2>/dev/null | wc -l)
+          echo "re-themed $count preview PNG(s), $svgcount figma-svg(s)"
           if [ "$count" -lt 70 ]; then
             echo "::error::only $count re-themed previews — the render broadly failed"
+            exit 1
+          fi
+          # Every re-themed PNG must carry a matching re-themed figma-svg. `bundle
+          # render --svg` writes the vector best-effort (a preview can get a PNG but
+          # not its SVG), and `bundle repack` only swaps the SVGs present in --renders
+          # — otherwise keeping the bundle's original (stock Material-colour)
+          # previews/<id>.figma.svg. A partial SVG export would therefore publish
+          # MeshCore-teal PNGs beside stale Material-purple Figma imports; fail instead.
+          if [ "$svgcount" -lt "$count" ]; then
+            echo "::error::only $svgcount re-themed figma-svg(s) for $count PNG(s) — the vector export fell short; would leave stale figma.svg"
             exit 1
           fi
           # Swap the re-themed PNG + figma-svg back into the bundle → a drop-in


### PR DESCRIPTION
## What

The first Material-3-tab run ([#245](https://github.com/yschimke/meshcore-mobile/pull/245)) failed at the re-theme step. `bundle render --knob` on the published compose-m3 bundle can't resolve three "catalog" **metadata** previews — `Palette colours`, `Typeface type styles`, `Shape shapes` (their `@Preview` names carry spaces) — so it reports them as failures and exits non-zero, failing the whole step:

```
rendered 74 / 77 preview(s) themed (+ 74 svg)
FAIL colorcatalog__Palette (timed out after 10s)
FAIL typographycatalog__Typeface (timed out after 10s)
FAIL shapecatalog__Shape (timed out after 10s)
##[error]Process completed with exit code 1
```

Those three are exactly the previews `generate-design-catalog` already **excludes** (metadata sheets with no static PNG), and none of the 26 catalog components need them.

## How

Tolerate that expected non-zero exit, but **guard against a broad render failure** (`<70` re-themed PNGs still fails the job, catching a real regression), then repack the 74 as before. Everything else is unchanged.

## Verified — the tab is live

Dispatched this branch's workflow (`workflow_dispatch` on the branch ref): the full pipeline ran **green in ~7.7 min** — from-source CLI build, re-theme (74/77 tolerated), repack, catalog build, `merge-catalog-section`, and force-push to `design-artifacts/meshcore-mobile`. The published catalog now carries the tab:

```
sections: {"(none)": 42, "Material 3": 26}
```

The folded stickers are **re-themed to MeshCore teal** — this is the actual `Button/Filled` sticker now live on the delivery branch:

![live Material 3 tab sticker](https://raw.githubusercontent.com/yschimke/meshcore-mobile/design-artifacts/meshcore-mobile/images/button-filled/ideal__default__light.png)

## Test plan

- Branch `workflow_dispatch` run succeeded end-to-end and published the catalog with the 26-component `Material 3` section (verified by parsing the published `catalog.json`).
- `find … -name '*.png'` count guard (`≥70`) keeps a genuine render regression failing the job.
- YAML parses.

Text-only diff otherwise (workflow tolerance logic); the visual outcome is the live sticker above.

_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBurh9kb3NJ2KsmYRFhU62)_