### PR TITLE
fix(catalog): drop the theme-picker dialog previews (no semantics for the publish gate)

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -295,22 +295,6 @@
           "caption": "Saved-devices list — empty state with the connect-once hint."
         }
       ]
-    },
-    {
-      "name": "Theme picker",
-      "section": "Screens",
-      "components": [
-        {
-          "componentId": "ThemePicker/MeshcoreSystem",
-          "preview": "ThemePickerMeshcoreSystemPreview",
-          "caption": "Theme picker — MeshCore palette, follow-system mode."
-        },
-        {
-          "componentId": "ThemePicker/DynamicDark",
-          "preview": "ThemePickerDynamicDarkPreview",
-          "caption": "Theme picker — dynamic (Material You) palette, dark mode."
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #246. The `design-artifacts` regeneration on `main` fails at the "Generate importable
catalog" step:

```
[meshcore-mobile] no semantics for: ThemePicker/MeshcoreSystem, ThemePicker/DynamicDark
[meshcore-mobile] incomplete render — refusing to publish.
```

`ThemePickerDialog` is an **`AlertDialog`**, which renders in a separate window the layout-inspector
doesn't capture — so those previews produce a PNG but **no semantics sidecar**, and the generator's
completeness gate refuses to publish. The PR-time preview-diff bot only needs a PNG, so it happily
rendered them and they slipped past review, but the stricter publish gate rejects them. (This is the
same dialog limitation that made the Login `AlertDialog` fail to render at all, and it's why the
original catalog deliberately included only full-screen Scaffold/Column screens, never dialogs.)

This drops the two ThemePicker entries, unblocking regeneration. The **Saved devices** screens added in
#246 are kept — they're a plain list, produce semantics, and were not flagged by the gate.

## Test plan
- [x] `catalog.spec.json` validated as JSON (11 groups; no `ThemePicker/*` remains).
- [x] Sole commit authored + committed as `Yuri Schimke <yuri@schimke.ee>`.
- [ ] After merge, re-dispatch `design-artifacts.yml`; the "Generate importable catalog" step should
      now pass and republish `design-artifacts/meshcore-mobile` (now including the Saved-devices screens).

## Note for future catalog work
Dialog surfaces (`AlertDialog`, `Dialog`) can't be published through the `:app` Robolectric catalog
path — they lack semantics. Cataloging the theme picker / login dialogs would need either a
semantics-producing render path for dialogs or previewing their content inline (not as a dialog).

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv7gVZDkeziE6sNTf8rsnV)_