### PR TITLE
ci(design-artifacts): publish meshcore-mobile liveBundle for server-side re-render

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -117,8 +117,23 @@ jobs:
             -o "$GITHUB_WORKSPACE/meshcore-components-bundle.png" --timeout 600
 
       # Join both renders to catalog.spec.json and write the importable bundle.
-      # `source: {repo, ref, module}` lets a trusted, toolchain-equipped box
-      # live-rerender; it's inert on the desktop-only public server.
+      #
+      # `--publish-live-bundle` carries the executable `:app` (Android/Robolectric)
+      # bundle onto the branch under `bundle/` and records `liveBundle: {path, file}`
+      # in catalog.json — the same treatment compose-ai-tools gives its Android
+      # `wear-m3` / `confetti` catalogs. The public preview server (preview.coo.ee)
+      # runs the prebuilt image, which bakes the Robolectric daemon + a minimal
+      # Android SDK, so it fetches this bundle and re-renders the `:app` previews
+      # (BlePermissionPanel, the Scanner tabs, …) live + per-variant instead of
+      # replaying baked PNGs. `bundle pack` (CLI ≥ 0.16.50) carries the app's
+      # compiled resource table so a `stringResource(R.string.…)` render resolves;
+      # a missing resource degrades to the placeholder marker rather than crashing.
+      #
+      # `source: {repo, ref, module}` stays as a fallback for a trusted,
+      # toolchain-equipped box that rebuilds from source — but it's inert on
+      # preview.coo.ee (cross-repo `source.repo` != server repo, and the public box
+      # has no meshcore checkout), so the carried liveBundle is what actually lights
+      # up the live lane there.
       - name: Generate importable catalog
         run: |
           set -euo pipefail
@@ -128,10 +143,37 @@ jobs:
             --extra-renders "$GITHUB_WORKSPACE/meshcore-components-bundle.png" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)" \
+            --publish-live-bundle \
             --source-repo "${GITHUB_REPOSITORY}" \
             --source-ref main \
             --source-module :app \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.allow_incomplete) && '--allow-incomplete' || '' }}
+
+      # Split the rendered sheet into one addressable, re-renderable bundle per
+      # preview under `bundle/previews/<id>.png` — the unit the serve host's
+      # per-preview live lane (ServePerPreviewLiveHost) fetches on demand so a
+      # `?knob.<key>=…` edit re-renders that one preview instead of routing through
+      # the monolithic catalog daemon (mirrors compose-ai-tools' Android live rows).
+      #
+      # FULL split of the `:app` tier: split the EXTERNALISED bundle the generate
+      # step wrote under out/bundle/ (fonts lifted to bundle/res/<sha>), not the raw
+      # sheet — so each per-preview bundle inherits the slimmed app.jar + shared-pool
+      # font references and the branch doesn't balloon by the preview count.
+      #
+      # The `:meshcore-components` supplement (the Chat / Settings / Cached screens,
+      # CMP desktop render) is split `--view-only`: those functions live only in the
+      # extra bundle, not the carried `:app` liveBundle, so they have no per-preview
+      # re-render classpath on this branch and stay baked-only (like compose-m3's
+      # Android supplement).
+      - name: Split into per-preview bundles
+        run: |
+          set -euo pipefail
+          compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/meshcore-mobile-bundle.png" \
+            -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          if [ -f "$GITHUB_WORKSPACE/meshcore-components-bundle.png" ]; then
+            compose-preview bundle split "$GITHUB_WORKSPACE/meshcore-components-bundle.png" --view-only \
+              -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          fi
 
       # ─────────────────────────────────────────────────────────────────────────
       # Reuse compose-m3, re-themed under MeshCore's palette, as a "Material 3" tab


### PR DESCRIPTION
## Summary

The public preview server (preview.coo.ee) serves `/meshcore-mobile/` previews as **baked-PNG snapshots only** — every preview reports `"modes": ["snapshot"]` with no live/override lane. For example, `blepermissionpanel-denied__ideal__default__light__compact` has no "live server" toggle.

Root cause: the `design-artifacts/meshcore-mobile` delivery branch carries **no `liveBundle`** in `catalog.json`. In `ServeCatalogStore.load` (compose-ai-tools), the daemon-backed session is only stood up when the catalog declares a `liveBundle` (preferred) or a buildable `source`. This catalog declares neither that the public box can use:
- No `liveBundle` → the server registers the static baked-PNG host and never constructs a live host, so `canRenderOverridesFor` is never reachable.
- The `source:` route is **inert on preview.coo.ee**: its `source.repo` (`yschimke/meshcore-mobile`) ≠ the server's own repo, and the public box has no meshcore checkout to build from.

The individual images already carry a `previewId` (the catalog-id→daemon-id bridge), so the only missing piece is publishing the executable bundle itself.

## Changes

`.github/workflows/design-artifacts.yml`, mirroring how compose-ai-tools publishes its Android `wear-m3` / `confetti` catalogs (the `androidLiveBundle` treatment):

- Add **`--publish-live-bundle`** to the *Generate importable catalog* step. This carries the executable `:app` (Robolectric) bundle onto the branch under `bundle/`, records `liveBundle: {path, file}` in `catalog.json`, and externalizes the fonts to `bundle/res/<sha>` so the bundle stays small.
- Add a **Split into per-preview bundles** step. FULL-splits the externalised `:app` bundle into `bundle/previews/<id>.png` (the per-preview live lane that `ServePerPreviewLiveHost` fetches so a `?knob.<key>=…` edit re-renders that one preview), and `--view-only`-splits the `:meshcore-components` CMP-desktop supplement, which has no runnable classpath on this branch and stays baked-only.

## Effect

preview.coo.ee runs the prebuilt image, which bakes the Robolectric daemon + a minimal Android SDK. Once the branch carries the `liveBundle`, the server takes the `buildTrustedBundle` path instead of `bakedFallback()`; combined with the existing `previewId` mapping, the `:app` previews (BlePermissionPanel, the Scanner tabs, …) gain a live, per-variant re-render lane instead of a static snapshot.

## Test plan

- [x] `design-artifacts.yml` parses as valid YAML.
- [ ] Merge, then dispatch the **Design Artifacts** workflow (`workflow_dispatch`, ref `main`) to regenerate `design-artifacts/meshcore-mobile`.
- [ ] Confirm the regenerated `catalog.json` contains a top-level `liveBundle`, that `bundle/meshcore-mobile-bundle.png` + `bundle/res/` + `bundle/previews/` are present, and that the public server (which auto-refreshes the catalog branch ~every 600s) exposes the live toggle for `blepermissionpanel-denied__ideal__default__light__compact`.

Note: the `:app` live render depends on `bundle pack` carrying the app's compiled resource table (CLI ≥ 0.16.50; this repo pins 0.17.1, so it's present). If a resource is missing at render time, the placeholder-fallback shows a marker rather than crashing — degraded, not broken. Worth watching on the first real run.

This is CI/build plumbing with no change to rendered pixels, so no visual before/after is included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuGu6aeVAU5rKt5igstHaN)_