### PR TITLE
feat(catalog): add a German (de) locale axis to the Settings and Cached-device screens

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -244,7 +244,10 @@
         {
           "componentId": "Device/Cached",
           "preview": "CachedDeviceBodyPreview",
-          "caption": "Device screen — cached (offline) data, with the stale-data warning banner."
+          "caption": "Device screen — cached (offline) data, with the stale-data warning banner.",
+          "variants": [
+            { "props": { "locale": "de" }, "preview": "CachedDeviceBodyGermanPreview" }
+          ]
         }
       ]
     },
@@ -276,7 +279,10 @@
         {
           "componentId": "Settings/Ready",
           "preview": "DeviceSettingsPreview",
-          "caption": "Device settings — discovered device, with the buzzer toggle."
+          "caption": "Device settings — discovered device, with the buzzer toggle.",
+          "variants": [
+            { "props": { "locale": "de" }, "preview": "DeviceSettingsGermanPreview" }
+          ]
         }
       ]
     },

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt
@@ -193,3 +193,21 @@ fun CachedDeviceBodyPreview() = cachedDevicePreview(dark = false)
 )
 @Composable
 fun CachedDeviceBodyDarkPreview() = cachedDevicePreview(dark = true)
+
+/**
+ * German (`de`) locale variant of [CachedDeviceBodyPreview] — the `catalog.spec.json`
+ * `Device/Cached` `props:{locale:"de"}` variant. `DeviceBody`'s section headers (Channels /
+ * Contacts / Rooms → Kanäle / Kontakte / Räume), filter chips, and empty/warning copy come from
+ * `stringResource(...)`, so this renders them in German via a `localeTag` override — which requires
+ * the desktop render-engine locale fix (compose-preview plugin ≥ 0.17.1). Contact/channel names
+ * stay literal.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "de",
+  name = "Cached device — German",
+)
+@Composable
+fun CachedDeviceBodyGermanPreview() = cachedDevicePreview(dark = false)

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt
@@ -42,3 +42,20 @@ fun DeviceSettingsPreview() = settingsPreview(dark = false)
 )
 @Composable
 fun DeviceSettingsDarkPreview() = settingsPreview(dark = true)
+
+/**
+ * German (`de`) locale variant of [DeviceSettingsPreview] — the `catalog.spec.json`
+ * `Settings/Ready` `props:{locale:"de"}` variant. Renders the same screen with a `localeTag`
+ * override so `DeviceSettingsBody`'s `stringResource(...)` chrome resolves German copy; requires
+ * the desktop render-engine locale fix (compose-preview plugin ≥ 0.17.1). Sender/device data stays
+ * literal.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "de",
+  name = "Device settings — German",
+)
+@Composable
+fun DeviceSettingsGermanPreview() = settingsPreview(dark = false)


### PR DESCRIPTION
First cut of the design-catalog **locale axis**, now that the desktop render-engine locale fix shipped in compose-preview plugin 0.17.1 (on `main` since #249).

## What

`@Preview(locale = "de")` variants of two CMP-desktop screens, wired into `catalog.spec.json` as `props:{locale:"de"}` variants so the generator's `foldVariants` merges each into its base sticker as a **locale toggle** (collision-free `…__locale-de.png` paths — no generator change needed):

- `Settings/Ready` → `DeviceSettingsGermanPreview`
- `Device/Cached` → `CachedDeviceBodyGermanPreview`

Both screens' chrome resolves from CMP `stringResource(...)`, so the variant renders real German — e.g. DeviceBody's section headers **Channels/Contacts/Rooms → Kanäle/Kontakte/Räume**, the filter chips, and the empty/warning copy. Contact/channel/device names stay literal.

## Why it works now

Before 0.17.1, `@Preview(locale=…)` on the CMP-desktop render path only flipped layout direction and left `stringResource(...)` resolving English (CMP resolves its locale from the JVM default `Locale`, which the renderer wasn't setting). [compose-ai-tools#2597](https://github.com/yschimke/compose-ai-tools/pull/2597) fixed that; #249 pinned 0.17.1 here.

## Visual evidence

The exact mechanism these variants rely on is proven end-to-end in [compose-ai-tools#2597](https://github.com/yschimke/compose-ai-tools/pull/2597): the same `stringResource` screen rendered en vs `locale="de"` produced real German ("Inbox" → "Posteingang", …).

For **these** meshcore screens: my sandbox can't run Skiko locally (the published plugin's Skiko binary hits a glibc-ABI mismatch against this Nix container — a local-only limitation), so the German renders are produced by the **"Render previews" CI job** on this PR (standard-glibc runners), and folded into the published catalog by the post-merge `design-artifacts` regen. I verified locally what I can: `catalog.spec.json` is valid, `composePreviewCompile` passes, ktfmt is clean.

## Follow-ups

- After merge, dispatch the `design-artifacts` regen so `design-artifacts/meshcore-mobile` gains the locale toggle.
- Extend the axis to the Chat screens and more locales; add CJK/Arabic once the render theme ships subset fallback fonts (they render tofu until then).

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_015wUT6sKvPKBCLXh5TwBZRX)_