### PR TITLE
refactor(catalog): drop the redundant standalone dark Scanner card

### DIFF
--- a/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/meshcore/app/ui/ScannerScreen.kt
@@ -549,23 +549,3 @@ fun ScannerTcpPreview() {
         )
     }
 }
-
-@Preview(
-    showBackground = true,
-    showSystemUi = true,
-    device = Devices.PIXEL_7,
-    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
-    name = "Scanner — Saved populated, dark",
-)
-@Composable
-fun ScannerBleDarkPreview() {
-    MeshcoreTheme(darkTheme = true) {
-        ScannerBody(
-            savedContent = { PreviewSavedPopulated() },
-            bleContent = { PreviewEmpty() },
-            usbContent = { PreviewEmpty() },
-            tcpContent = { PreviewEmpty() },
-            initialTab = 0,
-        )
-    }
-}

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -199,11 +199,6 @@
           "componentId": "Scanner/Tcp",
           "preview": "ScannerTcpPreview",
           "caption": "Scanner, TCP tab — the connect form."
-        },
-        {
-          "componentId": "Scanner/BleDark",
-          "preview": "ScannerBleDarkPreview",
-          "caption": "Scanner, Saved tab populated (dark theme)."
         }
       ]
     },


### PR DESCRIPTION
## Why

Follow-up to the light/dark screen pairing (#263, merged). While consolidating, `Scanner/BleDark` turned out to be a **duplicate**, not a missing-dark case: `ScannerSavedPopulatedPreview` already bakes both light and dark (a paired `@Preview(name="Light")` + `@Preview(name="Dark", uiMode=NIGHT_YES)` on one function), so it already publishes a Light/Dark swap card the preview server serves baked in either theme.

`ScannerBleDarkPreview` rendered the **exact same content** (`ScannerBody`, saved tab populated, `initialTab = 0`) forced dark — i.e. a copy of that card's dark sticker, published as a separate `Scanner/BleDark` card.

## What

- Remove the standalone `Scanner/BleDark` component from `catalog.spec.json`.
- Remove the now-dead `ScannerBleDarkPreview` `@Preview` function (only the spec referenced it).

The dark saved-populated view is served by `Scanner/SavedPopulated`'s own dark sticker — one card, both themes, instead of a light swap-card plus a redundant dark card.

## Test plan

- `validate-catalog-spec.mjs` → **0 errors, 0 warnings**; no dangling `ScannerBleDarkPreview` reference remains.
- ktfmt pre-commit clean.
- The published sheet loses the duplicate `Scanner/BleDark` card on the next `design-artifacts.yml` regen; `Scanner/SavedPopulated` is unchanged (still light+dark).

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_