### PR TITLE
ci: track latest compose-ai-tools and regenerate catalogs on bump

### DIFF
--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -11,7 +11,10 @@ name: Scheduled Merge
 #     cutting a release stays a deliberate human action
 #
 # GITHUB_TOKEN merges don't fire push-to-main workflows, so after merging
-# this dispatches compose-preview.yml to refresh the render baselines.
+# this dispatches compose-preview.yml to refresh the render baselines. When
+# the merged batch included a compose-ai-tools bump (its renderer/CLI drives
+# the catalog output), it also dispatches design-artifacts.yml so the
+# published catalog delivery branches are regenerated against the new release.
 
 on:
   schedule:
@@ -44,6 +47,7 @@ jobs:
               owner, repo, state: 'open', base: 'main', per_page: 100,
             });
             let merged = 0;
+            let bumpedComposeAiTools = false;
             for (const stub of prs) {
               if (stub.draft) continue;
               if (stub.labels.some((l) => skipLabels.has(l.name))) {
@@ -67,14 +71,25 @@ jobs:
                 });
                 core.notice(`Merged #${pr.number}: ${pr.title}`);
                 merged++;
+                // A compose-ai-tools bump changes the renderer/CLI that
+                // produces the design catalogs, so flag it to regenerate the
+                // published delivery branches below. Renovate groups these
+                // under the `compose-ai-tools` branch/title.
+                if (`${pr.head.ref} ${pr.title}`.toLowerCase().includes('compose-ai-tools')) {
+                  bumpedComposeAiTools = true;
+                }
               } catch (e) {
                 core.warning(`#${pr.number}: merge failed — ${e.message}`);
               }
             }
             if (merged > 0) {
               // GITHUB_TOKEN merges don't trigger push workflows; explicitly
-              // refresh the render baselines and the release-please PR.
-              for (const wf of ['compose-preview.yml', 'release-please.yml']) {
+              // refresh the render baselines and the release-please PR. When a
+              // compose-ai-tools bump landed, also regenerate the design
+              // catalog delivery branches against the new release.
+              const workflows = ['compose-preview.yml', 'release-please.yml'];
+              if (bumpedComposeAiTools) workflows.push('design-artifacts.yml');
+              for (const wf of workflows) {
                 try {
                   await github.rest.actions.createWorkflowDispatch({
                     owner, repo, workflow_id: wf, ref: 'main',

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,15 @@
     {
       "groupName": "Wire",
       "matchPackageNames": ["/^com\\.squareup\\.wire($|[.:])/"]
+    },
+    {
+      "description": "compose-ai-tools ships the preview CLI, the ee.schimke.composeai Gradle artifacts (preview-annotations dep + the ee.schimke.composeai.preview plugin marker), and the reusable CI composite actions as a single release. Track it aggressively so CI always runs the latest renderer: group the pinned action refs and the Gradle coords into ONE PR so the CLI/plugin/dependency pins never skew apart, and skip the weekly window. Deliberately NOT Renovate-automerged: scheduled-merge.yml owns the merge so its post-merge design-artifacts.yml dispatch fires and regenerates the catalog against the new renderer. Renovate/native automerge would merge the PR directly, bypass that dispatch (design-artifacts.yml has no push trigger), and leave the published catalog on the old renderer until the next weekly run. scheduled-merge still auto-merges this PR once it's green.",
+      "matchPackageNames": [
+        "yschimke/compose-ai-tools",
+        "/^ee\\.schimke\\.composeai($|[.:])/"
+      ],
+      "groupName": "compose-ai-tools",
+      "schedule": ["at any time"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Make CI always track the latest `compose-ai-tools` release, and regenerate the design catalogs whenever the bump lands. Mirrors the change just merged into `cadence` and `homeassistant-remotecompose`.

`compose-ai-tools` ships the preview CLI, the `ee.schimke.composeai` Gradle artifacts (the `preview-annotations` dependency + the `ee.schimke.composeai.preview` plugin marker), and the reusable CI composite actions as a single release. Those live in two Renovate managers (github-actions for the `apply`/`install` `@vX.Y.Z` refs, gradle for the coords), so left ungrouped they arrive as separate PRs and can **skew** apart. The `apply` action is deliberately skew-proofed and pins the CLI to your plugin version, so the right lever is **automerge the bump** (via the repo's existing `scheduled-merge`), not `cli-version: latest`.

### `renovate.json`
- New `compose-ai-tools` group that bundles the action refs and all `ee.schimke.composeai` coords into **one** PR (no skew) and runs **at any time** (skips the weekly window).
- Deliberately **not** Renovate-automerged: `scheduled-merge.yml` owns the merge so its post-merge `design-artifacts.yml` dispatch fires. `scheduled-merge` already auto-merges any green PR, so bumps still land automatically.

### `.github/workflows/scheduled-merge.yml`
- After merging, if the batch included a `compose-ai-tools` bump, also dispatch **`design-artifacts.yml`** to regenerate the published catalog delivery branches against the new renderer — on top of the existing `compose-preview.yml` baseline refresh. Dispatched explicitly because `GITHUB_TOKEN` squash-merges don't fire push-triggered workflows.

> Note: `design-artifacts.yml` here also calls the reusable `compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main`, which already floats to `main` — so the regeneration path picks up the newest reusable workflow automatically.

## Test plan
- `renovate.json` validated as JSON; `scheduled-merge.yml` validated as YAML.
- Exercised on the next Renovate `compose-ai-tools` PR: the action refs and the `ee.schimke.composeai` coords should move together in one PR, `scheduled-merge` auto-merges it once green, and dispatches `compose-preview.yml` + `design-artifacts.yml` after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMLGezfVXDZrpJmwHrdYWC)_