### PR TITLE
ci(render): stage bundled Noto subsets into fontconfig so the Skiko render shows CJK

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -39,6 +39,18 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+      # The desktop/Skiko render resolves a glyph a preview's FontFamily doesn't
+      # cover (CJK, here) through the system font path rather than continuing down
+      # the FontFamily list, so stage the app's own committed Noto subsets where
+      # fontconfig will find them before the render. These are the CJK/Arabic/…
+      # subsets the app bundles (meshcore-components/.../fonts/noto) — no generic
+      # Noto, so the Latin default is untouched. (Within-FontFamily fallback does
+      # work for Arabic etc., but not the CJK faces on this Skiko build; #253.)
+      - name: Stage bundled fallback fonts for the Skiko render
+        run: |
+          mkdir -p "$HOME/.local/share/fonts"
+          cp meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf "$HOME/.local/share/fonts/"
+          fc-cache -f "$HOME/.local/share/fonts" >/dev/null
       - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.16.58
         with:
           # Pin the render CLI to the Gradle plugin version (single source of
@@ -71,6 +83,13 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+      # See the apply job: make the app's bundled Noto subsets visible to
+      # fontconfig so the Skiko a11y render resolves CJK too.
+      - name: Stage bundled fallback fonts for the Skiko render
+        run: |
+          mkdir -p "$HOME/.local/share/fonts"
+          cp meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf "$HOME/.local/share/fonts/"
+          fc-cache -f "$HOME/.local/share/fonts" >/dev/null
       - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.16.58
         with:
           cli-version: catalog

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -48,6 +48,9 @@ jobs:
       # work for Arabic etc., but not the CJK faces on this Skiko build; #253.)
       - name: Stage bundled fallback fonts for the Skiko render
         run: |
+          # fontconfig ships on ubuntu-latest, but guard so a leaner image can't
+          # fail this step with `fc-cache: command not found` before the render.
+          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y --no-install-recommends fontconfig; }
           mkdir -p "$HOME/.local/share/fonts"
           cp meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf "$HOME/.local/share/fonts/"
           fc-cache -f "$HOME/.local/share/fonts" >/dev/null
@@ -87,6 +90,9 @@ jobs:
       # fontconfig so the Skiko a11y render resolves CJK too.
       - name: Stage bundled fallback fonts for the Skiko render
         run: |
+          # fontconfig ships on ubuntu-latest, but guard so a leaner image can't
+          # fail this step with `fc-cache: command not found` before the render.
+          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y --no-install-recommends fontconfig; }
           mkdir -p "$HOME/.local/share/fonts"
           cp meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf "$HOME/.local/share/fonts/"
           fc-cache -f "$HOME/.local/share/fonts" >/dev/null

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -85,6 +85,10 @@ jobs:
       # stage persists for the whole job.
       - name: Stage bundled fallback fonts for the Skiko renders
         run: |
+          # fontconfig is installed later (Install desktop (Skiko) render deps),
+          # but this stage runs first, so ensure fc-cache exists here. It ships on
+          # ubuntu-latest; the guard just covers a leaner image.
+          command -v fc-cache >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y --no-install-recommends fontconfig; }
           mkdir -p "$HOME/.local/share/fonts"
           cp meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf "$HOME/.local/share/fonts/"
           fc-cache -f "$HOME/.local/share/fonts" >/dev/null

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -76,6 +76,19 @@ jobs:
         working-directory: compose-ai-tools/scripts/design-artifacts
         run: npm ci
 
+      # The desktop/Skiko renders below (the :meshcore-components pack and the
+      # compose-m3 re-theme) resolve a glyph a preview's FontFamily doesn't cover
+      # (CJK) through the system font path rather than continuing down the
+      # FontFamily list, so stage the app's own committed Noto subsets where
+      # fontconfig will find them before any render. CJK/Arabic/… subsets the app
+      # bundles — no generic Noto, so the Latin default is untouched. A one-time
+      # stage persists for the whole job.
+      - name: Stage bundled fallback fonts for the Skiko renders
+        run: |
+          mkdir -p "$HOME/.local/share/fonts"
+          cp meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf "$HOME/.local/share/fonts/"
+          fc-cache -f "$HOME/.local/share/fonts" >/dev/null
+
       # Render the catalog module into a portable bundle with semantics (a11y
       # greenlines + layout tree → tokens/wireframes in the exported catalog).
       - name: Render catalog bundle (:app, Android/Robolectric)


### PR DESCRIPTION
Fast-follow to #254.

## Why

#254 added the Noto fallback and the design-parity render confirmed it works — **for Arabic** (glyphs, shaping, RTL all correct). But **CJK still rendered as tofu** on the desktop/Skiko render, and repeated experiments proved it isn't the fonts:

- ✅ cmap coverage, ✅ real glyph outlines, ✅ correct family name + weight (`updateFontNames`), ✅ OS/2 Unicode ranges, ✅ CJK-first ordering, ✅ confirmed-fresh render (a `.kt` reorder that recompiles, so it can't be cache-served).

Every one of those still tofu'd Japanese while Arabic worked. Conclusion: **on this Skiko build, an uncovered glyph is resolved through the system font path, not by continuing down the `FontFamily` list** — and that within-family continuation happens to work for Arabic but not the CJK faces. (This is the same reason compose-ai-tools' own catalog installs system CJK fonts for its desktop render.)

## Fix

Stage the app's **own committed Noto subsets** (`meshcore-components/src/desktopMain/resources/fonts/noto/*.ttf`) into `~/.local/share/fonts` + `fc-cache` before each Skiko render, so fontconfig — and therefore Skia's system fallback — can find them:

- `compose-preview.yml` — both render jobs (`apply` + `a11y`), before the apply action.
- `design-artifacts.yml` — once before the renders (covers the `:meshcore-components` pack and the compose-m3 re-theme).

These are **CJK/Arabic/… subsets only — no generic Noto**, so the generic Latin default is untouched (unlike the closed #252). Sourced from the repo, so they're the same fonts the app bundles. The in-app `FontFamily` fallback from #254 stays — it fixes the shipped Android app; this just makes the desktop **parity render** authoritative for CJK too.

## Verification

The `ja`/`ar` preview renders on this PR are the proof: Japanese should now show real Kana/Han instead of tofu (Arabic already did). I'll confirm from the preview-diff render and post the result.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015wUT6sKvPKBCLXh5TwBZRX)_