### PR TITLE
feat(catalog): add Arabic RTL previews for the chat screens, ja/ar for settings

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -258,7 +258,8 @@
           "preview": "ContactChatPreview",
           "caption": "Contact chat — a 1:1 direct-message thread.",
           "variants": [
-            { "theme": "dark", "preview": "ContactChatDarkPreview" }
+            { "theme": "dark", "preview": "ContactChatDarkPreview" },
+            { "props": { "locale": "ar" }, "preview": "ContactChatArabicPreview" }
           ]
         },
         {
@@ -266,7 +267,8 @@
           "preview": "ChannelChatPreview",
           "caption": "Channel chat — a group broadcast channel.",
           "variants": [
-            { "theme": "dark", "preview": "ChannelChatDarkPreview" }
+            { "theme": "dark", "preview": "ChannelChatDarkPreview" },
+            { "props": { "locale": "ar" }, "preview": "ChannelChatArabicPreview" }
           ]
         },
         {
@@ -274,7 +276,8 @@
           "preview": "CommandsPreview",
           "caption": "Commands console — the device command/response log.",
           "variants": [
-            { "theme": "dark", "preview": "CommandsDarkPreview" }
+            { "theme": "dark", "preview": "CommandsDarkPreview" },
+            { "props": { "locale": "ar" }, "preview": "CommandsArabicPreview" }
           ]
         }
       ]
