### PR TITLE
fix(build): target Java 17 bytecode for the preview render daemon

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,12 @@ play {
 kotlin { jvmToolchain(21) }
 
 tapmoc {
-  java(21)
+  // Java 17 bytecode (class-file v61) so the preview render daemon — JDK 17,
+  // Robolectric on preview.coo.ee — can load :app's classes (e.g. the
+  // ComponentPreviews). The build toolchain stays on JDK 21 (jvmToolchain(21)
+  // above / gradle-daemon-jvm.properties); only the emitted target drops. JDK-21
+  // (v65) bytecode throws UnsupportedClassVersionError in the JDK-17 daemon.
+  java(17)
   kotlin(libs.versions.kotlin.get())
 }
 

--- a/meshcore-components/build.gradle.kts
+++ b/meshcore-components/build.gradle.kts
@@ -11,6 +11,12 @@ plugins {
   alias(libs.plugins.composePreview)
 }
 
+// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-core/build.gradle.kts
+++ b/meshcore-core/build.gradle.kts
@@ -5,6 +5,15 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
+// Emit Java 17 bytecode (v61) so the JDK-17 preview render daemon (Robolectric,
+// preview.coo.ee) can load these classes; the build toolchain stays on JDK 21.
+// v65 (JDK 21) bytecode throws UnsupportedClassVersionError in the render daemon.
+// On the KMP extension jvmTarget isn't on the shared (common) compilerOptions, so
+// pin it on the JVM/Android Kotlin compile tasks directly.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-data/build.gradle.kts
+++ b/meshcore-data/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
   alias(libs.plugins.room)
 }
 
+// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-devices-proto/build.gradle.kts
+++ b/meshcore-devices-proto/build.gradle.kts
@@ -3,7 +3,16 @@ plugins {
   alias(libs.plugins.wire)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+  jvmToolchain(21)
+  // Java 17 bytecode so the JDK-17 preview render daemon can load these classes
+  // (:app depends on this module); build toolchain stays on JDK 21.
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
+// The kotlin-jvm plugin registers a compileJava task; pin javac to release 17 so
+// it matches the Kotlin target above (avoids the Kotlin/Java JVM-target mismatch).
+tasks.withType<JavaCompile>().configureEach { options.release.set(17) }
 
 wire {
   // Pure-Kotlin output: Wire generates idiomatic Kotlin data classes

--- a/meshcore-grpc-service/build.gradle.kts
+++ b/meshcore-grpc-service/build.gradle.kts
@@ -3,7 +3,17 @@ plugins {
   alias(libs.plugins.protobuf)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+  jvmToolchain(21)
+  // Java 17 bytecode so the JDK-17 preview render daemon can load these classes
+  // (:app depends on this module); build toolchain stays on JDK 21.
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
+// protobuf generates Java here — pin javac to release 17 to match the Kotlin
+// target above (avoids a Kotlin/Java JVM-target mismatch and keeps the generated
+// classes at v61 for the JDK-17 render daemon).
+tasks.withType<JavaCompile>().configureEach { options.release.set(17) }
 
 dependencies {
   api(projects.meshcoreCore)

--- a/meshcore-mobile/build.gradle.kts
+++ b/meshcore-mobile/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
   alias(libs.plugins.composeCompiler)
 }
 
+// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-session/build.gradle.kts
+++ b/meshcore-session/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
+// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-transport-ble/build.gradle.kts
+++ b/meshcore-transport-ble/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
+// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-transport-tcp/build.gradle.kts
+++ b/meshcore-transport-tcp/build.gradle.kts
@@ -1,8 +1,16 @@
 plugins { alias(libs.plugins.kotlinJvm) }
 
-kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
+// Java 17 bytecode so the JDK-17 preview render daemon can load this module —
+// :app pulls it in transitively via :meshcore-session's androidMain. The Java
+// toolchain below stays on JDK 21 (build JDK).
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) } }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
+
+// Pin javac to release 17 to match the Kotlin target above (the kotlin-jvm plugin
+// registers a compileJava task; the JDK-21 toolchain would otherwise target 21
+// and trip the Kotlin/Java JVM-target consistency check).
+tasks.withType<JavaCompile>().configureEach { options.release.set(17) }
 
 dependencies {
   api(projects.meshcoreCore)

--- a/meshcore-transport-usb/build.gradle.kts
+++ b/meshcore-transport-usb/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
+// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 kotlin {
   jvmToolchain(21)
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
 kotlin { jvmToolchain(21) }
 
 tapmoc {
-  java(21)
+  // Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
+  // build toolchain stays on JDK 21. See :app for the full rationale.
+  java(17)
   kotlin(libs.versions.kotlin.get())
 }
 


### PR DESCRIPTION
## Problem

The live preview render daemon behind **preview.coo.ee** runs on **JDK 17** (Robolectric), but every meshcore module compiled to **Java 21 bytecode** (class-file `v65`). Loading meshcore's preview classes there threw:

```
java.lang.UnsupportedClassVersionError:
ee/schimke/meshcore/app/ui/ComponentPreviewsKt has been compiled by a more recent
version of the Java Runtime (class file version 65.0), this version of the Java
Runtime only recognizes class file versions up to 61.0
```

`65.0` = Java 21, `61.0` = Java 17.

## Fix

Retarget emitted bytecode to **Java 17 (`v61`)** across every module on the render classpath, while keeping the **JDK 21 build toolchain** (`gradle/gradle-daemon-jvm.properties` still requires JDK 21 — only the *target* drops, not the build JDK):

- **`:app` / `:wear`** — `tapmoc { java(21) }` → `java(17)` (tapmoc sets Java + Kotlin source/target/api compatibility together).
- **KMP libraries** (`:meshcore-core`, `-components`, `-data`, `-session`, `-mobile`, `-transport-ble`, `-transport-usb`) — pin `jvmTarget` on the JVM/Android Kotlin compile tasks. The shared KMP `compilerOptions` is *common* (no `jvmTarget`), so it's set via `tasks.withType<KotlinCompile>()`.
- **kotlin-jvm modules** (`:meshcore-devices-proto`, `-grpc-service`, `-transport-tcp`) — Kotlin `jvmTarget` 17 **plus** `javac --release 17`, so the protobuf-generated Java matches and the Kotlin/Java JVM-target consistency check passes.

The standalone GraalVM native-image CLIs (`:meshcore-tui`, `:meshcore-cli`) are **not** on any render classpath and are intentionally left at 21.

`:app` transitively pulls in nearly every module (including `:meshcore-transport-tcp` via `:meshcore-session`'s `androidMain`), which is why the whole graph — not just `:app` — is retargeted.

## Verification (local)

Built with the JDK-21 toolchain and inspected the emitted class-file versions:

| Output | class-file version |
|---|---|
| `ComponentPreviewsKt` (the class that threw) | **61** ✅ |
| `:app` debug Kotlin (322 classes) | all **61** ✅ |
| `:meshcore-core` android + jvm targets (256 classes) | all **61** ✅ |
| `:meshcore-components` (83 classes) | all **61** ✅ |
| `:meshcore-grpc-service` protobuf-generated Java (84) + Kotlin (105) | all **61** ✅ |

`./gradlew ktfmtFormat` produced no changes.

## Test plan

- [x] `./gradlew :meshcore-core:assemble :meshcore-grpc-service:compileJava` — green, all output `v61`
- [x] `./gradlew :app:compileDebugKotlin` — green, `ComponentPreviewsKt` now `v61`
- [ ] CI build + lint
- [ ] After merge: regenerate the meshcore design-artifacts bundle so the JDK-17-loadable classes reach preview.coo.ee, then confirm the live interactive render no longer throws `UnsupportedClassVersionError`.

_Generated by [Claude Code]_

---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_