### PR TITLE
revert(design-artifacts): drop embed-deps/view-only split for meshcore

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -168,18 +168,7 @@ jobs:
       # re-renders the :app previews live (the :meshcore-components supplement is
       # split view-only by the reusable workflow).
       publish-live-bundle: true
-      # meshcore pulls JitPack-only deps (e.g. usb-serial-for-android) the public
-      # serve box can't resolve from Maven Central; embed the reachable jars in the
-      # bundle so the live daemon can build its classpath (else it falls back to
-      # baked PNGs / livebundle-unavailable). Requires compose-ai-tools#2662.
-      embed-deps: true
       split-per-preview: true
-      # With embed-deps the monolith live bundle carries ~84 MB of embedded jars.
-      # A `full` per-preview split would replicate that classpath into every one of
-      # the ~70 per-preview bundles (OOM at split time + a multi-GB branch), so split
-      # the per-preview lane view-only (baked). The monolith liveBundle still carries
-      # the embedded classpath, so the serve host re-renders live from it.
-      split-mode: view-only
       # Fold the re-themed compose-m3 bundle (from the retheme job) in as a tab.
       fold-artifact: compose-m3-meshcore
       fold-bundle: compose-m3-meshcore.png


### PR DESCRIPTION
## Summary

Backs out the embed-deps approach (#267 + #268). Embedding third-party jars in the published bundle is the wrong fix for meshcore's live daemon failing on preview.coo.ee — it bloated the bundle (84 MB) and forced a view-only per-preview split to avoid an OOM.

The **right** fix is on the serve host: its `CoordinateResolver` only resolves classpath deps from Maven Central + Google Maven, so meshcore's `jitpack.io` deps (`usb-serial-for-android`) get skipped and the daemon can't build its classpath. Teaching the serve host to resolve from the module's real repos (a `SERVE_EXTRA_MAVEN_REPOS` config — tracked separately in compose-ai-tools) fixes it with no bundle changes.

Restores the original `publish-live-bundle: true` + default per-preview split.

## Test plan
Workflow-only revert; the meshcore catalog goes back to its pre-#267 export shape. Live rendering is unblocked by the serve-side resolver change + a regen, not by this file.


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_