### PR TITLE
feat(i18n): localize the cached-data warning banner

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/CachedDeviceScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/CachedDeviceScreen.kt
@@ -5,9 +5,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import ee.schimke.meshcore.app.di.LocalAppGraph
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.warning_cached_data
 import ee.schimke.meshcore.data.repository.toBattery
 import ee.schimke.meshcore.data.repository.toRadio
 import ee.schimke.meshcore.data.repository.toSelfInfo
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Read-only device screen that shows cached data from Room for a saved
@@ -37,6 +40,8 @@ fun CachedDeviceScreen(
         channels = channels,
         onDisconnect = onBack,
         onOpenThemePicker = onOpenThemePicker,
-        warnings = if (state != null) listOf("Cached data — connect to refresh") else emptyList(),
+        warnings =
+            if (state != null) listOf(stringResource(Res.string.warning_cached_data))
+            else emptyList(),
     )
 }

--- a/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ar/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">اتصل مرة واحدة من علامة تبويب BLE أو USB أو TCP وسيظهر هنا.</string>
   <string name="saved_connected">متصل</string>
   <string name="saved_contacts_count">%1$d جهة اتصال</string>
+  <string name="warning_cached_data">بيانات مخزّنة مؤقتًا — اتصل للتحديث</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-de/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Verbinde dich einmal über den Tab BLE, USB oder TCP, dann erscheint es hier.</string>
   <string name="saved_connected">Verbunden</string>
   <string name="saved_contacts_count">%1$d Kontakte</string>
+  <string name="warning_cached_data">Zwischengespeicherte Daten — zum Aktualisieren verbinden</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-es/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Conéctate una vez desde la pestaña BLE, USB o TCP y aparecerá aquí.</string>
   <string name="saved_connected">Conectado</string>
   <string name="saved_contacts_count">%1$d contactos</string>
+  <string name="warning_cached_data">Datos en caché — conéctate para actualizar</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-fr/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Connectez-vous une fois depuis l’onglet BLE, USB ou TCP et il apparaîtra ici.</string>
   <string name="saved_connected">Connecté</string>
   <string name="saved_contacts_count">%1$d contacts</string>
+  <string name="warning_cached_data">Données en cache — connectez-vous pour actualiser</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-hi/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">BLE, USB या TCP टैब से एक बार कनेक्ट करें और यह यहाँ दिखाई देगा।</string>
   <string name="saved_connected">कनेक्टेड</string>
   <string name="saved_contacts_count">%1$d संपर्क</string>
+  <string name="warning_cached_data">कैश किया गया डेटा — रीफ़्रेश करने के लिए कनेक्ट करें</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-id/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Hubungkan sekali dari tab BLE, USB, atau TCP dan akan muncul di sini.</string>
   <string name="saved_connected">Terhubung</string>
   <string name="saved_contacts_count">%1$d kontak</string>
+  <string name="warning_cached_data">Data dalam cache — sambungkan untuk menyegarkan</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-it/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Connettiti una volta dalla scheda BLE, USB o TCP e apparirà qui.</string>
   <string name="saved_connected">Connesso</string>
   <string name="saved_contacts_count">%1$d contatti</string>
+  <string name="warning_cached_data">Dati in cache — connettiti per aggiornare</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ja/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">BLE、USB、TCP のいずれかのタブから一度接続すると、ここに表示されます。</string>
   <string name="saved_connected">接続済み</string>
   <string name="saved_contacts_count">連絡先 %1$d 件</string>
+  <string name="warning_cached_data">キャッシュされたデータ — 更新するには接続してください</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ko/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">BLE, USB 또는 TCP 탭에서 한 번 연결하면 여기에 표시됩니다.</string>
   <string name="saved_connected">연결됨</string>
   <string name="saved_contacts_count">연락처 %1$d개</string>
+  <string name="warning_cached_data">캐시된 데이터 — 새로 고치려면 연결하세요</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-nl/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Maak één keer verbinding via het tabblad BLE, USB of TCP en het verschijnt hier.</string>
   <string name="saved_connected">Verbonden</string>
   <string name="saved_contacts_count">%1$d contacten</string>
+  <string name="warning_cached_data">Gegevens in cache — maak verbinding om te vernieuwen</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pl/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Połącz się raz z karty BLE, USB lub TCP, a pojawi się tutaj.</string>
   <string name="saved_connected">Połączono</string>
   <string name="saved_contacts_count">Kontakty: %1$d</string>
+  <string name="warning_cached_data">Dane z pamięci podręcznej — połącz, aby odświeżyć</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Conecte-se uma vez pela aba BLE, USB ou TCP e ele aparecerá aqui.</string>
   <string name="saved_connected">Conectado</string>
   <string name="saved_contacts_count">%1$d contatos</string>
+  <string name="warning_cached_data">Dados em cache — conecte-se para atualizar</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-ru/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">Подключитесь один раз на вкладке BLE, USB или TCP, и оно появится здесь.</string>
   <string name="saved_connected">Подключено</string>
   <string name="saved_contacts_count">Контактов: %1$d</string>
