### PR TITLE
feat(design-parity): resolve five screen references against Figma

### DIFF
--- a/.github/workflows/design-parity.yml
+++ b/.github/workflows/design-parity.yml
@@ -94,10 +94,13 @@ jobs:
             "$HOME/.local/share/fonts/"
           fc-cache -f >/dev/null
 
+      # Only the `claude-design` entries have an HTML source to rasterize. The
+      # `figma` entries resolve through @design-parity/adapter-figma, which
+      # renders the node itself over the REST API — skip them here.
       - name: Render reference images from HTML
         run: |
           set -euo pipefail
-          for ref in $(jq -r '.components[].ref' design-map.json); do
+          for ref in $(jq -r '.components[] | select(.source == "claude-design") | .ref' design-map.json); do
             png="${ref%.html}.png"
             google-chrome-stable --headless=new --no-sandbox --disable-gpu \
               --hide-scrollbars --force-device-scale-factor=2.625 \
@@ -109,6 +112,18 @@ jobs:
           node-version: 24.18.0
 
       - name: Run design-parity
+        env:
+          # Needed by @design-parity/adapter-figma for the `figma:` entries in
+          # design-map.json: it fetches node structure and renders the reference
+          # image over the Figma REST API. A read-only personal access token with
+          # `file_content:read` is sufficient — that scope covers both
+          # /v1/files/:key/nodes and /v1/images.
+          #
+          # The adapter also probes /v1/files/:key/variables/local, which is
+          # Enterprise-only; on this Pro team it 403s and the adapter degrades to
+          # structure-only tokens. Harmless — spec tokens come from each entry's
+          # `tokensFile` (design/meshcore.tokens.json), not from Figma.
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
         run: |
           set -euo pipefail
           components="$(jq -r '[.components[].code] | join(",")' design-map.json)"

--- a/design-map.json
+++ b/design-map.json
@@ -17,8 +17,8 @@
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ContactChatPreview",
-      "source": "claude-design",
-      "ref": "design/ContactChat.light.html",
+      "source": "figma",
+      "ref": "figma:gYzowY4cQ7rNr2gYoco1M6/73:5",
       "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ContactChatPreview_Contact chat",
       "tokensFile": "design/meshcore.tokens.json"
     },
@@ -31,8 +31,8 @@
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#ChannelChatPreview",
-      "source": "claude-design",
-      "ref": "design/ChannelChat.light.html",
+      "source": "figma",
+      "ref": "figma:gYzowY4cQ7rNr2gYoco1M6/74:5",
       "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.ChannelChatPreview_Channel chat",
       "tokensFile": "design/meshcore.tokens.json"
     },
@@ -45,8 +45,8 @@
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt#CommandsPreview",
-      "source": "claude-design",
-      "ref": "design/Commands.light.html",
+      "source": "figma",
+      "ref": "figma:gYzowY4cQ7rNr2gYoco1M6/75:60",
       "previewId": "ee.schimke.meshcore.components.ui.ChatBodyPreviewsKt.CommandsPreview_Commands",
       "tokensFile": "design/meshcore.tokens.json"
     },
@@ -59,8 +59,8 @@
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceBodyPreviews.kt#CachedDeviceBodyPreview",
-      "source": "claude-design",
-      "ref": "design/CachedDevice.light.html",
+      "source": "figma",
+      "ref": "figma:gYzowY4cQ7rNr2gYoco1M6/82:4",
       "previewId": "ee.schimke.meshcore.components.ui.DeviceBodyPreviewsKt.CachedDeviceBodyPreview_Cached device",
       "tokensFile": "design/meshcore.tokens.json"
     },
@@ -73,8 +73,8 @@
     },
     {
       "code": "meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt#DeviceSettingsPreview",
-      "source": "claude-design",
-      "ref": "design/DeviceSettings.light.html",
+      "source": "figma",
+      "ref": "figma:gYzowY4cQ7rNr2gYoco1M6/76:104",
       "previewId": "ee.schimke.meshcore.components.ui.DeviceSettingsBodyPreviewsKt.DeviceSettingsPreview_Device settings",
       "tokensFile": "design/meshcore.tokens.json"
     },

