### PR TITLE
feat(design-artifacts): brand the re-themed compose-m3 type scale with theme.fonts

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -105,9 +105,19 @@ jobs:
           # reports them as failures and exits non-zero. Don't let that fail the job;
           # instead require that the rest re-themed (guarding a broad render failure),
           # then repack.
+          #
+          # theme.fonts brands the M3 type scale to match MeshcoreBrandedTypography
+          # (Orbitron for display/headline/title, Space Grotesk for body/label), so
+          # the re-themed "Material 3" tab + the theme-meshcore-dark foundation sticker
+          # render in the MeshCore faces instead of Roboto. Families resolve against the
+          # compose-m3 catalog's vendored Orbitron / Space Grotesk faces. (The knob is
+          # per role group, so the title group is one face; MeshcoreBrandedTypography
+          # splits titleLarge=Orbitron vs titleMedium/Small=Space Grotesk — Orbitron
+          # matches the prominent titleLarge.)
           xvfb-run -a -s "-screen 0 2000x1400x24" \
             "$CLI" bundle render "$SRC" \
               --knob "theme.colors=$BLOB" \
+              --knob "theme.fonts=families:display=Orbitron,headline=Orbitron,title=Orbitron,body=Space Grotesk,label=Space Grotesk" \
               --res compose-m3-artifacts/bundle/res \
               --svg \
               -o "$OUT" || echo "bundle render exited non-zero (expected for the metadata sheets)"


### PR DESCRIPTION
## Summary

The `retheme` job recolours the published `compose-m3` catalog to the MeshCore palette (`--knob theme.colors=…`) but left the **type scale on Roboto** — so the published *Material 3* tab and the `theme-meshcore-dark` foundation sticker showed the brand font *names* rendered in Roboto (e.g. `preview.coo.ee/meshcore-mobile/render/theme-meshcore-dark__ideal__default__dark__compact.svg?mode=web`).

compose-ai-tools#2752 added a sibling **`theme.fonts`** knob (and vendored the Orbitron / Space Grotesk / JetBrains Mono faces into the `compose-m3` catalog). This wires it into our re-theme step so the typography brands too.

### What's here
- One added line in `.github/workflows/design-artifacts.yml`'s `bundle render` invocation:
  ```
  --knob "theme.fonts=families:display=Orbitron,headline=Orbitron,title=Orbitron,body=Space Grotesk,label=Space Grotesk"
  ```
- The mapping matches `MeshcoreBrandedTypography` (`meshcore-components/.../MeshcoreFonts.kt`): **Orbitron** for display/headline/title, **Space Grotesk** for body/label. Families resolve against the vendored faces the re-packed `compose-m3` bundle now carries — no font assets needed here.
- The retheme CLI comes from `compose-ai-tools@main`, so no dep bump is required; the knob is a plain `namedOverrides` string.

**One fidelity note:** the knob is per M3 *role group*, so the whole `title` group takes one face. `MeshcoreBrandedTypography` actually splits it (`titleLarge`=Orbitron, `titleMedium`/`titleSmall`=Space Grotesk); `title=Orbitron` matches the prominent `titleLarge`. Display/headline/body/label are exact.

## Verification (build wiring — visual result is downstream)
This is workflow wiring; its visual output is produced by the `design-artifacts.yml` run, not renderable in this PR. After merge:
1. Dispatch `design-artifacts.yml` on `main` (re-themes + republishes the `design-artifacts/meshcore` branch).
2. Confirm `preview.coo.ee/meshcore-mobile/render/theme-meshcore-dark__ideal__default__dark__compact.svg?mode=web` renders Orbitron / Space Grotesk (and `?mode=web` `@import`s those families) instead of Roboto.

The upstream mechanism (Roboto → Space Grotesk on a re-themed sticker) is shown in compose-ai-tools#2752's before/after render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL6aMkWHRwot53LnwDoAc2)_