### PR TITLE
feat(design-artifacts): embed JitPack deps in the meshcore live bundle

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -168,6 +168,11 @@ jobs:
       # re-renders the :app previews live (the :meshcore-components supplement is
       # split view-only by the reusable workflow).
       publish-live-bundle: true
+      # meshcore pulls JitPack-only deps (e.g. usb-serial-for-android) the public
+      # serve box can't resolve from Maven Central; embed the reachable jars in the
+      # bundle so the live daemon can build its classpath (else it falls back to
+      # baked PNGs / livebundle-unavailable). Requires compose-ai-tools#2662.
+      embed-deps: true
       split-per-preview: true
       # Fold the re-themed compose-m3 bundle (from the retheme job) in as a tab.
       fold-artifact: compose-m3-meshcore


### PR DESCRIPTION
## Summary

meshcore-mobile publishes a `liveBundle`, but on preview.coo.ee its live daemon **won't stand up** — the catalog shows `livebundle-unavailable` and falls back to baked PNGs. Root cause (confirmed empirically: v0.17.9 is deployed and a fresh regen still doesn't clear it): meshcore declares `maven("https://jitpack.io")` and pulls JitPack-only artifacts (e.g. `usb-serial-for-android:3.9.0`). The bundle records those as bare Maven coordinates, and the public serve box resolves the daemon classpath from **Maven Central only** — so it can't fetch them and the daemon never launches.

`compose-ai-tools#2659` (v0.17.9) already fixed the *other* meshcore daemon blocker (the manifest `Application` class); this clears the classpath one.

Sets **`embed-deps: true`** on the reusable export so `bundle pack --embed-deps` carries the reachable third-party jars inside the bundle under `libs/`, letting the daemon build its classpath offline.

## Dependency
Requires **compose-ai-tools#2662** (adds the `embed-deps` input to the reusable workflow) to merge **first** — this repo calls `design-artifacts-reusable.yml@main`, so the input must exist on `main` before this runs.

## Rollout
1. Merge compose-ai-tools#2662, then this.
2. Regen (dispatch Design Artifacts, or the weekly run) republishes the meshcore bundle with embedded deps.
3. Preview server auto-refreshes (~10 min) and stands up the live daemon → `/meshcore-mobile/api/previews` `degradations` clears.

## Test plan
Workflow-only. The end-to-end proof is the post-merge regen clearing `livebundle-unavailable` on preview.coo.ee (I'll verify).


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_