--- a/docs/design-parity.md
+++ b/docs/design-parity.md
@@ -22,8 +22,139 @@ All render on the CMP desktop backend from `:meshcore-components` `commonMain`.
 | `design/ContactChat.{light,dark}.html`, `design/ChannelChat.{light,dark}.html`, `design/Commands.{light,dark}.html` | The chat screen references (`ContactChatPreview` etc.), authored from the MeshCore M3 scheme; `design/gen_chat_refs.py` is the re-runnable generator that emits them. |
 | `design/DeviceSettings.{light,dark}.html` | The Device Settings references (`DeviceSettingsPreview` etc.) — the discovered buzzer-toggle state; `design/gen_settings_refs.py` is the generator. |
 | `design/meshcore.tokens.json` | The MeshCore design-system tokens as a committed [W3C DTCG](https://tr.designtokens.org/) document — the artifact a Claude Code [`/design-sync`](#synced-design-system-tokens) run materialises from the Claude Design system (M3 colour roles + shape radii + spacing). Mirrors `meshcore-components/.../theme/MeshcoreTokens.kt`. |
-| `design-map.json` | Correspondence: each preview-function code handle ↔ its reference, plus the `previewId` that reconciles the compose-preview render id with the handle, plus the `tokensFile` that points every component at the synced `design/meshcore.tokens.json` spec tokens. |
+| `design-map.json` | Correspondence: each preview-function code handle ↔ its reference — either a `figma:` node in [the design file](#the-figma-file-design-led-references) or a committed HTML export — plus the `previewId` that reconciles the compose-preview render id with the handle, plus the `tokensFile` that points every component at the synced `design/meshcore.tokens.json` spec tokens. |
 | `.design-parity.json` | Parity direction. **`code-led`** (advisory) for now — flip to `design-led` once thresholds are calibrated. |
+
+## The Figma file (design-led references)
+
+The **[MeshCore Mobile design file](https://www.figma.com/design/gYzowY4cQ7rNr2gYoco1M6)**
+(`fileKey` `gYzowY4cQ7rNr2gYoco1M6`) is the emerging primary reference. It is
+**seeded from the published editable figma-SVGs** on the
+[`design-artifacts/meshcore-mobile`](https://github.com/yschimke/meshcore-mobile/tree/design-artifacts/meshcore-mobile)
+branch (`figma/<slug>.svg` — the "ideal render" as native Figma vectors, not
+raster), then **refined by hand in Figma**. Code is judged against it; the
+committed HTML references stay as the lower-precedence fallback for the variants
+Figma doesn't cover yet.
+
+One page per screen, plus foundations:
+
+| Page | id | Contents |
+| --- | --- | --- |
+| Themes | `47:2` | The four theme foundation sheets + the **"MeshCore tokens"** variable collection (`light`/`dark` modes, 34 variables) generated from `design/meshcore-theme-colors.json`. This is for **designers working in Figma** — something to bind fills and radii to while refining the screens. It is *not* a CI input; see the note on variables below. |
+| Components | `47:3` | The component sticker sheet, grouped into sections by family (buttons, selection controls, chips, cards, text fields, contact rows, scanner panels …). |
+| Device | `47:4` | Seven state sections: loading, status connecting, status failed, no contacts, low battery, many contacts, and **cached (offline)**. |
+| Contact chat | `47:6` | `chat-contact`. |
+| Channel chat | `47:7` | `chat-channel`. |
+| Commands | `47:8` | `chat-commands`. |
+| Device settings | `47:9` | `settings-ready`. |
+
+Cached device is **not** a separate page: `CachedDeviceBodyPreview` renders the
+same stateless `DeviceBody` with the "Cached data" warning banner, and
+`catalog.spec.json` already groups `Device/Cached` inside the Device group — so it
+is the seventh state section on the Device page.
+
+### Page layout
+
+Each page is a vertical stack of **sections**, one per major state, spaced 3 200 px
+apart. Inside a section sits a wrapping auto-layout of captioned **variant cells**,
+one per (theme, size, locale) combination that has a render:
+
+```
+SECTION "Low battery"
+└─ FRAME "variants"  (HORIZONTAL, layoutWrap WRAP)
+   ├─ FRAME "light · compact"   → the editable vector (figma/<slug>.svg)
+   └─ FRAME "dark · compact"    → a PNG (images/<slug>/…dark__compact.png)
+```
+
+### Variant coverage (and why it's uneven)
+
+Cells are vectors where a vector exists and PNGs otherwise, because
+compose-ai-tools' `figma-svg-emit.mjs` deliberately emits **one figma-SVG per
+component function, preferring the light variant** — "a single deterministic
+sticker per component". Everything else on the artifacts branch is raster:
+
+| Axis | Coverage |
+| --- | --- |
+| State | Full — every state has its own section. |
+| Theme | `light` vector + `dark` PNG for the six Device states. No dark render at all for cached device, the chat screens or settings. |
+| Locale | `device-cached` has de/ja/ar, `settings-ready` has de. Nothing else — each locale variant needs its own hand-written `@Preview`. |
+| Size | Only `compact` (412 dp). `catalog.spec.json` declares a single breakpoint. |
+
+Filling the matrix out (large phone, tablet landscape, dark everywhere, the full
+locale set) needs three things that don't exist yet: a per-variant figma-SVG export
+upstream, extra `breakpoints` in `catalog.spec.json`, and locale `@Preview`
+functions for the remaining screens.
+
+Entries in `design-map.json` that resolve against it carry `"source": "figma"`
+and a `"ref": "figma:gYzowY4cQ7rNr2gYoco1M6/<nodeId>"`;
+[`@design-parity/adapter-figma`](https://github.com/yschimke/design-parity/tree/main/packages/adapters/figma)
+fetches the node structure and renders the reference image over the Figma REST
+API. CI needs a **`FIGMA_TOKEN`** repo secret — a read-only PAT with
+**`file_content:read`** ("read the contents of and render images from files",
+which covers both `GET /v1/files/:key/nodes` and `GET /v1/images`). Without it
+the `figma` entries fail to resolve while the `claude-design` ones keep working.
+
+**Variables are not readable from CI.** The adapter would also like
+`GET /v1/files/:key/variables/local`, but Figma's Variables REST API is
+**Enterprise-only** — on a Pro plan the `file_variables:read` scope isn't even
+offered when minting a token, and the adapter
+[degrades gracefully to structure-only tokens](https://github.com/yschimke/design-parity/tree/main/packages/adapters/figma#what-it-does).
+This costs the parity check nothing: every `design-map.json` entry already
+carries `"tokensFile": "design/meshcore.tokens.json"`, so **spec tokens come from
+the committed DTCG document, not from Figma**. Moving a reference to Figma
+changes where the *image* comes from; the *tokens* stay on disk.
+
+Note the PAT is scoped to the whole **account**, not to this file — it inherits
+access to every file the owner can see. Keep it read-only and give it an expiry;
+the current token expires **2026-10-20**, tracked at
+[#259](https://github.com/yschimke/meshcore-mobile/issues/259). When it lapses,
+only the `figma` entries break while the `claude-design` ones keep rendering —
+a failure that reads as healthier than it is.
+
+### Seeding the file (local only)
+
+Seeding is a **local runbook**, not something the cloud agent can do: the
+`use_figma` plugin sandbox has no `fetch()` and no `figma.createImageAsync(url)`,
+so `figma.createNodeFromSvg` needs the SVG text embedded in the call — which
+means reading it from a checkout of the artifacts branch:
+
+```sh
+git fetch origin design-artifacts/meshcore-mobile
+git worktree add /tmp/mesh-figma-svgs origin/design-artifacts/meshcore-mobile
+```
+
+Three gotchas, all hit during the first seed:
+
+- **`use_figma` `code` is capped at 50 000 chars.** Every screen SVG fits; of the
+  components only `template-appscaffold` (64 KB) doesn't, and it is seeded as a
+  PNG via `upload_assets` instead.
+- **Long literals in `code` are silently truncated** well below that cap — one
+  13 022-char script arrived as 6 102 chars with no error and no exception, which
+  would have imported corrupt data while still looking successful. Guard every
+  call that carries a large literal: compute the string's length and an FNV-1a
+  hash locally, recompute both inside the script, and `throw` on mismatch.
+  `use_figma` is atomic, so a tripped guard writes nothing.
+- **Some SVGs reference raster sidecars** (`<slug>.figma-raster/NNN.png` — e.g.
+  the chat message-input field, the loading spinner). Relative `href`s don't
+  resolve inside `createNodeFromSvg`, so those areas import blank. Inlining them
+  as `data:` URIs works in principle but is exactly the truncation trap above.
+  Instead rewrite each `<image>` to a same-geometry placeholder `<rect>`, import,
+  then fill each rect via `upload_assets` with `nodeId` + `scaleMode: "FILL"`.
+
+### Known reference gaps
+
+The catalog carries the `:app` Device **state** variants, not the
+`:meshcore-components` parity subjects, and its figma-SVGs are **light only**. So
+five subjects have Figma nodes today (cached device, the three chat screens,
+device settings — all light); the seven others (`DeviceBodyPreview` and every
+`*DarkPreview`) still resolve to their HTML reference. Closing that gap means
+adding those previews to `catalog.spec.json` so the next `design-artifacts` run
+publishes figma-SVGs for them.
+
+The seeded renders also **include the synthetic OS status bar**, which the HTML
+references deliberately omit (see [Render path](#render-path)). Until the two
+agree, the `figma`-sourced entries carry that offset as visual diff — tolerable
+only because the direction is still `code-led` (advisory).
 
 The reference PNGs the manifests' `src` point to (`design/*.png`) are **generated
 from the HTML, not committed** (they would drift from it) — gitignored and


### PR DESCRIPTION
Stands up the [MeshCore Mobile Figma file](https://www.figma.com/design/gYzowY4cQ7rNr2gYoco1M6)
as a design-led reference source and points the five parity subjects that have a
Figma counterpart at it.

Refs #258.

## Figma file (seeded out-of-band, local session)

Seeded from the editable figma-SVGs on `design-artifacts/meshcore-mobile` — native
vectors, not raster. One page per screen; each major state is a bordered **section**
holding captioned **variant cells**:

| Page | Contents |
|---|---|
| Themes | 4 theme sheets + a "MeshCore tokens" variable collection (light/dark, 34 vars) |
| Components | 55 slugs in **12 clusters** (Buttons, Selection controls, Chips & badges, Cards, Progress, Text & text fields, Device summary, Contacts, BLE & connection panels, Saved devices, Templates, Scanner screens), wrapping at a fixed 4 000 px |
| Device | 7 state sections, incl. **cached (offline)** |
| Contact chat / Channel chat / Commands / Device settings | 1 section each |

`Cached device` is deliberately **not** its own page: `CachedDeviceBodyPreview`
renders the same stateless `DeviceBody` with the warning banner, and
`catalog.spec.json` already groups `Device/Cached` inside the Device group.

## What changed here

- **`design-map.json`** — `ContactChat`, `ChannelChat`, `Commands`, `CachedDevice`
  and `DeviceSettings` (light) now resolve via `"source": "figma"` +
  `"ref": "figma:<fileKey>/<nodeId>"`. The other seven entries keep their committed
  HTML references.
- **`design-parity.yml`** — the reference-render step now only rasterizes
  `claude-design` entries (a `figma:` ref is not a file path); `FIGMA_TOKEN` is
  passed to the run step.
- **`docs/design-parity.md`** — the file's structure and layout, variant-coverage
  gaps, and the three seeding gotchas.

## Deliberately not done

- **`.design-parity.json` stays `code-led`** (advisory). The seeded renders carry the
  synthetic OS status bar that the HTML references deliberately omit, so the five
  figma-sourced entries will show that offset as visual diff until the two agree.
- **Seven entries stay on HTML.** The catalog publishes the `:app` Device *state*
  variants, not the `:meshcore-components` parity subjects, and its figma-SVGs are
  light-only — so `DeviceBodyPreview` and every `*DarkPreview` has no Figma node yet.

## Variant coverage

Cells are vectors where a vector exists and PNGs otherwise, because
`figma-svg-emit.mjs` emits **one SVG per component function, preferring light**.

| Axis | Coverage |
|---|---|
| State | Full |
| Theme | light vector + dark PNG for the 6 Device states; no dark render at all elsewhere |
| Locale | `device-cached` de/ja/ar, `settings-ready` de. Nothing else |
| Size | `compact` (412 dp) only |

Filling this out needs a per-variant figma-SVG export upstream, extra `breakpoints`,
and locale `@Preview` functions — worth its own issue.

## Notes for reviewers

- `FIGMA_TOKEN` is set, scoped `file_content:read`, **expiring 2026-10-20** — rotation
  tracked in #259. Figma's Variables REST API is Enterprise-only, so the adapter
  degrades to structure-only tokens; harmless, since spec tokens come from each
  entry's `tokensFile` (`design/meshcore.tokens.json`).
- A PAT is scoped to the whole *account*, not one file — kept read-only, with an expiry.

## Test plan

- [x] `design-map.json` validates; 5 `figma` + 7 `claude-design` entries
- [x] workflow YAML parses; the HTML render loop selects only `claude-design` refs
- [x] all 5 referenced node ids verified in Figma — correct screen, correct page,
      rasters filled, no placeholders left
- [x] Components verified: 12 sections, 55 slugs, 0 strays, 0 unfilled rasters
- [ ] first `main` run of **Design parity artifacts** resolves the `figma:` entries
      (needs the secret in CI — cannot be verified from a branch)