+  <string name="warning_cached_data">Кэшированные данные — подключитесь для обновления</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-th/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">เชื่อมต่อครั้งหนึ่งจากแท็บ BLE, USB หรือ TCP แล้วรายการจะปรากฏที่นี่</string>
   <string name="saved_connected">เชื่อมต่อแล้ว</string>
   <string name="saved_contacts_count">%1$d รายชื่อ</string>
+  <string name="warning_cached_data">ข้อมูลแคช — เชื่อมต่อเพื่อรีเฟรช</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-tr/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">BLE, USB veya TCP sekmesinden bir kez bağlanın; burada görünecektir.</string>
   <string name="saved_connected">Bağlı</string>
   <string name="saved_contacts_count">%1$d kişi</string>
+  <string name="warning_cached_data">Önbelleğe alınan veriler — yenilemek için bağlanın</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">从 BLE、USB 或 TCP 标签页连接一次，它就会显示在这里。</string>
   <string name="saved_connected">已连接</string>
   <string name="saved_contacts_count">%1$d 个联系人</string>
+  <string name="warning_cached_data">缓存数据 — 连接以刷新</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -95,4 +95,5 @@
   <string name="saved_empty_hint">從 BLE、USB 或 TCP 分頁連線一次，它就會顯示在這裡。</string>
   <string name="saved_connected">已連線</string>
   <string name="saved_contacts_count">%1$d 個聯絡人</string>
+  <string name="warning_cached_data">快取資料 — 連線以重新整理</string>
 </resources>

--- a/meshcore-components/src/commonMain/composeResources/values/strings.xml
+++ b/meshcore-components/src/commonMain/composeResources/values/strings.xml
@@ -101,4 +101,5 @@
   <string name="saved_empty_hint">Connect once from the BLE, USB or TCP tab and it will appear here.</string>
   <string name="saved_connected">Connected</string>
   <string name="saved_contacts_count">%1$d contacts</string>
+  <string name="warning_cached_data">Cached data — connect to refresh</string>
 </resources>

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt
@@ -3,6 +3,8 @@ package ee.schimke.meshcore.components.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.meshcore.components.generated.resources.Res
+import ee.schimke.meshcore.components.generated.resources.warning_cached_data
 import ee.schimke.meshcore.components.ui.theme.MeshcoreTheme
 import ee.schimke.meshcore.core.model.BatteryInfo
 import ee.schimke.meshcore.core.model.ChannelInfo
@@ -13,6 +15,7 @@ import ee.schimke.meshcore.core.model.RadioSettings
 import ee.schimke.meshcore.core.model.SelfInfo
 import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
+import org.jetbrains.compose.resources.stringResource
 
 // Design-parity preview subjects for the Device screen, on the CMP desktop
 // render path. The other Device previews (status views, extra DeviceBody states)
@@ -144,8 +147,6 @@ fun DeviceBodyDarkPreview() {
   }
 }
 
-private const val CACHED_WARNING = "Cached data — connect to refresh"
-
 @Composable
 private fun cachedDevicePreview(dark: Boolean) {
   val alice = previewContact("alice", -1, 0x11)
@@ -163,7 +164,7 @@ private fun cachedDevicePreview(dark: Boolean) {
       channels = listOf(ChannelInfo(0, "General", ByteString())),
       contactedKeys = setOf(alice.publicKey.toHex()),
       contactedChannelIndices = setOf(0),
-      warnings = listOf(CACHED_WARNING),
+      warnings = listOf(stringResource(Res.string.warning_cached_data)),
       onDisconnect = {},
     )
   }


### PR DESCRIPTION
Follow-up to #250 — closes the app-wide i18n gap Codex flagged there.

## Problem

The cached/offline warning banner ("Cached data — connect to refresh") was a **hard-coded English literal** in both the real screen (`CachedDeviceScreen.kt`) and the preview fixture (`DeviceBodyPreviews.kt`), with no resource key. So it stayed English on-device in every locale, and it was the one English element in the `Device/Cached` German catalog toggle from #250.

## Fix

- Adds `warning_cached_data` to the meshcore-components string set — **base + all 17 shipped locales** (`ar de es fr hi id it ja ko nl pl pt-rBR ru th tr zh-rCN zh-rTW`).
- Routes both `CachedDeviceScreen` (the on-device screen) and the `cachedDevicePreview` fixture through `stringResource(Res.string.warning_cached_data)` — the `:app` screen reuses the components' generated `Res` (per-key import, matching the established pattern).

Net effect: the real cached screen is now localized on-device, and the catalog's `Device/Cached` German toggle renders a **fully** German screen (banner included). The English base render is unchanged (same text).

## Verification

`catalog.spec.json`/XML valid, `:meshcore-components:composePreviewCompile` and `:app:compileDebugKotlin` pass, ktfmt clean. The German banner render comes from the "Render previews" CI job (this sandbox can't run the published plugin's Skiko — glibc mismatch); the diff bot will show the `CachedDeviceBodyGermanPreview` warning now switching English → German.

Translations are UI-concise and follow the existing strings' conventions. German I'm confident on; the CJK/Thai/Hindi/Arabic ones use standard platform terminology but are worth a native skim if you have reviewers.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_015wUT6sKvPKBCLXh5TwBZRX)_