### PR TITLE
fix(build): restore Java 21 bytecode now the render daemon selects a matching JDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,12 +37,7 @@ play {
 kotlin { jvmToolchain(21) }
 
 tapmoc {
-  // Java 17 bytecode (class-file v61) so the preview render daemon — JDK 17,
-  // Robolectric on preview.coo.ee — can load :app's classes (e.g. the
-  // ComponentPreviews). The build toolchain stays on JDK 21 (jvmToolchain(21)
-  // above / gradle-daemon-jvm.properties); only the emitted target drops. JDK-21
-  // (v65) bytecode throws UnsupportedClassVersionError in the JDK-17 daemon.
-  java(17)
+  java(21)
   kotlin(libs.versions.kotlin.get())
 }
 

--- a/meshcore-components/build.gradle.kts
+++ b/meshcore-components/build.gradle.kts
@@ -11,12 +11,6 @@ plugins {
   alias(libs.plugins.composePreview)
 }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-core/build.gradle.kts
+++ b/meshcore-core/build.gradle.kts
@@ -5,15 +5,6 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
-// Emit Java 17 bytecode (v61) so the JDK-17 preview render daemon (Robolectric,
-// preview.coo.ee) can load these classes; the build toolchain stays on JDK 21.
-// v65 (JDK 21) bytecode throws UnsupportedClassVersionError in the render daemon.
-// On the KMP extension jvmTarget isn't on the shared (common) compilerOptions, so
-// pin it on the JVM/Android Kotlin compile tasks directly.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-data/build.gradle.kts
+++ b/meshcore-data/build.gradle.kts
@@ -5,12 +5,6 @@ plugins {
   alias(libs.plugins.room)
 }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-devices-proto/build.gradle.kts
+++ b/meshcore-devices-proto/build.gradle.kts
@@ -3,16 +3,7 @@ plugins {
   alias(libs.plugins.wire)
 }
 
-kotlin {
-  jvmToolchain(21)
-  // Java 17 bytecode so the JDK-17 preview render daemon can load these classes
-  // (:app depends on this module); build toolchain stays on JDK 21.
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
-// The kotlin-jvm plugin registers a compileJava task; pin javac to release 17 so
-// it matches the Kotlin target above (avoids the Kotlin/Java JVM-target mismatch).
-tasks.withType<JavaCompile>().configureEach { options.release.set(17) }
+kotlin { jvmToolchain(21) }
 
 wire {
   // Pure-Kotlin output: Wire generates idiomatic Kotlin data classes

--- a/meshcore-grpc-service/build.gradle.kts
+++ b/meshcore-grpc-service/build.gradle.kts
@@ -3,17 +3,7 @@ plugins {
   alias(libs.plugins.protobuf)
 }
 
-kotlin {
-  jvmToolchain(21)
-  // Java 17 bytecode so the JDK-17 preview render daemon can load these classes
-  // (:app depends on this module); build toolchain stays on JDK 21.
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
-// protobuf generates Java here — pin javac to release 17 to match the Kotlin
-// target above (avoids a Kotlin/Java JVM-target mismatch and keeps the generated
-// classes at v61 for the JDK-17 render daemon).
-tasks.withType<JavaCompile>().configureEach { options.release.set(17) }
+kotlin { jvmToolchain(21) }
 
 dependencies {
   api(projects.meshcoreCore)

--- a/meshcore-mobile/build.gradle.kts
+++ b/meshcore-mobile/build.gradle.kts
@@ -5,12 +5,6 @@ plugins {
   alias(libs.plugins.composeCompiler)
 }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-session/build.gradle.kts
+++ b/meshcore-session/build.gradle.kts
@@ -3,12 +3,6 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-transport-ble/build.gradle.kts
+++ b/meshcore-transport-ble/build.gradle.kts
@@ -3,12 +3,6 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/meshcore-transport-tcp/build.gradle.kts
+++ b/meshcore-transport-tcp/build.gradle.kts
@@ -1,16 +1,8 @@
 plugins { alias(libs.plugins.kotlinJvm) }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load this module —
-// :app pulls it in transitively via :meshcore-session's androidMain. The Java
-// toolchain below stays on JDK 21 (build JDK).
-kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) } }
+kotlin { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
-
-// Pin javac to release 17 to match the Kotlin target above (the kotlin-jvm plugin
-// registers a compileJava task; the JDK-21 toolchain would otherwise target 21
-// and trip the Kotlin/Java JVM-target consistency check).
-tasks.withType<JavaCompile>().configureEach { options.release.set(17) }
 
 dependencies {
   api(projects.meshcoreCore)

--- a/meshcore-transport-usb/build.gradle.kts
+++ b/meshcore-transport-usb/build.gradle.kts
@@ -3,12 +3,6 @@ plugins {
   alias(libs.plugins.androidKotlinMultiplatformLibrary)
 }
 
-// Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-// build toolchain stays on JDK 21. See :meshcore-core for the full rationale.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
-}
-
 kotlin {
   jvmToolchain(21)
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -10,9 +10,7 @@ plugins {
 kotlin { jvmToolchain(21) }
 
 tapmoc {
-  // Java 17 bytecode so the JDK-17 preview render daemon can load these classes;
-  // build toolchain stays on JDK 21. See :app for the full rationale.
-  java(17)
+  java(21)
   kotlin(libs.versions.kotlin.get())
 }
 


### PR DESCRIPTION
Reverts #271 (squash commit `d6a69d9`), which downgraded every render-classpath module to Java-17 bytecode so the JDK-17 Robolectric preview daemon (`preview.coo.ee`) could load the classes without `UnsupportedClassVersionError`.

## Why it's safe to revert now

That workaround is obsolete: this repo is already on **`composePreviewPlugin = "0.17.16"`** (bumped in #275). 0.17.16 forks the preview render subprocess on a JDK **matched to the module's bytecode target** — compose-ai-tools [#2712](https://github.com/yschimke/compose-ai-tools/pull/2712) plus the KMP-Android `jvmTarget` detection [#2713](https://github.com/yschimke/compose-ai-tools/pull/2713), which matters here since these are KMP Android modules. The JDK-17 daemon path now provisions a JDK 21 render for the restored Java-21 (`v65`) bytecode instead of throwing.

## What changes

A clean `git revert` of #271 — back to the pre-#271 state:
- `:app` / `:wear` — `tapmoc { java(17) }` → `java(21)`.
- KMP + kotlin-jvm modules — drops the `jvmTarget = JVM_17` pins (and the `javac --release 17` on the proto/grpc modules).
- Build toolchain unchanged (still JDK 21 via `jvmToolchain(21)` / `gradle-daemon-jvm.properties`).

12 files, +5 / −84 — exactly reversing #271. No source changes.

## Test plan

- [ ] CI build + lint (the render toolchain is now 0.17.16 via #275).
- [ ] **After merge:** regenerate the meshcore design-artifacts bundle so the Java-21 classes reach `preview.coo.ee`, then confirm the live interactive render loads them (the 0.17.16 daemon provisions JDK 21 for the `v65` bytecode). This is the real end-to-end confirmation — worth verifying before considering the render-JVM issue closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rdn8bx3BjXBQoZFoxRWm6c)_