### PR TITLE
fix(design-artifacts): split meshcore per-preview bundles view-only

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -174,6 +174,12 @@ jobs:
       # baked PNGs / livebundle-unavailable). Requires compose-ai-tools#2662.
       embed-deps: true
       split-per-preview: true
+      # With embed-deps the monolith live bundle carries ~84 MB of embedded jars.
+      # A `full` per-preview split would replicate that classpath into every one of
+      # the ~70 per-preview bundles (OOM at split time + a multi-GB branch), so split
+      # the per-preview lane view-only (baked). The monolith liveBundle still carries
+      # the embedded classpath, so the serve host re-renders live from it.
+      split-mode: view-only
       # Fold the re-themed compose-m3 bundle (from the retheme job) in as a tab.
       fold-artifact: compose-m3-meshcore
       fold-bundle: compose-m3-meshcore.png


### PR DESCRIPTION
## Summary

Follow-up to #267 (`embed-deps: true`). That change worked — the regen's pack embedded all JitPack deps into the monolith live bundle (`classpath: 47 entries, Maven=0, embedded=45`, 84 MB). But the run then **failed in the `bundle split` step** with `java.lang.OutOfMemoryError: Java heap space` (`writeDeterministicZip`): the default `split-mode: full` replicates that 84 MB embedded classpath into **each** of ~70 per-preview bundles — OOM at split time, and a multi-GB delivery branch.

Set **`split-mode: view-only`**: per-preview bundles become baked (no classpath, small), while the **monolith `liveBundle` still carries the embedded classpath**. The serve host stands the live daemon up from the monolith and re-renders every preview live — so meshcore goes from `livebundle-unavailable` to live, without the OOM.

## Test plan
Workflow-only. Proof is the next regen completing (no split OOM) and `/meshcore-mobile/api/previews` `degradations` clearing on preview.coo.ee (I'll dispatch + verify).


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_