@@ -289,7 +292,9 @@
           "caption": "Device settings — discovered device, with the buzzer toggle.",
           "variants": [
             { "theme": "dark", "preview": "DeviceSettingsDarkPreview" },
-            { "props": { "locale": "de" }, "preview": "DeviceSettingsGermanPreview" }
+            { "props": { "locale": "de" }, "preview": "DeviceSettingsGermanPreview" },
+            { "props": { "locale": "ja" }, "preview": "DeviceSettingsJapanesePreview" },
+            { "props": { "locale": "ar" }, "preview": "DeviceSettingsArabicPreview" }
           ]
         }
       ]

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/ChatBodyPreviews.kt
@@ -186,6 +186,30 @@ fun ContactChatPreview() = chatPreview("alice", "Direct message", contactMessage
 fun ContactChatDarkPreview() = chatPreview("alice", "Direct message", contactMessages, dark = true)
 
 /**
+ * Arabic (`ar`) locale variant of [ContactChatPreview] — the `catalog.spec.json` `Chat/Contact`
+ * `props:{locale:"ar"}` variant.
+ *
+ * `ChatBody` draws only three `stringResource(...)` strings (the input placeholder and the send /
+ * back content descriptions), so a `de` or `ja` variant would render all but indistinguishable from
+ * English and earn its place in the catalog on nothing. **RTL is different**: it mirrors the entire
+ * layout regardless of how much localized copy a screen carries — message bubbles swap sides, the
+ * back arrow flips, and the input row's leading/trailing affordances exchange ends. That is real
+ * coverage, and it's why `ar` is the one locale worth carrying on every screen.
+ *
+ * Sender names and message bodies stay literal, so any mirroring visible here is layout, not copy.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "ar",
+  name = "Contact chat — Arabic",
+)
+@Composable
+fun ContactChatArabicPreview() =
+  chatPreview("alice", "Direct message", contactMessages, dark = false)
+
+/**
  * Design-parity subject: the group channel chat (light). Reference `design/ChannelChat.light.html`.
  */
 @Preview(
@@ -211,12 +235,51 @@ fun ChannelChatPreview() = chatPreview("General", "Channel 0", channelMessages, 
 fun ChannelChatDarkPreview() = chatPreview("General", "Channel 0", channelMessages, dark = true)
 
 /**
+ * Arabic (`ar`) locale variant of [ChannelChatPreview] — see [ContactChatArabicPreview] for why RTL
+ * is the locale worth carrying here. The channel variant additionally mirrors the subtitle row
+ * ("Channel 0") under the title.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "ar",
+  name = "Channel chat — Arabic",
+)
+@Composable
+fun ChannelChatArabicPreview() = chatPreview("General", "Channel 0", channelMessages, dark = false)
+
+/**
  * Design-parity subject: the device commands console (light). Reference
  * `design/Commands.light.html`.
  */
 @Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_7, name = "Commands")
 @Composable
 fun CommandsPreview() =
+  chatPreview(
+    title = "Commands",
+    subtitle = null,
+    messages = commandMessages,
+    dark = false,
+    inputPlaceholder = "Enter command…",
+    actions = { terminalAction() },
+  )
+
+/**
+ * Arabic (`ar`) locale variant of [CommandsPreview] — see [ContactChatArabicPreview] for why RTL is
+ * the locale worth carrying here. The commands console is the most interesting of the three under
+ * mirroring: its monospace command/response log and terminal action keep Latin content inside an
+ * otherwise mirrored frame, which is exactly where bidirectional layout tends to go wrong.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "ar",
+  name = "Commands — Arabic",
+)
+@Composable
+fun CommandsArabicPreview() =
   chatPreview(
     title = "Commands",
     subtitle = null,

--- a/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt
+++ b/meshcore-components/src/commonMain/kotlin/ee/schimke/meshcore/components/ui/DeviceSettingsBodyPreviews.kt
@@ -59,3 +59,38 @@ fun DeviceSettingsDarkPreview() = settingsPreview(dark = true)
 )
 @Composable
 fun DeviceSettingsGermanPreview() = settingsPreview(dark = false)
+
+/**
+ * Japanese (`ja`) locale variant of [DeviceSettingsPreview] — the screen title, the buzzer row's
+ * label and its mode summary come from `stringResource(...)`, so a `localeTag` override renders
+ * them in Japanese. MeshCore's branded faces (Orbitron / Space Grotesk) are Latin-only, so this
+ * exercises the bundled **Noto** CJK fallback appended to those families (see
+ * `MeshcoreFonts.desktop.kt`): the Kana/Han resolve within the app's own typography instead of
+ * rendering tofu. The `rtttl` buzzer mode stays literal.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "ja",
+  name = "Device settings — Japanese",
+)
+@Composable
+fun DeviceSettingsJapanesePreview() = settingsPreview(dark = false)
+
+/**
+ * Arabic (`ar`) locale variant of [DeviceSettingsPreview] — exercises the bundled **Noto Sans
+ * Arabic** fallback (glyph shaping) and right-to-left layout. RTL is the reason this variant earns
+ * its place on every screen rather than only the string-heavy ones: the whole layout mirrors, so it
+ * catches a hardcoded `Alignment.Start`/`padding(start = …)` or a back arrow that fails to flip,
+ * none of which depend on how much localized copy a screen carries.
+ */
+@Preview(
+  showBackground = true,
+  showSystemUi = true,
+  device = Devices.PIXEL_7,
+  locale = "ar",
+  name = "Device settings — Arabic",
+)
+@Composable
+fun DeviceSettingsArabicPreview() = settingsPreview(dark = false)


### PR DESCRIPTION
Workstream 3 of #261. Locale coverage was uneven — `Device/Cached` carried de/ja/ar,
`Settings/Ready` only de, and the three chat screens none at all.

## Chosen by what each locale actually exercises

The issue originally scoped this at "~30 previews" (en/ar/ja/de across every screen).
Measuring first cut it to five:

| Screen | `stringResource` calls | Added |
|---|---|---|
| `DeviceBody` | 31 | — (already de/ja/ar) |
| `DeviceSettingsBody` | 10 | **ja, ar** |
| `ChatBody` | 3 | **ar** only |

`ChatBody` draws just three localizable strings — the input placeholder and the send /
back content descriptions. A `de` or `ja` chat variant would render all but
indistinguishable from English and earn its place in the catalog on nothing.

**`ar` is different, and earns its place on every screen.** RTL mirrors the entire
layout regardless of how much localized copy a screen carries: message bubbles swap
sides, the back arrow flips, the input row's leading/trailing affordances exchange
ends. That catches a hardcoded `Alignment.Start`, a `padding(start = …)`, or an
unflipped chevron — none of which depend on string volume. On the commands console
it's the most interesting of the three: a monospace Latin command/response log inside
an otherwise mirrored frame is exactly where bidirectional layout tends to break.

## Changes

Five previews + their `catalog.spec.json` variants:

    Chat/Contact    + ar     ContactChatArabicPreview
    Chat/Channel    + ar     ChannelChatArabicPreview
    Chat/Commands   + ar     CommandsArabicPreview
    Settings/Ready  + ja     DeviceSettingsJapanesePreview
    Settings/Ready  + ar     DeviceSettingsArabicPreview

Coverage is now **dark + ar everywhere**, with de/ja on the two string-heavy screens.

The `ja` variant also exercises the bundled **Noto** CJK fallback appended to the
branded Latin-only faces (Orbitron / Space Grotesk, see `MeshcoreFonts.desktop.kt`) —
Kana/Han should resolve within the app's own typography rather than rendering tofu.
`ar` exercises **Noto Sans Arabic** glyph shaping.

## Test plan

- [x] `./gradlew :meshcore-components:compileKotlinDesktop` — BUILD SUCCESSFUL
- [x] `./gradlew :meshcore-components:ktfmtFormatKmpCommonMain`, and the ktfmt
      pre-commit hook passes
- [x] `catalog.spec.json` validated against compose-ai-tools' own `validateSpec` —
      **0 errors, 0 warnings**
- [ ] renders land on the next `design-artifacts.yml` run

## Sequencing note

Hold the next `design-artifacts.yml` dispatch until
[compose-ai-tools#2656](https://github.com/yschimke/compose-ai-tools/pull/2656) lands.
This repo adopted theme variants in #263, and the unfixed live-preview bridge gives
every theme-only dark sticker the **light** preview's `previewId` — which, now that
the per-variant figma-SVG emit
([#2653](https://github.com/yschimke/compose-ai-tools/pull/2653)) keys off
`previewId`, would publish the light vector at each `…__dark.svg` path. The locale
variants here are unaffected (they key on `props`, not `theme`).